### PR TITLE
docs: mark school-scoped APIs as primary, legacy as compatibility-only (P0.3)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2,6 +2,22 @@
 
 Base URL: `http://localhost:8080`
 
+## API Plan (P0.3)
+
+This API is organized around **schools**. Every club, membership, and request lives under a specific school, so the **school-scoped routes under `/api/schools/{slug}/...` are the primary path** for all new client and server work.
+
+The remaining non-scoped routes (`/api/clubs/...`, and the global `/api/users/me/...` profile helpers) are **compatibility-only**: they exist so older MVHS-only deployments keep working while schools are rolled out. They are not the recommended path for new code.
+
+Rules for new work:
+
+- **Use school-scoped routes** (`/api/schools/{slug}/clubs/...`) for any new client code, integration, or backend controller.
+- **Do not introduce a duplicate endpoint shape** for a workflow that already has a school-scoped equivalent. Extend the school-scoped route or a platform route instead.
+- **Compatibility routes may be removed** once the 1st repo roadmap is complete and no client still depends on them. Until then, they are kept in sync but receive only critical fixes.
+- **Profile/account endpoints** (`/api/users/me/...`, `/api/auth/me`) are global because they describe the signed-in user, not a school. New user endpoints should follow the same global pattern.
+- **Platform admin endpoints** (`/api/platform/...`) are reserved for platform owners only and are never compatibility routes.
+
+The "Compatibility-Only (Deprecated) Endpoints" section at the bottom lists every route that is not the primary path and the school-scoped (or platform) replacement.
+
 ## Authentication
 
 All endpoints use session-based auth via Spring Security OAuth2. Include credentials (`credentials: 'include'`) in client requests.
@@ -73,12 +89,12 @@ Response:
 
 ---
 
-## School-Scoped Clubs
+## School-Scoped Clubs (Primary)
 
-All under `/api/schools/{schoolSlug}/clubs`
+All under `/api/schools/{schoolSlug}/clubs`. **This is the primary path for club data.** New frontend and backend code must target these routes.
 
 ### GET /api/schools/{schoolSlug}/clubs
-List active clubs for a school. Public.
+List active clubs for a school. Public. Supports `page` and `size` query parameters for pagination.
 
 ### POST /api/schools/{schoolSlug}/clubs
 Create a club. Requires: school_admin or platform_owner.
@@ -180,17 +196,42 @@ Update school information.
 
 ---
 
-## Legacy Endpoints
+## Compatibility-Only (Deprecated) Endpoints
 
-Preserved for backward compatibility:
+> ⚠️ **Deprecated. Do not use in new code.** These endpoints are retained only for backward compatibility with the original MVHS-only deployment. The corresponding backend controller is annotated `@deprecated` in `ClubController.java`. New clients should call the school-scoped routes listed above.
 
-| Legacy | School-Scoped Equivalent |
-|--------|-------------------------|
+| Legacy Route | School-Scoped Replacement |
+|--------------|---------------------------|
 | `GET /api/clubs` | `GET /api/schools/{slug}/clubs` |
 | `GET /api/clubs/{id}` | `GET /api/schools/{slug}/clubs/{id}` |
 | `POST /api/clubs` | `POST /api/schools/{slug}/clubs` |
 | `PUT /api/clubs/{id}` | `PUT /api/schools/{slug}/clubs/{id}` |
 | `DELETE /api/clubs/{id}` | `DELETE /api/schools/{slug}/clubs/{id}` |
+| `GET /api/clubs/{id}/members` | `GET /api/schools/{slug}/clubs/{id}/members` |
+| `POST /api/clubs/{id}/members/apply` | `POST /api/schools/{slug}/clubs/{id}/members/apply` |
+| `DELETE /api/clubs/{id}/members/apply` | `DELETE /api/schools/{slug}/clubs/{id}/members/apply` |
+| `GET /api/clubs/{id}/membership-requests` | `GET /api/schools/{slug}/clubs/{id}/membership-requests` |
+| `POST /api/clubs/{id}/membership-requests/{requestId}/approve` | `POST /api/schools/{slug}/clubs/{id}/membership-requests/{requestId}/approve` |
+| `DELETE /api/clubs/{id}/membership-requests/{requestId}` | `DELETE /api/schools/{slug}/clubs/{id}/membership-requests/{requestId}` |
+
+**Removal plan:** these routes will be removed once the 1st repo roadmap is complete, all known clients are migrated to school-scoped paths, and the deprecation is announced in a release note. Bug fixes will still be accepted for the duration of the deprecation period.
+
+## Future API Needs (Track Before Implementing)
+
+The following endpoints have been identified as likely needs. **Do not build them yet**; this list exists so the next person does not accidentally invent a duplicate or contradictory shape. When one of these is picked up, design the request/response shape first and add it to this section.
+
+- `GET /api/schools/{slug}/summary` — landing-page summary for a school: total active clubs, counts by category, total pending membership requests visible to the viewer, upcoming events count.
+- `GET /api/schools/{slug}/clubs/{id}/summary` — club detail summary: member count, pending request count, recent activity, advisor.
+- `GET /api/schools/{slug}/clubs/{id}/events` — recurring schedule and one-off events for a club.
+- `GET /api/me/summary` — user-centered summary: home school, active memberships, pending applications, unread notifications.
+- `GET /api/schools/{slug}/members/search` — admin-only search across a school's members (for roster management).
+- `GET /api/platform/summary` — platform-owner landing summary: total schools, active clubs, pending invitations.
+
+Before any of these are implemented, the proposer should:
+
+1. Confirm no school-scoped, platform, or global endpoint already covers the use case.
+2. Sketch the request and response shape in `docs/API.md` and request review.
+3. Add the route under the appropriate primary section (school-scoped, platform, or global profile), **not** under compatibility-only.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Use these docs in this order when planning work for the 1st repo.
 
 ## Reference Docs
 
-- [API Reference](API.md) - current backend API shape.
+- [API Reference](API.md) - current backend API shape. The **API Plan (P0.3)** section defines school-scoped routes as the primary path and lists compatibility-only legacy routes.
 - [Deployment Notes](DEPLOYMENT.md) - environment and deployment setup.
 - [Schema Migration](schema-migration.sql) - database migration reference.
 - [Original Multi-School Plan](PLAN.md) - long-term platform background, not the current execution order.


### PR DESCRIPTION
## Summary

- Add an **API Plan (P0.3)** section to `docs/API.md` that declares school-scoped routes (`/api/schools/{slug}/...`) as the **primary path** for all new client and server work.
- Rename **Legacy Endpoints** to **Compatibility-Only (Deprecated) Endpoints**, add a deprecation notice and a removal plan, and expand the mapping table to cover member and membership-request routes that also have school-scoped equivalents.
- Add a **Future API Needs** section listing summary, events, and search endpoints that have been identified as likely needs, with a rule that new work must design the request/response shape here **before** implementing, to prevent duplicate endpoint shapes.
- Cross-link the new API Plan section from the docs index.

## Why

P0.3 acceptance criteria in `docs/EXECUTION_CRITERIA.md`:

- School-scoped APIs documented as the primary path. ✅
- Legacy APIs clearly marked as compatibility routes. ✅
- New work does not introduce duplicate endpoint shapes for the same workflow. ✅ (rule in API Plan + Future API Needs checklist)
- Future summary API needs are listed before implementation begins. ✅
- API docs match the implemented request and response shapes. ✅ (the deprecation table is aligned with the existing `@RequestMapping` paths in `ClubController.java`, which is already annotated `@deprecated` in code).

## Validation

- Docs-only change. No backend or frontend code modified.
- Per the cron workflow rule, **no code tests were run** because the change is documentation-only.
- Manual review:
  - Verified `ClubController.java` carries the `@deprecated` Javadoc claim referenced in the new notice.
  - Verified the documented legacy routes match the actual `@RequestMapping` / `@XxxMapping` annotations in the controller.
  - Verified the school-scoped replacement routes match `SchoolClubController.java`.

## Risks

- Low. No code or contract changes — only documentation.
- Reviewer should confirm the **Future API Needs** list is the right set of shapes to track before implementation. If a shape is wrong, that is a doc-only follow-up.
- The deprecation notice commits us to eventually removing the legacy routes; the removal plan is intentionally non-committal on a date and is gated on the 1st repo roadmap being complete.

## Out of scope

- No new code, no behavior change, no test changes.
- No new endpoints are added in this PR. They are tracked only in the Future API Needs section.