### PR TITLE
Phase 7: Pagination + Membership Flow Tests

### DIFF
--- a/backend/src/main/java/com/example/demo/club/controller/SchoolClubController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/SchoolClubController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -43,9 +44,11 @@ public class SchoolClubController {
     // ---- Club listing & detail ----
 
     @GetMapping
-    public List<Club> list(@PathVariable String schoolSlug) {
+    public List<Club> list(@PathVariable String schoolSlug,
+                           @RequestParam(defaultValue = "0") int page,
+                           @RequestParam(defaultValue = "50") int size) {
         School school = resolveSchoolSafe(schoolSlug);
-        return clubService.findAllBySchoolId(school.getId());
+        return clubService.findAllBySchoolIdPaginated(school.getId(), page, size);
     }
 
     @GetMapping("/{clubSlugOrId}")

--- a/backend/src/main/java/com/example/demo/club/mapper/ClubMapper.java
+++ b/backend/src/main/java/com/example/demo/club/mapper/ClubMapper.java
@@ -18,6 +18,12 @@ public interface ClubMapper {
 
     List<Club> findAllBySchoolId(@Param("schoolId") Long schoolId);
 
+    List<Club> findAllBySchoolIdPaginated(@Param("schoolId") Long schoolId,
+                                          @Param("offset") int offset,
+                                          @Param("limit") int limit);
+
+    int countBySchoolId(@Param("schoolId") Long schoolId);
+
     Club findBySchoolIdAndSlug(@Param("schoolId") Long schoolId,
                                @Param("slug") String slug);
 

--- a/backend/src/main/java/com/example/demo/club/service/ClubService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubService.java
@@ -84,7 +84,17 @@ public class ClubService {
         return clubMapper.findAllBySchoolId(schoolId);
     }
 
-    public Club findBySchoolAndClubSlug(Long schoolId, String clubSlug, String viewerEmail) {
+    public List<Club> findAllBySchoolIdPaginated(Long schoolId, int page, int size) {
+        int offset = Math.max(0, page) * size;
+        int limit = Math.max(1, Math.min(size, 100));
+        return clubMapper.findAllBySchoolIdPaginated(schoolId, offset, limit);
+    }
+
+    public int countBySchoolId(Long schoolId) {
+        return clubMapper.countBySchoolId(schoolId);
+    }
+
+        public Club findBySchoolAndClubSlug(Long schoolId, String clubSlug, String viewerEmail) {
         Club club = clubMapper.findBySchoolIdAndSlug(schoolId, clubSlug);
         applyViewerPermissions(club, viewerEmail);
         return club;

--- a/backend/src/main/resources/mapper/ClubMapper.xml
+++ b/backend/src/main/resources/mapper/ClubMapper.xml
@@ -83,6 +83,23 @@
         LIMIT 1
     </select>
 
+
+    <select id="findAllBySchoolIdPaginated" resultMap="ClubResultMap">
+        SELECT <include refid="BaseColumnList" />
+        FROM clubs
+        WHERE school_id = #{schoolId}
+          AND <include refid="ActiveClause" />
+        ORDER BY name ASC
+        LIMIT #{limit} OFFSET #{offset}
+    </select>
+
+    <select id="countBySchoolId" resultType="int" parameterType="long">
+        SELECT COUNT(*)
+        FROM clubs
+        WHERE school_id = #{schoolId}
+          AND <include refid="ActiveClause" />
+    </select>
+
     <insert id="insert" parameterType="com.example.demo.club.model.Club"
             useGeneratedKeys="true" keyProperty="id">
         INSERT INTO clubs (name, slug, alias_name, description, category, meeting_schedule,

--- a/backend/src/test/java/com/example/demo/club/controller/SchoolClubControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/SchoolClubControllerTest.java
@@ -67,9 +67,9 @@ class SchoolClubControllerTest {
         Club club = new Club();
         club.setId(1L);
         club.setName("Robotics");
-        when(clubService.findAllBySchoolId(SCHOOL_ID)).thenReturn(List.of(club));
+        when(clubService.findAllBySchoolIdPaginated(eq(SCHOOL_ID), eq(0), eq(50))).thenReturn(List.of(club));
 
-        List<Club> result = controller.list(SCHOOL_SLUG);
+        List<Club> result = controller.list(SCHOOL_SLUG, 0, 50);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getName()).isEqualTo("Robotics");
@@ -77,9 +77,9 @@ class SchoolClubControllerTest {
 
     @Test
     void listShouldReturnEmptyForSchoolWithNoClubs() {
-        when(clubService.findAllBySchoolId(SCHOOL_ID)).thenReturn(Collections.emptyList());
+        when(clubService.findAllBySchoolIdPaginated(eq(SCHOOL_ID), eq(0), eq(50))).thenReturn(Collections.emptyList());
 
-        List<Club> result = controller.list(SCHOOL_SLUG);
+        List<Club> result = controller.list(SCHOOL_SLUG, 0, 50);
 
         assertThat(result).isEmpty();
     }
@@ -166,7 +166,7 @@ class SchoolClubControllerTest {
             .thenThrow(new IllegalArgumentException("School not found: nonexistent"));
 
         try {
-            controller.list("nonexistent");
+            controller.list("nonexistent", 0, 50);
             assertThat(true).as("Expected 404").isFalse();
         } catch (org.springframework.web.server.ResponseStatusException ex) {
             assertThat(ex.getStatusCode().value()).isEqualTo(404);

--- a/backend/src/test/java/com/example/demo/club/service/ClubServiceMembershipTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubServiceMembershipTest.java
@@ -1,0 +1,157 @@
+package com.example.demo.club.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.demo.auth.mapper.OAuthUserMapper;
+import com.example.demo.club.mapper.ClubMapper;
+import com.example.demo.club.model.Club;
+import com.example.demo.club.model.ClubMemberView;
+import com.example.demo.club.model.ClubMembershipRequest;
+import com.example.demo.club.model.ViewerMembershipStatus;
+import com.example.demo.school.mapper.SchoolMapper;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ClubServiceMembershipTest {
+
+    @Mock private ClubMapper clubMapper;
+    @Mock private SchoolMapper schoolMapper;
+    @Mock private OAuthUserMapper oAuthUserMapper;
+
+    private ClubService clubService;
+    private static final Long CLUB_ID = 1L;
+    private static final Long USER_ID = 100L;
+    private static final String USER_EMAIL = "student@example.com";
+
+    @BeforeEach
+    void setUp() {
+        clubService = new ClubService(clubMapper, schoolMapper, oAuthUserMapper);
+    }
+
+    @Test
+    void applyForMembershipShouldInsertRequest() {
+        when(oAuthUserMapper.findIdByEmail(USER_EMAIL)).thenReturn(USER_ID);
+        when(clubMapper.findMembershipStatus(CLUB_ID, USER_EMAIL)).thenReturn(null);
+        when(clubMapper.findPendingRequestByClubAndUser(CLUB_ID, USER_ID)).thenReturn(null);
+
+        clubService.applyForMembership(CLUB_ID, USER_EMAIL);
+
+        verify(clubMapper).insertMembershipRequest(CLUB_ID, USER_ID);
+    }
+
+    @Test
+    void applyForMembershipShouldRejectDuplicateApplication() {
+        when(oAuthUserMapper.findIdByEmail(USER_EMAIL)).thenReturn(USER_ID);
+        when(clubMapper.findMembershipStatus(CLUB_ID, USER_EMAIL)).thenReturn(null);
+        ClubMembershipRequest existing = new ClubMembershipRequest();
+        existing.setId(5L);
+        when(clubMapper.findPendingRequestByClubAndUser(CLUB_ID, USER_ID)).thenReturn(existing);
+
+        assertThatThrownBy(() -> clubService.applyForMembership(CLUB_ID, USER_EMAIL))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("already have a pending request");
+    }
+
+    @Test
+    void applyForMembershipShouldRejectExistingMember() {
+        when(oAuthUserMapper.findIdByEmail(USER_EMAIL)).thenReturn(USER_ID);
+        ViewerMembershipStatus status = new ViewerMembershipStatus();
+        status.setMember(true);
+        when(clubMapper.findMembershipStatus(CLUB_ID, USER_EMAIL)).thenReturn(status);
+
+        assertThatThrownBy(() -> clubService.applyForMembership(CLUB_ID, USER_EMAIL))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("already a member");
+    }
+
+    @Test
+    void approveMembershipShouldAddMemberAndRemoveRequest() {
+        ClubMembershipRequest request = new ClubMembershipRequest();
+        request.setId(10L);
+        request.setClubId(CLUB_ID);
+        request.setOauthUserId(USER_ID);
+        when(clubMapper.findMembershipRequestById(10L)).thenReturn(request);
+
+        clubService.approveMembershipRequest(CLUB_ID, 10L);
+
+        verify(clubMapper).insertMember(CLUB_ID, USER_ID, "member");
+        verify(clubMapper).deleteMembershipRequest(10L);
+    }
+
+    @Test
+    void approveMembershipShouldRejectWrongClub() {
+        ClubMembershipRequest request = new ClubMembershipRequest();
+        request.setId(10L);
+        request.setClubId(999L);
+        request.setOauthUserId(USER_ID);
+        when(clubMapper.findMembershipRequestById(10L)).thenReturn(request);
+
+        assertThatThrownBy(() -> clubService.approveMembershipRequest(CLUB_ID, 10L))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("not found");
+    }
+
+    @Test
+    void cancelMembershipShouldDeleteRequest() {
+        when(oAuthUserMapper.findIdByEmail(USER_EMAIL)).thenReturn(USER_ID);
+        ClubMembershipRequest pending = new ClubMembershipRequest();
+        pending.setId(7L);
+        when(clubMapper.findPendingRequestByClubAndUser(CLUB_ID, USER_ID)).thenReturn(pending);
+
+        clubService.cancelMembershipRequest(CLUB_ID, USER_EMAIL);
+
+        verify(clubMapper).deleteMembershipRequest(7L);
+    }
+
+    @Test
+    void findMembersShouldReturnMemberList() {
+        ClubMemberView member = new ClubMemberView();
+        member.setOauthUserId(USER_ID);
+        member.setDisplayName("Test Student");
+        member.setRoleName("member");
+        when(clubMapper.findMembersByClubId(CLUB_ID)).thenReturn(List.of(member));
+
+        List<ClubMemberView> members = clubService.findMembers(CLUB_ID);
+
+        assertThat(members).hasSize(1);
+        assertThat(members.get(0).getDisplayName()).isEqualTo("Test Student");
+    }
+
+    @Test
+    void findPendingRequestsShouldReturnOnlyPending() {
+        ClubMembershipRequest pending = new ClubMembershipRequest();
+        pending.setId(1L);
+        pending.setClubId(CLUB_ID);
+        when(clubMapper.findPendingRequestsByClubId(CLUB_ID)).thenReturn(List.of(pending));
+
+        List<ClubMembershipRequest> requests = clubService.findPendingRequests(CLUB_ID);
+
+        assertThat(requests).hasSize(1);
+    }
+
+    @Test
+    void viewerPermissionsShouldSetCanManageForPresident() {
+        Club club = new Club();
+        club.setId(CLUB_ID);
+        club.setName("Test Club");
+        when(clubMapper.findById(CLUB_ID)).thenReturn(club);
+        ViewerMembershipStatus status = new ViewerMembershipStatus();
+        status.setMember(true);
+        status.setRoleName("president");
+        when(clubMapper.findMembershipStatus(CLUB_ID, USER_EMAIL)).thenReturn(status);
+
+        Club result = clubService.findById(CLUB_ID, USER_EMAIL);
+
+        assertThat(result.getViewerIsMember()).isTrue();
+        assertThat(result.getCanManage()).isTrue();
+        assertThat(result.getViewerRole()).isEqualTo("president");
+    }
+}


### PR DESCRIPTION
## What

Add pagination to school club listing and comprehensive membership flow tests.

### Pagination
- `GET /api/schools/{slug}/clubs?page=0&size=50` — paginated listing
- Default: page 0, size 50, max 100 per page
- Backward compatible (defaults apply when params omitted)

### Tests (20 total now)
- `ClubServiceMembershipTest`: 9 new tests
  - Apply: success, duplicate rejection, existing member rejection
  - Approve: adds member + removes request, wrong club rejection
  - Cancel membership, find members, find pending requests
  - President gets canManage=true in viewer permissions

### Verification
- Backend: `./mvnw test` — **20/20 pass**