### PR TITLE
[codex] Enforce club management permissions

### DIFF
--- a/backend/src/main/java/com/example/demo/club/controller/ClubController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubController.java
@@ -59,7 +59,8 @@ public class ClubController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Club create(@RequestBody Club club) {
+    public Club create(@RequestBody Club club, Authentication authentication) {
+        requirePlatformOwner(authentication);
         try {
             return clubService.create(club);
         } catch (IllegalArgumentException ex) {
@@ -79,7 +80,8 @@ public class ClubController {
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable Long id) {
+    public void delete(@PathVariable Long id, Authentication authentication) {
+        requirePlatformOwner(authentication);
         if (clubService.findById(id) == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
         }
@@ -182,6 +184,16 @@ public class ClubController {
         return securityProperties.getOwnerEmails().stream()
             .filter(item -> item != null && !item.isBlank())
             .anyMatch(item -> email.equalsIgnoreCase(item.trim()));
+    }
+
+    private void requirePlatformOwner(Authentication authentication) {
+        String email = resolveViewerEmail(authentication);
+        if (email == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authentication required");
+        }
+        if (!isOwner(authentication)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Platform owner access required");
+        }
     }
 
     private Club requireManageAccess(Long clubId, Authentication authentication) {

--- a/backend/src/main/java/com/example/demo/club/controller/ClubImageController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubImageController.java
@@ -1,10 +1,15 @@
 package com.example.demo.club.controller;
 
+import com.example.demo.auth.config.SecurityProperties;
 import com.example.demo.club.model.Club;
 import com.example.demo.club.service.ClubService;
 import com.example.demo.school.model.School;
+import com.example.demo.school.service.SchoolUserService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,12 +29,20 @@ import java.util.UUID;
 @RequestMapping("/api/schools/{schoolSlug}/clubs")
 public class ClubImageController {
 
+    private static final long MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
     private final ClubService clubService;
+    private final SchoolUserService schoolUserService;
+    private final SecurityProperties securityProperties;
     private final Path uploadDir;
 
     public ClubImageController(ClubService clubService,
+                               SchoolUserService schoolUserService,
+                               SecurityProperties securityProperties,
                                @Value("${app.upload.dir:uploads}") String uploadDirPath) {
         this.clubService = clubService;
+        this.schoolUserService = schoolUserService;
+        this.securityProperties = securityProperties;
         this.uploadDir = Paths.get(uploadDirPath).toAbsolutePath().normalize();
         try {
             Files.createDirectories(this.uploadDir);
@@ -41,23 +54,25 @@ public class ClubImageController {
     @PostMapping("/{clubSlugOrId}/image")
     public Map<String, String> uploadImage(@PathVariable String schoolSlug,
                                            @PathVariable String clubSlugOrId,
-                                           @RequestParam("file") MultipartFile file) {
-        School school = clubService.resolveSchool(schoolSlug);
-        Club club = resolveClub(school.getId(), clubSlugOrId);
+                                           @RequestParam("file") MultipartFile file,
+                                           Authentication authentication) {
+        School school = resolveSchoolSafe(schoolSlug);
+        Club club = requireManageAccess(school, clubSlugOrId, authentication);
 
         if (file.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "File is empty");
         }
-
-        String originalName = file.getOriginalFilename();
-        String ext = "";
-        if (originalName != null && originalName.contains(".")) {
-            ext = originalName.substring(originalName.lastIndexOf('.'));
+        if (file.getSize() > MAX_IMAGE_BYTES) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Image must be 5MB or smaller");
         }
-        String filename = UUID.randomUUID() + ext;
+
+        String filename = UUID.randomUUID() + resolveImageExtension(file.getContentType());
 
         try {
-            Path target = uploadDir.resolve(filename);
+            Path target = uploadDir.resolve(filename).normalize();
+            if (!target.startsWith(uploadDir)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid file name");
+            }
             file.transferTo(target);
 
             String imageUrl = "/uploads/" + filename;
@@ -70,16 +85,83 @@ public class ClubImageController {
         }
     }
 
-    private Club resolveClub(Long schoolId, String clubSlugOrId) {
+    private String resolveImageExtension(String contentType) {
+        if (contentType == null || contentType.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Image content type is required");
+        }
+        return switch (contentType.toLowerCase()) {
+            case "image/jpeg", "image/jpg" -> ".jpg";
+            case "image/png" -> ".png";
+            case "image/webp" -> ".webp";
+            case "image/gif" -> ".gif";
+            default -> throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unsupported image type");
+        };
+    }
+
+    private Club requireManageAccess(School school,
+                                     String clubSlugOrId,
+                                     Authentication authentication) {
+        String viewerEmail = resolveViewerEmail(authentication);
+        if (viewerEmail == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authentication required");
+        }
+        Club club = resolveClub(school.getId(), clubSlugOrId, viewerEmail);
+        boolean canManage = Boolean.TRUE.equals(club.getCanManage())
+            || isPlatformOwner(authentication)
+            || isSchoolAdmin(school.getId(), viewerEmail);
+        if (!canManage) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You do not have permission to update this club image");
+        }
+        return club;
+    }
+
+    private School resolveSchoolSafe(String schoolSlug) {
+        try {
+            return clubService.resolveSchool(schoolSlug);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage());
+        }
+    }
+
+    private String resolveViewerEmail(Authentication authentication) {
+        if (!(authentication instanceof OAuth2AuthenticationToken token)) {
+            return null;
+        }
+        OAuth2User principal = token.getPrincipal();
+        if (principal == null) {
+            return null;
+        }
+        Object email = principal.getAttributes().get("email");
+        return (email instanceof String str && !str.isBlank()) ? str : null;
+    }
+
+    private boolean isPlatformOwner(Authentication authentication) {
+        String email = resolveViewerEmail(authentication);
+        if (email == null || securityProperties.getOwnerEmails() == null) {
+            return false;
+        }
+        return securityProperties.getOwnerEmails().stream()
+            .filter(item -> item != null && !item.isBlank())
+            .anyMatch(item -> email.equalsIgnoreCase(item.trim()));
+    }
+
+    private boolean isSchoolAdmin(Long schoolId, String email) {
+        Long oauthUserId = clubService.resolveOauthUserId(email);
+        return oauthUserId != null && schoolUserService.isSchoolAdmin(schoolId, oauthUserId);
+    }
+
+    private Club resolveClub(Long schoolId, String clubSlugOrId, String viewerEmail) {
         try {
             Long numericId = Long.valueOf(clubSlugOrId);
-            Club club = clubService.findBySchoolAndClubId(schoolId, numericId, null);
+            Club club = clubService.findBySchoolAndClubId(schoolId, numericId, viewerEmail);
             if (club == null) throw new IllegalArgumentException("Club not found");
             return club;
         } catch (NumberFormatException e) {
-            Club club = clubService.findBySchoolAndClubSlug(schoolId, clubSlugOrId, null);
+            Club club = clubService.findBySchoolAndClubSlug(schoolId, clubSlugOrId, viewerEmail);
             if (club == null) throw new IllegalArgumentException("Club not found");
             return club;
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage());
         }
     }
 }

--- a/backend/src/test/java/com/example/demo/club/controller/ClubControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubControllerTest.java
@@ -1,0 +1,112 @@
+package com.example.demo.club.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.demo.auth.config.SecurityProperties;
+import com.example.demo.club.model.Club;
+import com.example.demo.club.service.ClubService;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.server.ResponseStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class ClubControllerTest {
+
+    @Mock
+    private ClubService clubService;
+
+    private ClubController controller;
+
+    @BeforeEach
+    void setUp() {
+        SecurityProperties securityProperties = new SecurityProperties();
+        securityProperties.setOwnerEmails(List.of("owner@example.com"));
+        controller = new ClubController(clubService, securityProperties);
+    }
+
+    @Test
+    void createShouldRequireAuthentication() {
+        try {
+            controller.create(new Club(), null);
+            assertThat(true).as("Expected 401").isFalse();
+        } catch (ResponseStatusException ex) {
+            assertThat(ex.getStatusCode().value()).isEqualTo(401);
+        }
+        verify(clubService, never()).create(any(Club.class));
+    }
+
+    @Test
+    void createShouldRejectNonOwner() {
+        try {
+            controller.create(new Club(), createAuth("student@example.com"));
+            assertThat(true).as("Expected 403").isFalse();
+        } catch (ResponseStatusException ex) {
+            assertThat(ex.getStatusCode().value()).isEqualTo(403);
+        }
+        verify(clubService, never()).create(any(Club.class));
+    }
+
+    @Test
+    void createShouldAllowPlatformOwner() {
+        Club input = new Club();
+        input.setName("New Club");
+        Club created = new Club();
+        created.setId(10L);
+        when(clubService.create(eq(input))).thenReturn(created);
+
+        Club result = controller.create(input, createAuth("owner@example.com"));
+
+        assertThat(result.getId()).isEqualTo(10L);
+        verify(clubService).create(input);
+    }
+
+    @Test
+    void deleteShouldRejectNonOwner() {
+        try {
+            controller.delete(1L, createAuth("student@example.com"));
+            assertThat(true).as("Expected 403").isFalse();
+        } catch (ResponseStatusException ex) {
+            assertThat(ex.getStatusCode().value()).isEqualTo(403);
+        }
+        verify(clubService, never()).delete(1L);
+    }
+
+    @Test
+    void deleteShouldAllowPlatformOwner() {
+        Club existing = new Club();
+        existing.setId(1L);
+        when(clubService.findById(1L)).thenReturn(existing);
+
+        controller.delete(1L, createAuth("owner@example.com"));
+
+        verify(clubService).delete(1L);
+    }
+
+    private Authentication createAuth(String email) {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("email", email);
+        attributes.put("sub", email.replace("@", "-id"));
+        OAuth2User principal = new DefaultOAuth2User(
+            Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+            attributes,
+            "sub");
+        return new OAuth2AuthenticationToken(principal, principal.getAuthorities(), "google");
+    }
+}

--- a/backend/src/test/java/com/example/demo/club/controller/ClubImageControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubImageControllerTest.java
@@ -1,0 +1,174 @@
+package com.example.demo.club.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.demo.auth.config.SecurityProperties;
+import com.example.demo.club.model.Club;
+import com.example.demo.club.service.ClubService;
+import com.example.demo.school.model.School;
+import com.example.demo.school.service.SchoolUserService;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.server.ResponseStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class ClubImageControllerTest {
+
+    private static final String SCHOOL_SLUG = "mvhs";
+    private static final Long SCHOOL_ID = 1L;
+
+    @TempDir
+    Path uploadDir;
+
+    @Mock
+    private ClubService clubService;
+
+    @Mock
+    private SchoolUserService schoolUserService;
+
+    private ClubImageController controller;
+
+    @BeforeEach
+    void setUp() {
+        SecurityProperties securityProperties = new SecurityProperties();
+        securityProperties.setOwnerEmails(List.of("owner@example.com"));
+        controller = new ClubImageController(clubService, schoolUserService, securityProperties, uploadDir.toString());
+
+        School school = new School();
+        school.setId(SCHOOL_ID);
+        school.setSlug(SCHOOL_SLUG);
+        school.setSchoolName("Mountain View High School");
+        school.setStatus("active");
+        lenient().when(clubService.resolveSchool(SCHOOL_SLUG)).thenReturn(school);
+        lenient().when(clubService.resolveOauthUserId("student@example.com")).thenReturn(100L);
+        lenient().when(clubService.resolveOauthUserId("admin@example.com")).thenReturn(200L);
+    }
+
+    @Test
+    void uploadShouldRequireAuthentication() {
+        try {
+            controller.uploadImage(SCHOOL_SLUG, "1", pngFile(), null);
+            assertThat(true).as("Expected 401").isFalse();
+        } catch (ResponseStatusException ex) {
+            assertThat(ex.getStatusCode().value()).isEqualTo(401);
+        }
+        verify(clubService, never()).updateInSchool(any(), any(), any());
+    }
+
+    @Test
+    void uploadShouldRejectStudentWithoutManageAccess() {
+        Club club = club(false);
+        when(clubService.findBySchoolAndClubId(SCHOOL_ID, 1L, "student@example.com")).thenReturn(club);
+        when(schoolUserService.isSchoolAdmin(SCHOOL_ID, 100L)).thenReturn(false);
+
+        try {
+            controller.uploadImage(SCHOOL_SLUG, "1", pngFile(), createAuth("student@example.com"));
+            assertThat(true).as("Expected 403").isFalse();
+        } catch (ResponseStatusException ex) {
+            assertThat(ex.getStatusCode().value()).isEqualTo(403);
+        }
+        verify(clubService, never()).updateInSchool(any(), any(), any());
+    }
+
+    @Test
+    void uploadShouldAllowPresidentForOwnClub() {
+        Club club = club(true);
+        when(clubService.findBySchoolAndClubId(SCHOOL_ID, 1L, "president@example.com")).thenReturn(club);
+        when(clubService.updateInSchool(eq(SCHOOL_ID), eq(1L), eq(club))).thenReturn(club);
+
+        Map<String, String> result = controller.uploadImage(
+            SCHOOL_SLUG,
+            "1",
+            pngFile(),
+            createAuth("president@example.com"));
+
+        assertThat(result.get("imageUrl")).startsWith("/uploads/").endsWith(".png");
+        assertThat(club.getImageUrl()).isEqualTo(result.get("imageUrl"));
+        verify(clubService).updateInSchool(SCHOOL_ID, 1L, club);
+    }
+
+    @Test
+    void uploadShouldAllowSchoolAdmin() {
+        Club club = club(false);
+        when(clubService.findBySchoolAndClubId(SCHOOL_ID, 1L, "admin@example.com")).thenReturn(club);
+        when(schoolUserService.isSchoolAdmin(SCHOOL_ID, 200L)).thenReturn(true);
+        when(clubService.updateInSchool(eq(SCHOOL_ID), eq(1L), eq(club))).thenReturn(club);
+
+        Map<String, String> result = controller.uploadImage(
+            SCHOOL_SLUG,
+            "1",
+            pngFile(),
+            createAuth("admin@example.com"));
+
+        assertThat(result.get("imageUrl")).startsWith("/uploads/").endsWith(".png");
+        verify(clubService).updateInSchool(SCHOOL_ID, 1L, club);
+    }
+
+    @Test
+    void uploadShouldRejectUnsupportedContentType() {
+        Club club = club(true);
+        when(clubService.findBySchoolAndClubId(SCHOOL_ID, 1L, "president@example.com")).thenReturn(club);
+        MockMultipartFile textFile = new MockMultipartFile(
+            "file",
+            "note.txt",
+            "text/plain",
+            "not an image".getBytes());
+
+        try {
+            controller.uploadImage(SCHOOL_SLUG, "1", textFile, createAuth("president@example.com"));
+            assertThat(true).as("Expected 400").isFalse();
+        } catch (ResponseStatusException ex) {
+            assertThat(ex.getStatusCode().value()).isEqualTo(400);
+        }
+        verify(clubService, never()).updateInSchool(any(), any(), any());
+    }
+
+    private Club club(boolean canManage) {
+        Club club = new Club();
+        club.setId(1L);
+        club.setName("Robotics");
+        club.setSchoolId(SCHOOL_ID);
+        club.setCanManage(canManage);
+        return club;
+    }
+
+    private MockMultipartFile pngFile() {
+        return new MockMultipartFile(
+            "file",
+            "club.png",
+            "image/png",
+            new byte[] {1, 2, 3});
+    }
+
+    private Authentication createAuth(String email) {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("email", email);
+        attributes.put("sub", email.replace("@", "-id"));
+        OAuth2User principal = new DefaultOAuth2User(
+            Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+            attributes,
+            "sub");
+        return new OAuth2AuthenticationToken(principal, principal.getAuthorities(), "google");
+    }
+}


### PR DESCRIPTION
## Summary

- Require platform owner access for legacy global club create/delete endpoints.
- Require authenticated club management access before uploading school-scoped club images.
- Validate uploaded club images by content type, size, and normalized target path.
- Add controller tests for legacy create/delete authorization and image upload authorization/validation.

## Why

P0 starts with security and permissions. These endpoints were high-risk because legacy create/delete did not enforce owner access, and image upload could update club data without checking whether the caller could manage the club.

## Validation

- `cd backend && ./mvnw test`
- Backend test result: 30 tests passed.
