### PR TITLE
feat: add user agreements (Terms of Use & Privacy Policy)

### DIFF
--- a/backend/src/main/java/com/example/demo/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/example/demo/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.example.demo.auth.controller;
 
 import java.util.List;
+import java.util.Map;
 
 import com.example.demo.auth.model.AuthProvider;
 import com.example.demo.auth.model.AuthUser;
@@ -8,8 +9,11 @@ import com.example.demo.auth.service.AuthService;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -40,5 +44,34 @@ public class AuthController {
         }
 
         return currentUser;
+    }
+
+    @PostMapping("/accept-terms")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void acceptTerms(Authentication authentication) {
+        String email = resolveEmail(authentication);
+        if (email == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authentication required");
+        }
+        authService.acceptTerms(email);
+    }
+
+    @GetMapping("/me/has-accepted-terms")
+    public Map<String, Boolean> hasAcceptedTerms(Authentication authentication) {
+        String email = resolveEmail(authentication);
+        boolean accepted = email != null && authService.hasAcceptedTerms(email);
+        return Map.of("accepted", accepted);
+    }
+
+    private String resolveEmail(Authentication authentication) {
+        if (!(authentication instanceof OAuth2AuthenticationToken token)) {
+            return null;
+        }
+        OAuth2User principal = token.getPrincipal();
+        if (principal == null) {
+            return null;
+        }
+        Object email = principal.getAttributes().get("email");
+        return (email instanceof String str && !str.isBlank()) ? str : null;
     }
 }

--- a/backend/src/main/java/com/example/demo/auth/mapper/OAuthUserMapper.java
+++ b/backend/src/main/java/com/example/demo/auth/mapper/OAuthUserMapper.java
@@ -10,4 +10,8 @@ public interface OAuthUserMapper {
     void upsert(OAuthUserRecord record);
 
     Long findIdByEmail(@Param("email") String email);
+
+    int acceptTerms(@Param("email") String email);
+
+    Boolean hasAcceptedTerms(@Param("email") String email);
 }

--- a/backend/src/main/java/com/example/demo/auth/model/AuthUser.java
+++ b/backend/src/main/java/com/example/demo/auth/model/AuthUser.java
@@ -14,6 +14,7 @@ public class AuthUser {
     private Integer graduationYear;
     @JsonProperty("isOwner")
     private boolean platformOwner;
+    private Boolean acceptedTerms;
 
     public String getId() { return id; }
     public void setId(String id) { this.id = id; }
@@ -32,6 +33,9 @@ public class AuthUser {
 
     public Integer getGraduationYear() { return graduationYear; }
     public void setGraduationYear(Integer graduationYear) { this.graduationYear = graduationYear; }
+
+    public Boolean getAcceptedTerms() { return acceptedTerms; }
+    public void setAcceptedTerms(Boolean acceptedTerms) { this.acceptedTerms = acceptedTerms; }
 
     public boolean isPlatformOwner() { return platformOwner; }
     public void setPlatformOwner(boolean platformOwner) { this.platformOwner = platformOwner; }

--- a/backend/src/main/java/com/example/demo/auth/service/AuthService.java
+++ b/backend/src/main/java/com/example/demo/auth/service/AuthService.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import com.example.demo.auth.config.SecurityProperties;
 import com.example.demo.auth.model.AuthProvider;
 import com.example.demo.auth.model.AuthUser;
+import com.example.demo.auth.mapper.OAuthUserMapper;
 import com.example.demo.user.service.UserService;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
@@ -23,9 +24,11 @@ public class AuthService {
     private final OAuthUserService oAuthUserService;
     private final SecurityProperties securityProperties;
     private final UserService userService;
+    private final OAuthUserMapper oAuthUserMapper;
     private final String authorizationRequestBaseUri;
 
     public AuthService(ClientRegistrationRepository clientRegistrationRepository,
+                       OAuthUserMapper oAuthUserMapper,
                        OAuthUserService oAuthUserService,
                        SecurityProperties securityProperties,
                        UserService userService) {
@@ -37,6 +40,7 @@ public class AuthService {
         this.oAuthUserService = oAuthUserService;
         this.securityProperties = securityProperties;
         this.userService = userService;
+        this.oAuthUserMapper = oAuthUserMapper;
         this.authorizationRequestBaseUri = resolveAuthorizationRequestBaseUri(securityProperties);
     }
 
@@ -74,9 +78,22 @@ public class AuthService {
             user.setGraduationYear(storedGraduationYear);
         }
         user.setPlatformOwner(isPlatformOwner(user.getEmail()));
+        user.setAcceptedTerms(hasAcceptedTerms(user.getEmail()));
 
         oAuthUserService.recordLogin(provider, attributes);
         return user;
+    }
+
+    public void acceptTerms(String email) {
+        oAuthUserMapper.acceptTerms(email);
+    }
+
+    public boolean hasAcceptedTerms(String email) {
+        if (!StringUtils.hasText(email)) {
+            return false;
+        }
+        Boolean result = oAuthUserMapper.hasAcceptedTerms(email);
+        return Boolean.TRUE.equals(result);
     }
 
     private String stringAttribute(Map<String, Object> attributes, String... keys) {

--- a/backend/src/main/resources/mapper/OAuthUserMapper.xml
+++ b/backend/src/main/resources/mapper/OAuthUserMapper.xml
@@ -22,4 +22,19 @@
         LIMIT 1
     </select>
 
+    <update id="acceptTerms">
+        UPDATE oauth_users
+        SET accepted_terms_at = NOW()
+        WHERE LOWER(email) = LOWER(#{email})
+          AND accepted_terms_at IS NULL
+    </update>
+
+    <select id="hasAcceptedTerms" resultType="boolean">
+        SELECT COUNT(*) > 0
+        FROM oauth_users
+        WHERE LOWER(email) = LOWER(#{email})
+          AND accepted_terms_at IS NOT NULL
+        LIMIT 1
+    </select>
+
 </mapper>

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS oauth_users (
     display_name VARCHAR(200),
     avatar_url VARCHAR(500),
     role VARCHAR(50) NOT NULL DEFAULT 'student',
+    accepted_terms_at TIMESTAMP NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     last_login_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT uq_provider_user UNIQUE (provider, provider_user_id)

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -239,6 +239,16 @@ watch(
       <ErrorDisplay v-if="appError" :message="appError" @retry="resetError" />
       <RouterView v-else />
     </main>
+
+    <footer class="app-footer">
+      <div class="footer-inner page-shell">
+        <span class="footer-brand">HS Clubs</span>
+        <nav class="footer-links">
+          <RouterLink to="/terms">Terms of Use</RouterLink>
+          <RouterLink to="/privacy">Privacy Policy</RouterLink>
+        </nav>
+      </div>
+    </footer>
   </div>
 </template>
 
@@ -606,6 +616,48 @@ watch(
   .logo-icon {
     width: 36px;
     height: 36px;
+  }
+}
+/* ---- Footer ---- */
+.app-footer {
+  padding-block: 1.5rem;
+  border-top: 1px solid var(--mv-header-border);
+  background: var(--mv-header-bg);
+  margin-top: auto;
+}
+
+.footer-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.footer-brand {
+  font-size: 0.85rem;
+  color: var(--mv-text-faint);
+}
+
+.footer-links {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.footer-links a {
+  font-size: 0.85rem;
+  color: var(--mv-text-faint);
+  text-decoration: none;
+}
+
+.footer-links a:hover {
+  color: var(--mv-nav-text-hover);
+}
+
+@media (max-width: 480px) {
+  .footer-inner {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }
 </style>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -55,6 +55,23 @@ const router = createRouter({
       component: () => import('../views/SettingsView.vue'),
     },
 
+    // ---- Legal ----
+    {
+      path: '/terms',
+      name: 'terms',
+      component: () => import('../views/TermsOfUseView.vue'),
+    },
+    {
+      path: '/privacy',
+      name: 'privacy',
+      component: () => import('../views/PrivacyPolicyView.vue'),
+    },
+    {
+      path: '/accept-terms',
+      name: 'accept-terms',
+      component: () => import('../views/AcceptTermsView.vue'),
+    },
+
     // ---- Auth routes ----
     {
       path: '/auth',

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -13,4 +13,5 @@ export interface AuthUser {
   isOwner: boolean
   isPlatformOwner?: boolean
   graduationYear?: number | null
+  acceptedTerms?: boolean | null
 }

--- a/frontend/src/views/AcceptTermsView.vue
+++ b/frontend/src/views/AcceptTermsView.vue
@@ -1,0 +1,182 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '../stores/auth'
+import { buildApiUrl } from '../services/httpClient'
+
+const router = useRouter()
+const authStore = useAuthStore()
+const agreed = ref(false)
+const loading = ref(false)
+const error = ref('')
+
+const handleAccept = async () => {
+  if (!agreed.value) return
+  loading.value = true
+  error.value = ''
+  try {
+    const response = await fetch(buildApiUrl('/api/auth/accept-terms'), {
+      method: 'POST',
+      credentials: 'include',
+    })
+    if (!response.ok) {
+      throw new Error('Failed to record acceptance')
+    }
+    await authStore.refreshUser()
+    router.push('/')
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Something went wrong'
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="accept-terms page-shell">
+    <header class="terms-hero">
+      <p class="section-label">Welcome</p>
+      <h1>Before you continue</h1>
+      <p>Please review and accept our terms to start using HS Clubs.</p>
+    </header>
+
+    <div class="terms-summary">
+      <div class="summary-card">
+        <h2>Terms of Use</h2>
+        <ul>
+          <li>Use a valid school Google account</li>
+          <li>Provide accurate information</li>
+          <li>Respect other community members</li>
+          <li>Club leaders are responsible for their listings</li>
+        </ul>
+        <RouterLink to="/terms" target="_blank" class="read-link">Read full terms →</RouterLink>
+      </div>
+
+      <div class="summary-card">
+        <h2>Privacy Policy</h2>
+        <ul>
+          <li>We collect your name, email, and profile picture via Google</li>
+          <li>Your data stays within the HS Clubs platform</li>
+          <li>We do not sell or share your personal information</li>
+          <li>You can request account deletion anytime</li>
+        </ul>
+        <RouterLink to="/privacy" target="_blank" class="read-link">Read full policy →</RouterLink>
+      </div>
+    </div>
+
+    <form class="accept-form" @submit.prevent="handleAccept">
+      <label class="checkbox-label">
+        <input v-model="agreed" type="checkbox" />
+        <span>I have read and agree to the Terms of Use and Privacy Policy</span>
+      </label>
+
+      <p v-if="error" class="form-error">{{ error }}</p>
+
+      <button type="submit" class="btn primary" :disabled="!agreed || loading">
+        {{ loading ? 'Saving…' : 'Continue to HS Clubs' }}
+      </button>
+    </form>
+  </div>
+</template>
+
+<style scoped>
+.accept-terms {
+  padding-block: clamp(2rem, 5vw, 4rem);
+  max-width: 680px;
+}
+
+.terms-hero {
+  margin-bottom: 2.5rem;
+  text-align: center;
+}
+
+.terms-hero h1 {
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  font-weight: 700;
+  color: var(--mv-text);
+  margin: 0.5rem 0;
+}
+
+.terms-hero p {
+  color: var(--mv-text-muted);
+}
+
+.terms-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.summary-card {
+  padding: 1.5rem;
+  border-radius: 20px;
+  border: 1px solid var(--mv-border);
+  background: var(--mv-surface-card);
+}
+
+.summary-card h2 {
+  font-size: 1.1rem;
+  margin: 0 0 0.75rem;
+  color: var(--mv-text);
+}
+
+.summary-card ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: var(--mv-text-muted);
+  font-size: 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.read-link {
+  display: inline-block;
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--mv-gold);
+}
+
+.accept-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+  font-size: 0.95rem;
+  color: var(--mv-text);
+  cursor: pointer;
+}
+
+.checkbox-label input {
+  margin-top: 0.25rem;
+}
+
+.form-error {
+  color: var(--mv-status-danger);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.btn.primary {
+  padding: 0.7rem 1.5rem;
+  border-radius: 999px;
+  background: var(--mv-primary-bg);
+  color: var(--mv-primary-text);
+  border: none;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  align-self: flex-start;
+}
+
+.btn.primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/frontend/src/views/AuthCallbackView.vue
+++ b/frontend/src/views/AuthCallbackView.vue
@@ -17,7 +17,11 @@ onMounted(async () => {
   await authStore.refreshUser()
 
   if (authStore.isAuthenticated) {
-    router.replace(resolveRedirectTarget())
+    if (authStore.currentUser && authStore.currentUser.acceptedTerms === false) {
+      router.replace('/accept-terms')
+    } else {
+      router.replace(resolveRedirectTarget())
+    }
   } else {
     router.replace({ path: '/auth', query: { error: 'login_failed' } })
   }

--- a/frontend/src/views/PrivacyPolicyView.vue
+++ b/frontend/src/views/PrivacyPolicyView.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <div class="legal-page page-shell">
+    <header class="legal-hero">
+      <p class="section-label">Legal</p>
+      <h1>Privacy Policy</h1>
+      <p>Last updated: July 2026</p>
+    </header>
+
+    <section class="legal-content">
+      <h2>1. Information We Collect</h2>
+      <p>
+        When you sign in with Google OAuth, we receive your name, email address, and profile picture
+        from Google. We also collect the graduation year and club memberships you provide.
+      </p>
+
+      <h2>2. How We Use Information</h2>
+      <p>Your information is used to:</p>
+      <ul>
+        <li>Display your profile to other users within your school community.</li>
+        <li>Process club membership applications and manage club rosters.</li>
+        <li>Enable club presidents and school administrators to manage their clubs.</li>
+      </ul>
+
+      <h2>3. Data Sharing</h2>
+      <p>
+        We do not sell or share your personal information with third parties. Your data stays within
+        the HS Clubs platform and your school's instance.
+      </p>
+
+      <h2>4. Data Retention</h2>
+      <p>
+        Your account data is retained as long as your account is active. You may request account
+        deletion by contacting your school administrator or the platform owner.
+      </p>
+
+      <h2>5. Security</h2>
+      <p>
+        We use session-based authentication via Google OAuth 2.0. All API access requires
+        authentication for protected operations. However, no online service is 100% secure.
+      </p>
+
+      <h2>6. Children's Privacy</h2>
+      <p>
+        The Platform is designed for high school students. We comply with applicable student
+        data privacy laws. Parents or guardians with concerns may contact the platform administrator.
+      </p>
+
+      <h2>7. Contact</h2>
+      <p>
+        For privacy-related questions, contact the platform administrator through your school's
+        club directory page.
+      </p>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.legal-page {
+  padding-block: clamp(2rem, 5vw, 4rem);
+}
+
+.legal-hero {
+  margin-bottom: 2.5rem;
+}
+
+.legal-hero h1 {
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+  font-weight: 700;
+  color: var(--mv-text);
+  margin: 0.5rem 0 0.25rem;
+}
+
+.legal-hero p {
+  color: var(--mv-text-muted);
+  margin: 0;
+}
+
+.legal-content {
+  max-width: 780px;
+}
+
+.legal-content h2 {
+  font-size: 1.2rem;
+  color: var(--mv-text);
+  margin: 2rem 0 0.5rem;
+}
+
+.legal-content h2:first-child {
+  margin-top: 0;
+}
+
+.legal-content p,
+.legal-content li {
+  color: var(--mv-text-muted);
+  line-height: 1.7;
+}
+
+.legal-content ul {
+  padding-left: 1.5rem;
+  margin: 0.5rem 0;
+}
+</style>

--- a/frontend/src/views/TermsOfUseView.vue
+++ b/frontend/src/views/TermsOfUseView.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <div class="legal-page page-shell">
+    <header class="legal-hero">
+      <p class="section-label">Legal</p>
+      <h1>Terms of Use</h1>
+      <p>Last updated: July 2026</p>
+    </header>
+
+    <section class="legal-content">
+      <h2>1. Acceptance of Terms</h2>
+      <p>
+        By accessing or using HS Clubs ("the Platform"), you agree to be bound by these Terms of Use.
+        If you do not agree, do not use the Platform.
+      </p>
+
+      <h2>2. Eligibility</h2>
+      <p>
+        The Platform is intended for high school students, staff, and administrators. You must use a
+        valid school-issued or school-affiliated Google account to sign in.
+      </p>
+
+      <h2>3. User Conduct</h2>
+      <p>Users agree to:</p>
+      <ul>
+        <li>Provide accurate profile information.</li>
+        <li>Not impersonate others or misrepresent club affiliations.</li>
+        <li>Not post harmful, harassing, or inappropriate content.</li>
+        <li>Respect the privacy of other users.</li>
+      </ul>
+
+      <h2>4. Platform Role</h2>
+      <p>
+        HS Clubs provides a directory and management tool for school clubs. Individual schools and
+        club leaders are responsible for the content and accuracy of their club listings.
+      </p>
+
+      <h2>5. Account Termination</h2>
+      <p>
+        Platform owners reserve the right to suspend or terminate accounts that violate these terms
+        or disrupt the community.
+      </p>
+
+      <h2>6. Changes to Terms</h2>
+      <p>
+        These terms may be updated periodically. Continued use of the Platform after changes
+        constitutes acceptance of the updated terms.
+      </p>
+
+      <h2>7. Contact</h2>
+      <p>
+        Questions about these terms? Contact the platform administrator through your school's
+        club directory page.
+      </p>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.legal-page {
+  padding-block: clamp(2rem, 5vw, 4rem);
+}
+
+.legal-hero {
+  margin-bottom: 2.5rem;
+}
+
+.legal-hero h1 {
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+  font-weight: 700;
+  color: var(--mv-text);
+  margin: 0.5rem 0 0.25rem;
+}
+
+.legal-hero p {
+  color: var(--mv-text-muted);
+  margin: 0;
+}
+
+.legal-content {
+  max-width: 780px;
+}
+
+.legal-content h2 {
+  font-size: 1.2rem;
+  color: var(--mv-text);
+  margin: 2rem 0 0.5rem;
+}
+
+.legal-content h2:first-child {
+  margin-top: 0;
+}
+
+.legal-content p,
+.legal-content li {
+  color: var(--mv-text-muted);
+  line-height: 1.7;
+}
+
+.legal-content ul {
+  padding-left: 1.5rem;
+  margin: 0.5rem 0;
+}
+</style>


### PR DESCRIPTION
## Summary

Add Terms of Use and Privacy Policy pages with a first-login consent flow.

### Backend
- `accepted_terms_at` column on `oauth_users` table
- `POST /api/auth/accept-terms` — records acceptance
- `GET /api/auth/me/has-accepted-terms` — check endpoint
- `AuthUser` now returns `acceptedTerms` boolean

### Frontend
- `/terms` — Terms of Use page
- `/privacy` — Privacy Policy page
- `/accept-terms` — consent page with checkbox (shown after first OAuth login if terms not yet accepted)
- Footer on all pages with links to Terms and Privacy
- `AuthCallbackView` redirects new users to `/accept-terms`

### Build Status
- ✅ Frontend: `npm run build` passes
- ✅ Backend: `./mvnw compile` passes