### PR TITLE
fix(#3,#16): configurable summary identity + 7-day session timeout

### DIFF
--- a/backend/src/main/java/com/example/demo/summary/service/SummaryService.java
+++ b/backend/src/main/java/com/example/demo/summary/service/SummaryService.java
@@ -3,6 +3,7 @@ package com.example.demo.summary.service;
 import com.example.demo.club.mapper.ClubMapper;
 import com.example.demo.club.model.Club;
 import com.example.demo.summary.model.SummaryResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.nio.charset.StandardCharsets;
@@ -19,9 +20,18 @@ import java.util.stream.Collectors;
 public class SummaryService {
 
     private final ClubMapper clubMapper;
+    private final String schoolName;
+    private final String shortName;
+    private final String slug;
 
-    public SummaryService(ClubMapper clubMapper) {
+    public SummaryService(ClubMapper clubMapper,
+                          @Value("${app.summary.school-name:HS Clubs}") String schoolName,
+                          @Value("${app.summary.short-name:HS Clubs}") String shortName,
+                          @Value("${app.summary.slug:hsclubs}") String slug) {
         this.clubMapper = clubMapper;
+        this.schoolName = schoolName;
+        this.shortName = shortName;
+        this.slug = slug;
     }
 
     public SummaryResponse buildSummary() {
@@ -46,9 +56,9 @@ public class SummaryService {
             .orElse(null);
 
         SummaryResponse summary = new SummaryResponse();
-        summary.setSchoolName("HS Clubs");
-        summary.setShortName("HS Clubs");
-        summary.setSlug("hsclubs");
+        summary.setSchoolName(schoolName);
+        summary.setShortName(shortName);
+        summary.setSlug(slug);
         summary.setStatus("active");
         summary.setClubCount(clubs.size());
         summary.setCategories(categoryCounts);

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -3,7 +3,9 @@ server:
   port: 8080
   servlet:
     session:
-      timeout: 7d  # Keep users signed in for 7 days
+      timeout: 7d
+      cookie:
+        max-age: 7d  # Persist JSESSIONID across browser restarts
 
 app:
   security:

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -1,6 +1,9 @@
 server:
   address: 127.0.0.1
   port: 8080
+  servlet:
+    session:
+      timeout: 7d  # Keep users signed in for 7 days
 
 app:
   security:
@@ -12,6 +15,10 @@ app:
     authorization-request-base-uri: ${APP_AUTHORIZATION_REQUEST_BASE_URI:/api/auth/authorize}
   upload:
     dir: ${APP_UPLOAD_DIR:uploads}
+  summary:
+    school-name: ${APP_SUMMARY_SCHOOL_NAME:HS Clubs}
+    short-name: ${APP_SUMMARY_SHORT_NAME:HS Clubs}
+    slug: ${APP_SUMMARY_SLUG:hsclubs}
 
 spring:
   config:


### PR DESCRIPTION
## #3 Summary API
- School name/shortName/slug now configurable via app.summary.* in application.yaml
- Supports env var overrides: APP_SUMMARY_SCHOOL_NAME, APP_SUMMARY_SHORT_NAME, APP_SUMMARY_SLUG

## #16 Session
- Set server.servlet.session.timeout to 7 days
- Users stay logged in across browser restarts

## Merge Order: 7 of 8