### PR TITLE
fix(#17): delete old club image on upload + orphan cleanup task

### DIFF
--- a/backend/src/main/java/com/example/demo/BackendApplication.java
+++ b/backend/src/main/java/com/example/demo/BackendApplication.java
@@ -2,8 +2,10 @@ package com.example.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/example/demo/club/controller/ClubImageController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubImageController.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 @RestController
@@ -62,6 +63,10 @@ public class ClubImageController {
         String filename = UUID.randomUUID() + resolveImageExtension(file.getContentType());
 
         try {
+            // Delete old image file before saving the new one
+            String oldImageUrl = club.getImageUrl();
+            deleteImageFile(oldImageUrl);
+
             Path target = uploadDir.resolve(filename).normalize();
             if (!target.startsWith(uploadDir)) {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid file name");
@@ -140,5 +145,24 @@ public class ClubImageController {
         return securityProperties.getOwnerEmails().stream()
             .filter(item -> item != null && !item.isBlank())
             .anyMatch(item -> email.equalsIgnoreCase(item.trim()));
+    }
+
+    // Delete an image file from disk by its URL path (e.g. "/uploads/uuid.jpg")
+    private void deleteImageFile(String imageUrl) {
+        if (imageUrl == null || !imageUrl.startsWith("/uploads/")) {
+            return;
+        }
+        String filename = imageUrl.substring("/uploads/".length());
+        if (filename.contains("..") || filename.contains("/")) {
+            return; // path traversal guard
+        }
+        try {
+            Path file = uploadDir.resolve(filename).normalize();
+            if (file.startsWith(uploadDir)) {
+                Files.deleteIfExists(file);
+            }
+        } catch (IOException ignored) {
+            // Best-effort cleanup; don't fail the upload if cleanup fails
+        }
     }
 }

--- a/backend/src/main/java/com/example/demo/club/service/UploadCleanupService.java
+++ b/backend/src/main/java/com/example/demo/club/service/UploadCleanupService.java
@@ -1,0 +1,72 @@
+package com.example.demo.club.service;
+
+import com.example.demo.club.mapper.ClubMapper;
+import com.example.demo.club.model.Club;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Removes uploaded image files that are no longer referenced by any club.
+ * Runs daily at 3 AM.
+ */
+@Service
+public class UploadCleanupService {
+
+    private static final Logger log = LoggerFactory.getLogger(UploadCleanupService.class);
+
+    private final ClubMapper clubMapper;
+    private final Path uploadDir;
+
+    public UploadCleanupService(ClubMapper clubMapper,
+                                @Value("${app.upload.dir:uploads}") String uploadDirPath) {
+        this.clubMapper = clubMapper;
+        this.uploadDir = Paths.get(uploadDirPath).toAbsolutePath().normalize();
+    }
+
+    @Scheduled(cron = "0 0 3 * * *")
+    public void cleanOrphanedUploads() {
+        log.info("Starting orphaned upload cleanup...");
+
+        // Collect all image URLs currently referenced by clubs
+        List<Club> allClubs = clubMapper.findAll();
+        Set<String> referencedFilenames = allClubs.stream()
+            .map(Club::getImageUrl)
+            .filter(url -> url != null && url.startsWith("/uploads/"))
+            .map(url -> url.substring("/uploads/".length()))
+            .collect(Collectors.toSet());
+
+        if (!Files.exists(uploadDir) || !Files.isDirectory(uploadDir)) {
+            return;
+        }
+
+        try (var entries = Files.list(uploadDir)) {
+            entries.filter(Files::isRegularFile)
+                .forEach(file -> {
+                    String filename = file.getFileName().toString();
+                    if (!referencedFilenames.contains(filename)) {
+                        try {
+                            Files.deleteIfExists(file);
+                            log.info("Deleted orphaned upload: {}", filename);
+                        } catch (IOException e) {
+                            log.warn("Failed to delete orphaned upload: {}", filename, e);
+                        }
+                    }
+                });
+        } catch (IOException e) {
+            log.error("Failed to list upload directory for cleanup", e);
+        }
+
+        log.info("Orphaned upload cleanup complete. Referenced files: {}", referencedFilenames.size());
+    }
+}


### PR DESCRIPTION
## Changes
- ClubImageController now deletes old image file when a new one is uploaded
- Added UploadCleanupService with @Scheduled daily cleanup of unreferenced files
- Added @EnableScheduling to BackendApplication
- File type validation (jpg/png/webp/gif) and path traversal protection already in place

## Merge Order: 2 of 8