### PR TITLE
docs: reconcile API.md, DEPLOYMENT.md, and SettingsView to single-school pattern

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -39,7 +39,7 @@ List available OAuth providers.
 Response: `[{ "id": "google", "name": "Google", "authorizationUrl": "/api/auth/authorize/google" }]`
 
 ### GET /api/auth/me
-Return current authenticated user with school memberships.
+Return current authenticated user profile.
 
 Response:
 ```json
@@ -51,20 +51,6 @@ Response:
   "provider": "google",
   "graduationYear": 2026,
   "isOwner": false,
-  "homeSchool": {
-    "schoolId": 1,
-    "slug": "mvhs",
-    "schoolName": "Mountain View High School"
-  },
-  "schoolMemberships": [
-    {
-      "schoolId": 1,
-      "slug": "mvhs",
-      "schoolName": "Mountain View High School",
-      "role": "student",
-      "status": "active"
-    }
-  ]
 }
 ```
 
@@ -75,40 +61,17 @@ Invalidate session. Status: 204
 
 ---
 
-## Schools
-
-### GET /api/schools
-List all active schools. Public.
-
-### GET /api/schools/{slug}
-Get school detail by slug. 404 if not found or inactive.
-
-Response:
-```json
-{
-  "id": 1,
-  "slug": "mvhs",
-  "schoolName": "Mountain View High School",
-  "shortName": "MVHS",
-  "logoUrl": "/school-assets/mvhs-logo.png",
-  "bannerUrl": null,
-  "primaryColor": "#facc15",
-  "status": "active",
-  "timezone": "America/Los_Angeles"
-}
-```
-
 ---
 
-## School-Scoped Clubs (Primary)
+## Clubs (Primary)
 
-All under `/api/schools/{schoolSlug}/clubs`. **This is the primary path for club data.** New frontend and backend code must target these routes.
+All club endpoints live under `/api/clubs`. This is the single-school API pattern.
 
-### GET /api/schools/{schoolSlug}/clubs
-List active clubs for a school. Public. Supports `page` and `size` query parameters for pagination.
+### GET /api/clubs
+List active clubs. Public. Supports `page` and `size` query parameters for pagination.
 
-### POST /api/schools/{schoolSlug}/clubs
-Create a club. Requires: school_admin or platform_owner.
+### POST /api/clubs
+Create a club. Requires: admin or platform_owner.
 
 Request body:
 ```json
@@ -121,28 +84,27 @@ Request body:
   "location": "Room 301",
   "contactEmail": "robotics@school.edu",
   "advisor": "Dr. Smith",
-  "memberCount": 0,
-  "schoolId": 1
+  "memberCount": 0
 }
 ```
 
 Status: 201 | 400 | 403
 
-### GET /api/schools/{schoolSlug}/clubs/{clubSlugOrId}
+### GET /api/clubs/{clubSlugOrId}
 Get club detail. Accepts numeric ID or slug string. Viewer permissions (viewerIsMember, canManage, viewerHasPendingRequest) included when authenticated.
 
-### PUT /api/schools/{schoolSlug}/clubs/{clubSlugOrId}
-Update club. Requires: school_admin, platform_owner, or club president.
+### PUT /api/clubs/{clubSlugOrId}
+Update club. Requires: admin, platform_owner, or club president.
 
-### DELETE /api/schools/{schoolSlug}/clubs/{clubSlugOrId}
-Delete club. Requires: school_admin or platform_owner. Status: 204
+### DELETE /api/clubs/{clubSlugOrId}
+Delete club. Requires: admin or platform_owner. Status: 204
 
 ---
 
 ## Membership
 
-### GET /api/schools/{schoolSlug}/clubs/{clubSlugOrId}/members
-List club members. Requires: school_admin, platform_owner, or club president.
+### GET /api/clubs/{id}/members
+List club members. Requires: admin, platform_owner, or club president.
 
 Response:
 ```json
@@ -157,92 +119,61 @@ Response:
 ]
 ```
 
-### POST /api/schools/{schoolSlug}/clubs/{clubSlugOrId}/members/apply
+### POST /api/clubs/{id}/members/apply
 Apply to join a club. Requires: authenticated.
 
 Status: 204 | 400 | 401 | 409 (already applied/member)
 
-### DELETE /api/schools/{schoolSlug}/clubs/{clubSlugOrId}/members/apply
+### DELETE /api/clubs/{id}/members/apply
 Cancel own membership application. Requires: authenticated.
 
 ---
 
 ## Membership Requests (Admin)
 
-### GET /api/schools/{schoolSlug}/clubs/{clubSlugOrId}/membership-requests
-List pending membership requests. Requires: school_admin, platform_owner, or club president.
+### GET /api/clubs/{id}/membership-requests
+List pending membership requests. Requires: admin, platform_owner, or club president.
 
-### POST .../membership-requests/{requestId}/approve
+### POST /api/clubs/{id}/membership-requests/{requestId}/approve
 Approve a membership request. Adds user as member. Status: 204
 
-### DELETE .../membership-requests/{requestId}
+### DELETE /api/clubs/{id}/membership-requests/{requestId}
 Reject/delete a membership request. Status: 204
-
----
 
 ## Platform Admin
 
 All under `/api/platform`. Requires: platform_owner.
 
-### GET /api/platform/schools
-List all schools (including inactive).
+### GET /api/platform/stats
+Platform-level statistics (club count, user count, pending requests).
 
-### POST /api/platform/schools
-Create a new school.
-
-Request body:
-```json
-{
-  "slug": "pahs",
-  "schoolName": "Palo Alto High School",
-  "shortName": "Paly",
-  "timezone": "America/Los_Angeles"
-}
-```
+### POST /api/platform/owners
+Add a platform owner by email. Requires: platform_owner.
 
 Status: 201 | 400
 
-### PUT /api/platform/schools/{slug}
-Update school information.
-
 ---
 
-## Compatibility-Only (Deprecated) Endpoints
+## Route Summary
 
-> ⚠️ **Deprecated. Do not use in new code.** These endpoints are retained only for backward compatibility with the original MVHS-only deployment. The corresponding backend controller is annotated `@deprecated` in `ClubController.java`. New clients should call the school-scoped routes listed above.
-
-| Legacy Route | School-Scoped Replacement |
-|--------------|---------------------------|
-| `GET /api/clubs` | `GET /api/schools/{slug}/clubs` |
-| `GET /api/clubs/{id}` | `GET /api/schools/{slug}/clubs/{id}` |
-| `POST /api/clubs` | `POST /api/schools/{slug}/clubs` |
-| `PUT /api/clubs/{id}` | `PUT /api/schools/{slug}/clubs/{id}` |
-| `DELETE /api/clubs/{id}` | `DELETE /api/schools/{slug}/clubs/{id}` |
-| `GET /api/clubs/{id}/members` | `GET /api/schools/{slug}/clubs/{id}/members` |
-| `POST /api/clubs/{id}/members/apply` | `POST /api/schools/{slug}/clubs/{id}/members/apply` |
-| `DELETE /api/clubs/{id}/members/apply` | `DELETE /api/schools/{slug}/clubs/{id}/members/apply` |
-| `GET /api/clubs/{id}/membership-requests` | `GET /api/schools/{slug}/clubs/{id}/membership-requests` |
-| `POST /api/clubs/{id}/membership-requests/{requestId}/approve` | `POST /api/schools/{slug}/clubs/{id}/membership-requests/{requestId}/approve` |
-| `DELETE /api/clubs/{id}/membership-requests/{requestId}` | `DELETE /api/schools/{slug}/clubs/{id}/membership-requests/{requestId}` |
-
-**Removal plan:** these routes will be removed once the 1st repo roadmap is complete, all known clients are migrated to school-scoped paths, and the deprecation is announced in a release note. Bug fixes will still be accepted for the duration of the deprecation period.
+All primary club routes use the `/api/clubs` pattern. There are no school-scoped route variants.
 
 ## Future API Needs (Track Before Implementing)
 
 The following endpoints have been identified as likely needs. **Do not build them yet**; this list exists so the next person does not accidentally invent a duplicate or contradictory shape. When one of these is picked up, design the request/response shape first and add it to this section.
 
-- `GET /api/schools/{slug}/summary` — landing-page summary for a school: total active clubs, counts by category, total pending membership requests visible to the viewer, upcoming events count.
-- `GET /api/schools/{slug}/clubs/{id}/summary` — club detail summary: member count, pending request count, recent activity, advisor.
-- `GET /api/schools/{slug}/clubs/{id}/events` — recurring schedule and one-off events for a club.
-- `GET /api/me/summary` — user-centered summary: home school, active memberships, pending applications, unread notifications.
-- `GET /api/schools/{slug}/members/search` — admin-only search across a school's members (for roster management).
-- `GET /api/platform/summary` — platform-owner landing summary: total schools, active clubs, pending invitations.
+- `GET /api/clubs/summary` — directory-wide summary: total active clubs, counts by category, upcoming events count.
+- `GET /api/clubs/{id}/summary` — club detail summary: member count, pending request count, recent activity, advisor.
+- `GET /api/clubs/{id}/events` — recurring schedule and one-off events for a club.
+- `GET /api/me/summary` — user-centered summary: active memberships, pending applications, unread notifications.
+- `GET /api/users/search` — admin-only search across members (for roster management).
+- `GET /api/platform/summary` — platform-owner landing summary: total clubs, active users, pending requests.
 
 Before any of these are implemented, the proposer should:
 
-1. Confirm no school-scoped, platform, or global endpoint already covers the use case.
+1. Confirm no existing endpoint already covers the use case.
 2. Sketch the request and response shape in `docs/API.md` and request review.
-3. Add the route under the appropriate primary section (school-scoped, platform, or global profile), **not** under compatibility-only.
+3. Add the route under the appropriate primary section (Clubs, Platform, or Profile).
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -71,7 +71,7 @@ All club endpoints live under `/api/clubs`. This is the single-school API patter
 List active clubs. Public. Supports `page` and `size` query parameters for pagination.
 
 ### POST /api/clubs
-Create a club. Requires: admin or platform_owner.
+Create a club. Requires: platform_owner.
 
 Request body:
 ```json
@@ -94,17 +94,17 @@ Status: 201 | 400 | 403
 Get club detail. Accepts numeric ID or slug string. Viewer permissions (viewerIsMember, canManage, viewerHasPendingRequest) included when authenticated.
 
 ### PUT /api/clubs/{clubSlugOrId}
-Update club. Requires: admin, platform_owner, or club president.
+Update club. Requires: platform_owner, or club president.
 
 ### DELETE /api/clubs/{clubSlugOrId}
-Delete club. Requires: admin or platform_owner. Status: 204
+Delete club. Requires: platform_owner. Status: 204
 
 ---
 
 ## Membership
 
 ### GET /api/clubs/{id}/members
-List club members. Requires: admin, platform_owner, or club president.
+List club members. Requires: platform_owner, or club president.
 
 Response:
 ```json
@@ -132,7 +132,7 @@ Cancel own membership application. Requires: authenticated.
 ## Membership Requests (Admin)
 
 ### GET /api/clubs/{id}/membership-requests
-List pending membership requests. Requires: admin, platform_owner, or club president.
+List pending membership requests. Requires: platform_owner, or club president.
 
 ### POST /api/clubs/{id}/membership-requests/{requestId}/approve
 Approve a membership request. Adds user as member. Status: 204
@@ -140,19 +140,7 @@ Approve a membership request. Adds user as member. Status: 204
 ### DELETE /api/clubs/{id}/membership-requests/{requestId}
 Reject/delete a membership request. Status: 204
 
-## Platform Admin
 
-All under `/api/platform`. Requires: platform_owner.
-
-### GET /api/platform/stats
-Platform-level statistics (club count, user count, pending requests).
-
-### POST /api/platform/owners
-Add a platform owner by email. Requires: platform_owner.
-
-Status: 201 | 400
-
----
 
 ## Route Summary
 
@@ -166,8 +154,9 @@ The following endpoints have been identified as likely needs. **Do not build the
 - `GET /api/clubs/{id}/summary` — club detail summary: member count, pending request count, recent activity, advisor.
 - `GET /api/clubs/{id}/events` — recurring schedule and one-off events for a club.
 - `GET /api/me/summary` — user-centered summary: active memberships, pending applications, unread notifications.
-- `GET /api/users/search` — admin-only search across members (for roster management).
-- `GET /api/platform/summary` — platform-owner landing summary: total clubs, active users, pending requests.
+- `GET /api/users/search` — platform-owner search across members (for roster management).
+- `GET /api/platform/stats` — platform-owner landing stats: total clubs, active users, pending requests.
+- `GET /api/platform/owners` — manage platform owners (post/delete by email).
 
 Before any of these are implemented, the proposer should:
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,4 +1,4 @@
-# HSclubs — Deployment Guide
+# HSclubs — Single-School Deployment Guide
 
 ## Architecture
 
@@ -106,19 +106,18 @@ This script uses only `ALTER TABLE` and `CREATE TABLE IF NOT EXISTS` — safe to
 ### Verify
 
 ```sql
--- Check schools
-SELECT id, slug, school_name, status FROM schools;
+-- Check clubs
+SELECT id, name, slug, category, status FROM clubs LIMIT 5;
 
--- Check clubs with school context
-SELECT c.name, s.school_name, c.status
-FROM clubs c JOIN schools s ON c.school_id = s.id
+-- Check users
+SELECT uid, email, display_name, graduation_year, is_owner FROM oauth_users LIMIT 5;
+
+-- Check club members
+SELECT ou.email, cm.role_name, c.name
+FROM club_member cm
+JOIN oauth_users ou ON ou.uid = cm.oauth_user_id
+JOIN clubs c ON c.id = cm.club_id
 LIMIT 5;
-
--- Check user-school relationships
-SELECT ou.email, su.role, s.school_name
-FROM school_users su
-JOIN oauth_users ou ON ou.uid = su.oauth_user_id
-JOIN schools s ON s.id = su.school_id;
 ```
 
 ---
@@ -176,8 +175,8 @@ sudo systemctl status hsclubs
 ### Health check
 
 ```bash
-# List schools (public endpoint)
-curl http://localhost:8080/api/schools
+# List clubs (public endpoint)
+curl http://localhost:8080/api/clubs
 
 # Check auth providers
 curl http://localhost:8080/api/auth/providers
@@ -341,10 +340,9 @@ The `/api/auth/providers` endpoint auto-discovers all configured providers.
 ### First-run steps
 
 1. Deploy and start the backend — tables auto-create
-2. Open `/schools` — should show "Mountain View High School"
+2. Open the home page — should show the club directory
 3. Sign in as a platform owner (email in `APP_OWNER_EMAILS`)
-4. Visit `/platform/admin` — create additional schools
-5. Invite school admins via `/platform/admin` invite form
+4. Visit `/admin` — create clubs and manage the directory
 
 ---
 
@@ -373,15 +371,7 @@ Google OAuth redirect URIs must match exactly:
 - Dev: `http://localhost:8080/api/auth/google/callback`
 - Prod: `https://yourdomain.com/api/auth/google/callback`
 
-### "School not found" on valid slug
 
-Check `schools.status` is `active`:
-
-```sql
-SELECT slug, school_name, status FROM schools;
-```
-
-Inactive or `pending` schools are hidden from the public API.
 
 ### Invitation link not working
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -110,7 +110,13 @@ This script uses only `ALTER TABLE` and `CREATE TABLE IF NOT EXISTS` — safe to
 SELECT id, name, slug, category, status FROM clubs LIMIT 5;
 
 -- Check users
-SELECT uid, email, display_name, graduation_year, is_owner FROM oauth_users LIMIT 5;
+SELECT uid, email, display_name, provider FROM oauth_users LIMIT 5;
+
+-- Check user profiles (includes graduation year)
+SELECT up.oauth_user_id, ou.email, up.graduation_year
+FROM user_profiles up
+JOIN oauth_users ou ON ou.uid = up.oauth_user_id
+LIMIT 5;
 
 -- Check club members
 SELECT ou.email, cm.role_name, c.name

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -52,7 +52,7 @@ const clearCache = () => {
       <div class="setting-row">
         <div>
           <strong>HS Clubs</strong>
-          <p>Multi-school club directory platform. Built with Vue 3 + Spring Boot.</p>
+          <p>Single-school club directory platform. Built with Vue 3 + Spring Boot.</p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

Fixes remaining documentation gaps found during repo integrity check.

### Changes

- **docs/API.md**: Remove Schools section, replace all school-scoped routes with `/api/clubs`, flip deprecated table to route summary, update future API needs, simplify auth response
- **docs/DEPLOYMENT.md**: Update DB verify queries, first-run steps, curl examples, remove multi-school troubleshooting
- **frontend/src/views/SettingsView.vue**: Multi-school → Single-school

All `/api/schools` and `school_admin` references removed from active docs.