### PR TITLE
Fix club admin counts and access gates

### DIFF
--- a/backend/src/main/java/com/example/demo/club/controller/ClubController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubController.java
@@ -55,6 +55,11 @@ public class ClubController {
         return clubService.findAllPaginated(page, size);
     }
 
+    @GetMapping("/count")
+    public Map<String, Integer> count() {
+        return Map.of("count", clubService.countAll());
+    }
+
     @GetMapping("/{clubSlugOrId}")
     public Club get(@PathVariable String clubSlugOrId, Authentication authentication) {
         Club club = resolveClub(clubSlugOrId, resolveViewerEmail(authentication));
@@ -107,6 +112,24 @@ public class ClubController {
                                              Authentication authentication) {
         Club club = requireManageAccess(clubSlugOrId, authentication);
         return clubService.findMembers(club.getId());
+    }
+
+    @PutMapping("/{clubSlugOrId}/members/{oauthUserId}/role")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateMemberRole(@PathVariable String clubSlugOrId,
+                                 @PathVariable Long oauthUserId,
+                                 @RequestBody UpdateMemberRoleRequest request,
+                                 Authentication authentication) {
+        requirePlatformOwner(authentication);
+        Club club = resolveClub(clubSlugOrId, resolveViewerEmail(authentication));
+        if (club == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
+        }
+        try {
+            clubService.updateMemberRole(club.getId(), oauthUserId, request == null ? null : request.roleName());
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage());
+        }
     }
 
     // ---- Membership application ----
@@ -314,4 +337,6 @@ public class ClubController {
         }
         return false;
     }
+
+    public record UpdateMemberRoleRequest(String roleName) {}
 }

--- a/backend/src/main/java/com/example/demo/club/mapper/ClubMapper.java
+++ b/backend/src/main/java/com/example/demo/club/mapper/ClubMapper.java
@@ -42,6 +42,13 @@ public interface ClubMapper {
 
     List<ClubMemberView> findMembersByClubId(@Param("clubId") Long clubId);
 
+    int updateMemberRole(@Param("clubId") Long clubId,
+                         @Param("oauthUserId") Long oauthUserId,
+                         @Param("roleName") String roleName);
+
+    int demoteOtherPresidents(@Param("clubId") Long clubId,
+                              @Param("oauthUserId") Long oauthUserId);
+
     int insertMember(@Param("clubId") Long clubId,
                      @Param("oauthUserId") Long oauthUserId,
                      @Param("roleName") String roleName);
@@ -70,10 +77,7 @@ public interface ClubMapper {
     List<String> findCategoriesByOauthUserId(@Param("oauthUserId") Long oauthUserId);
 
     List<Long> findClubIdsByOauthUserId(@Param("oauthUserId") Long oauthUserId);
+
     ViewerMembershipStatus findMembershipStatusByUserId(@Param("clubId") Long clubId,
                                                          @Param("oauthUserId") Long oauthUserId);
-
-    int updateMemberRole(@Param("clubId") Long clubId,
-                         @Param("oauthUserId") Long oauthUserId,
-                         @Param("roleName") String roleName);
 }

--- a/backend/src/main/java/com/example/demo/club/service/ClubService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubService.java
@@ -25,6 +25,7 @@ public class ClubService {
         "Wellness & Athletics",
         "Competition & Strategy"
     );
+    private static final Set<String> ALLOWED_MEMBER_ROLES = Set.of("member", "president");
 
     private final ClubMapper clubMapper;
     private final OAuthUserMapper oAuthUserMapper;
@@ -87,6 +88,18 @@ public class ClubService {
 
     public List<ClubMemberView> findMembers(Long clubId) {
         return clubMapper.findMembersByClubId(clubId);
+    }
+
+    @Transactional
+    public void updateMemberRole(Long clubId, Long oauthUserId, String roleName) {
+        String normalizedRole = normalizeMemberRole(roleName);
+        int updated = clubMapper.updateMemberRole(clubId, oauthUserId, normalizedRole);
+        if (updated == 0) {
+            throw new IllegalArgumentException("Member not found for this club");
+        }
+        if ("president".equals(normalizedRole)) {
+            clubMapper.demoteOtherPresidents(clubId, oauthUserId);
+        }
     }
 
     // ---- CRUD ----
@@ -220,11 +233,10 @@ public class ClubService {
         // Check if already a member
         ViewerMembershipStatus status = clubMapper.findMembershipStatusByUserId(clubId, oauthUserId);
         if (status != null && Boolean.TRUE.equals(status.getMember())) {
-            // Update existing membership to president role
-            clubMapper.updateMemberRole(clubId, oauthUserId, "president");
+            updateMemberRole(clubId, oauthUserId, "president");
         } else {
-            // Insert as president
             clubMapper.insertMember(clubId, oauthUserId, "president");
+            clubMapper.demoteOtherPresidents(clubId, oauthUserId);
         }
     }
 
@@ -265,6 +277,17 @@ public class ClubService {
 
     private String cleanSearchTerm(String value) {
         return StringUtils.hasText(value) ? value.trim() : null;
+    }
+
+    private String normalizeMemberRole(String roleName) {
+        if (!StringUtils.hasText(roleName)) {
+            throw new IllegalArgumentException("Member role is required");
+        }
+        String normalizedRole = roleName.trim().toLowerCase();
+        if (!ALLOWED_MEMBER_ROLES.contains(normalizedRole)) {
+            throw new IllegalArgumentException("Invalid member role");
+        }
+        return normalizedRole;
     }
 
     private void applyViewerPermissions(Club club, String viewerEmail) {

--- a/backend/src/main/resources/mapper/ClubMapper.xml
+++ b/backend/src/main/resources/mapper/ClubMapper.xml
@@ -164,6 +164,7 @@
 
     <!-- Members -->
     <resultMap id="ClubMemberViewMap" type="com.example.demo.club.model.ClubMemberView">
+        <id column="oauth_user_id" property="oauthUserId" />
         <result column="display_name" property="displayName" />
         <result column="email" property="email" />
         <result column="avatar_url" property="avatarUrl" />
@@ -172,7 +173,8 @@
     </resultMap>
 
     <select id="findMembersByClubId" resultMap="ClubMemberViewMap" parameterType="long">
-        SELECT ou.display_name,
+        SELECT cm.oauth_user_id,
+               ou.display_name,
                ou.email,
                ou.avatar_url,
                cm.role_name,
@@ -182,6 +184,21 @@
         WHERE cm.club_id = #{clubId}
         ORDER BY cm.joined_at ASC
     </select>
+
+    <update id="updateMemberRole">
+        UPDATE club_member
+        SET role_name = #{roleName}
+        WHERE club_id = #{clubId}
+          AND oauth_user_id = #{oauthUserId}
+    </update>
+
+    <update id="demoteOtherPresidents">
+        UPDATE club_member
+        SET role_name = 'member'
+        WHERE club_id = #{clubId}
+          AND oauth_user_id != #{oauthUserId}
+          AND LOWER(role_name) = 'president'
+    </update>
 
     <insert id="insertMember">
         INSERT INTO club_member (club_id, oauth_user_id, role_name)
@@ -326,11 +343,5 @@
         FROM (SELECT 1) AS dummy
         LEFT JOIN club_member cm ON cm.club_id = #{clubId} AND cm.oauth_user_id = #{oauthUserId}
     </select>
-
-    <update id="updateMemberRole">
-        UPDATE club_member
-        SET role_name = #{roleName}
-        WHERE club_id = #{clubId} AND oauth_user_id = #{oauthUserId}
-    </update>
 
 </mapper>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
+import { useAuthStore } from '../stores/auth'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -111,6 +112,40 @@ const router = createRouter({
       component: () => import('../views/NotFoundView.vue'),
     },
   ],
+})
+
+const termsBypassRouteNames = new Set([
+  'auth-choice',
+  'auth-callback',
+  'accept-terms',
+  'terms',
+  'privacy',
+  'not-found',
+])
+
+router.beforeEach(async (to) => {
+  const authStore = useAuthStore()
+  if (!authStore.hasCheckedSession) {
+    await authStore.refreshUser()
+  }
+
+  if (to.name === 'accept-terms' && !authStore.isAuthenticated) {
+    return { name: 'auth-choice', query: { intent: 'login' } }
+  }
+
+  if (
+    authStore.isAuthenticated &&
+    authStore.currentUser?.acceptedTerms === false &&
+    !termsBypassRouteNames.has(String(to.name))
+  ) {
+    return { name: 'accept-terms' }
+  }
+
+  if (to.name === 'accept-terms' && authStore.currentUser?.acceptedTerms === true) {
+    return { name: 'home' }
+  }
+
+  return true
 })
 
 export default router

--- a/frontend/src/services/clubService.ts
+++ b/frontend/src/services/clubService.ts
@@ -13,6 +13,7 @@ let clubsCache: Club[] | null = null
 let clubsCacheKey = ''
 let clubsCacheExpiresAt = 0
 let clubsRequest: Promise<Club[]> | null = null
+let clubsRequestKey = ''
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const url = buildApiUrl(path)
@@ -46,6 +47,7 @@ export const invalidateClubCache = () => {
   clubsCacheKey = ''
   clubsCacheExpiresAt = 0
   clubsRequest = null
+  clubsRequestKey = ''
 }
 
 const clubPath = (suffix: string, page?: number, size?: number) => {
@@ -59,18 +61,19 @@ const clubPath = (suffix: string, page?: number, size?: number) => {
 
 export const fetchClubs = async (options: FetchClubsOptions = {}) => {
   const { force = false } = options
-  const cacheKey = '__global__'
+  const { page, size } = options
+  const cacheKey = `page:${page ?? 'default'}:size:${size ?? 'default'}`
   const now = Date.now()
 
   if (!force && clubsCache && cacheKey === clubsCacheKey && now < clubsCacheExpiresAt) {
     return cloneClubs(clubsCache)
   }
 
-  if (!force && clubsRequest) {
+  if (!force && clubsRequest && clubsRequestKey === cacheKey) {
     return cloneClubs(await clubsRequest)
   }
 
-  const { page, size } = options
+  clubsRequestKey = cacheKey
   clubsRequest = request<Club[]>(clubPath('', page, size))
 
   try {
@@ -79,7 +82,13 @@ export const fetchClubs = async (options: FetchClubsOptions = {}) => {
     return cloneClubs(clubs)
   } finally {
     clubsRequest = null
+    clubsRequestKey = ''
   }
+}
+
+export const fetchClubCount = async () => {
+  const response = await request<{ count: number }>(clubPath('/count'))
+  return response.count
 }
 
 export const fetchClubById = (id: number | string) =>
@@ -103,6 +112,16 @@ export const updateClub = async (
 
 export const fetchClubMembers = (id: number | string) =>
   request<ClubMember[]>(clubPath(`/${id}/members`))
+
+export const updateClubMemberRole = (
+  clubId: number | string,
+  oauthUserId: number | string,
+  roleName: string,
+) =>
+  request<void>(clubPath(`/${clubId}/members/${oauthUserId}/role`), {
+    method: 'PUT',
+    body: JSON.stringify({ roleName }),
+  })
 
 export const applyToClub = (id: number | string) =>
   request<void>(clubPath(`/${id}/members/apply`), {

--- a/frontend/src/views/AuthChoiceView.vue
+++ b/frontend/src/views/AuthChoiceView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
 import { storeToRefs } from 'pinia'
 
@@ -8,6 +8,8 @@ import { useAuthStore } from '../stores/auth'
 const route = useRoute()
 const authStore = useAuthStore()
 const { providers, providersLoading, providersError } = storeToRefs(authStore)
+const acceptedTerms = ref(false)
+const termsError = ref('')
 
 onMounted(() => {
   authStore.ensureProvidersLoaded()
@@ -20,6 +22,11 @@ const routeError = computed(() => {
 })
 
 const handleProviderLogin = (providerId: string) => {
+  if (!acceptedTerms.value) {
+    termsError.value = 'Please accept the Terms of Use before continuing.'
+    return
+  }
+  termsError.value = ''
   authStore.beginLogin(providerId)
 }
 </script>
@@ -36,14 +43,25 @@ const handleProviderLogin = (providerId: string) => {
       <div class="alerts">
         <p v-if="routeError" class="alert error">{{ routeError }}</p>
         <p v-if="providersError" class="alert error">{{ providersError }}</p>
+        <p v-if="termsError" class="alert error">{{ termsError }}</p>
         <p v-else-if="providersLoading" class="alert muted">Loading sign-in options…</p>
       </div>
+      <label class="terms-check">
+        <input v-model="acceptedTerms" type="checkbox" @change="termsError = ''" />
+        <span>
+          I agree to the
+          <RouterLink to="/terms" target="_blank">Terms of Use</RouterLink>
+          and
+          <RouterLink to="/privacy" target="_blank">Privacy Policy</RouterLink>.
+        </span>
+      </label>
       <div v-if="!providersLoading && !providersError" class="provider-list">
         <button
           v-for="provider in providers"
           :key="provider.id"
           class="provider-btn"
           type="button"
+          :disabled="!acceptedTerms"
           @click="handleProviderLogin(provider.id)"
         >
           <span class="provider-icon" aria-hidden="true">{{ provider.name.charAt(0) }}</span>
@@ -131,6 +149,33 @@ const handleProviderLogin = (providerId: string) => {
 .provider-btn:hover {
   transform: translateY(-2px);
   box-shadow: var(--mv-shadow-elevated);
+}
+
+.provider-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.terms-check {
+  width: 100%;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+  color: var(--mv-text-soft);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.terms-check input {
+  margin-top: 0.25rem;
+  flex: 0 0 auto;
+}
+
+.terms-check a {
+  color: var(--mv-gold);
+  font-weight: 600;
 }
 
 .provider-icon {

--- a/frontend/src/views/ClubAdminView.vue
+++ b/frontend/src/views/ClubAdminView.vue
@@ -2,7 +2,7 @@
 import { computed, reactive, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { RouterLink, useRoute } from 'vue-router'
-import { fetchClubById, fetchClubMembers, updateClub } from '../services/clubService'
+import { fetchClubById, fetchClubMembers, updateClub, updateClubMemberRole } from '../services/clubService'
 import { searchUsers, assignPresident, removePresident } from '../services/userService'
 import type { Club, ClubMember } from '../types/club'
 import type { UserSearchResult } from '../services/userService'
@@ -21,6 +21,12 @@ const successMessage = ref('')
 const members = ref<ClubMember[]>([])
 const membersLoading = ref(false)
 const membersError = ref('')
+const memberRoleError = ref('')
+const roleSavingMemberId = ref<number | null>(null)
+const memberRoleOptions = [
+  { value: 'member', label: 'Member' },
+  { value: 'president', label: 'President' },
+]
 
 // President management state
 const presidentSearchQuery = ref('')
@@ -175,9 +181,46 @@ const loadMembers = async (id: string) => {
   }
 }
 
-const refreshMembers = () => {
+const refreshMembers = async () => {
   if (club.value && canManageMembers.value) {
-    void loadMembers(String(club.value.id))
+    await loadMembers(String(club.value.id))
+  }
+}
+
+const handleMemberRoleChange = async (member: ClubMember, event: Event) => {
+  if (!club.value || !canManageMembers.value || roleSavingMemberId.value) {
+    return
+  }
+  const select = event.target as HTMLSelectElement
+  const previousRole = member.roleName || 'member'
+  const nextRole = select.value
+  if (nextRole === previousRole) {
+    return
+  }
+
+  memberRoleError.value = ''
+  roleSavingMemberId.value = member.oauthUserId
+  try {
+    await updateClubMemberRole(club.value.id, member.oauthUserId, nextRole)
+    await loadMembers(String(club.value.id))
+    await refreshClubSnapshot()
+  } catch (err) {
+    member.roleName = previousRole
+    memberRoleError.value = err instanceof Error ? err.message : 'Failed to update member role'
+    await loadMembers(String(club.value.id))
+  } finally {
+    roleSavingMemberId.value = null
+  }
+}
+
+const refreshClubSnapshot = async () => {
+  if (!club.value) {
+    return
+  }
+  try {
+    club.value = await fetchClubById(String(club.value.id))
+  } catch (err) {
+    console.error(err)
   }
 }
 
@@ -451,22 +494,37 @@ watch(
             <p>{{ membersError }}</p>
             <button type="button" class="ghost-btn" @click="refreshMembers">Try again</button>
           </div>
-          <ul v-else-if="members.length" class="member-list">
-            <li v-for="member in members" :key="member.oauthUserId" class="member-entry">
-              <div class="member-avatar">
-                <img
-                  :src="member.avatarUrl || 'https://api.dicebear.com/7.x/thumbs/svg?seed=' + encodeURIComponent(member.displayName || 'Member')"
-                  :alt="member.displayName || 'Club member'"
-                />
-              </div>
-              <div class="member-info">
-                <p>{{ member.displayName || 'Unnamed member' }}</p>
-                <small>{{ member.roleName || 'Member' }}</small>
-              </div>
-              <a v-if="member.email" class="member-email" :href="`mailto:${member.email}`">{{ member.email }}</a>
-            </li>
-          </ul>
-          <p v-else class="member-empty">No members have been linked yet.</p>
+          <template v-else>
+            <p v-if="memberRoleError" class="member-hint error" role="alert">{{ memberRoleError }}</p>
+            <ul v-if="members.length" class="member-list">
+              <li v-for="member in members" :key="member.oauthUserId" class="member-entry">
+                <div class="member-avatar">
+                  <img
+                    :src="member.avatarUrl || 'https://api.dicebear.com/7.x/thumbs/svg?seed=' + encodeURIComponent(member.displayName || 'Member')"
+                    :alt="member.displayName || 'Club member'"
+                  />
+                </div>
+                <div class="member-info">
+                  <p>{{ member.displayName || 'Unnamed member' }}</p>
+                  <small>{{ member.roleName || 'Member' }}</small>
+                </div>
+                <label v-if="isOwner" class="member-role">
+                  <span>Role</span>
+                  <select
+                    :value="member.roleName || 'member'"
+                    :disabled="roleSavingMemberId === member.oauthUserId"
+                    @change="handleMemberRoleChange(member, $event)"
+                  >
+                    <option v-for="option in memberRoleOptions" :key="option.value" :value="option.value">
+                      {{ option.label }}
+                    </option>
+                  </select>
+                </label>
+                <a v-if="member.email" class="member-email" :href="`mailto:${member.email}`">{{ member.email }}</a>
+              </li>
+            </ul>
+            <p v-else class="member-empty">No members have been linked yet.</p>
+          </template>
         </section>
       </section>
 
@@ -837,7 +895,7 @@ textarea {
 
 .member-entry {
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto minmax(0, 1fr) minmax(150px, auto) auto;
   gap: 0.75rem;
   align-items: center;
   padding: 0.75rem 0;
@@ -873,9 +931,25 @@ textarea {
   color: var(--mv-text-dim);
 }
 
+.member-role {
+  min-width: 150px;
+  gap: 0.25rem;
+}
+
+.member-role span {
+  font-size: 0.75rem;
+  color: var(--mv-text-dim);
+}
+
+.member-role select {
+  min-height: 2.25rem;
+  padding: 0.4rem 0.75rem;
+}
+
 .member-email {
   color: var(--mv-gold);
   font-size: 0.9rem;
+  overflow-wrap: anywhere;
 }
 
 @media (max-width: 900px) {
@@ -951,8 +1025,13 @@ textarea {
     grid-template-columns: auto 1fr;
   }
 
+  .member-role,
   .member-email {
     grid-column: 1 / -1;
+  }
+
+  .member-role {
+    width: 100%;
   }
 }
 

--- a/frontend/src/views/OwnerAdminView.vue
+++ b/frontend/src/views/OwnerAdminView.vue
@@ -2,7 +2,7 @@
 import { computed, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { RouterLink, useRoute } from 'vue-router'
-import { fetchClubs, createClub } from '../services/clubService'
+import { fetchClubCount, fetchClubs, createClub } from '../services/clubService'
 import type { Club } from '../types/club'
 import { useAuthStore } from '../stores/auth'
 import { clubImage } from '../utils/clubImages'
@@ -20,6 +20,7 @@ const searchQuery = ref('')
 const categoryFilter = ref('all')
 const hasLoadedOnce = ref(false)
 const lastFetchedAt = ref<Date | null>(null)
+const totalClubCount = ref(0)
 
 const isOwner = computed(() => Boolean(currentUser.value?.isOwner))
 const sessionReady = computed(() => hasCheckedSession.value || !userLoading.value)
@@ -83,7 +84,12 @@ const loadClubs = async () => {
   loading.value = true
   error.value = ''
   try {
-    clubs.value = await fetchClubs({ force: hasLoadedOnce.value})
+    const [clubList, clubCount] = await Promise.all([
+      fetchClubs({ force: true, size: 100 }),
+      fetchClubCount(),
+    ])
+    clubs.value = clubList
+    totalClubCount.value = clubCount
     hasLoadedOnce.value = true
     lastFetchedAt.value = new Date()
   } catch (err) {
@@ -101,6 +107,7 @@ watch(
     }
     if (!owner) {
       clubs.value = []
+      totalClubCount.value = 0
       hasLoadedOnce.value = false
     }
   },
@@ -169,7 +176,7 @@ const resetFilters = () => {
         <div class="hero-stats">
           <div class="stat-card">
             <span>Total clubs</span>
-            <strong>{{ clubs.length }}</strong>
+            <strong>{{ totalClubCount }}</strong>
           </div>
           <div class="stat-card">
             <span>Total members</span>

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -136,6 +136,13 @@ const handleGraduationYearSave = async () => {
 
     <div v-if="isAuthenticated" class="profile page-shell">
       <section class="profile-hero">
+        <div class="hero-avatar-pane">
+          <img
+            class="profile-avatar"
+            :src="currentUser?.avatarUrl"
+            :alt="`${currentUser?.displayName || 'Member'} avatar`"
+          />
+        </div>
         <div class="hero-copy">
           <p class="section-label">Personal hub</p>
           <h1>Welcome back, {{ currentUser?.displayName || 'Explorer' }}</h1>
@@ -272,16 +279,32 @@ const handleGraduationYearSave = async () => {
 }
 
 .profile-hero {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) minmax(0, 1fr);
   gap: clamp(1.5rem, 3vw, 2.5rem);
   padding: clamp(1.5rem, 4vw, 3rem);
   border-radius: 36px;
   border: 1px solid var(--mv-border);
   background: var(--mv-surface-hero-strong);
-  flex-wrap: wrap;
-  justify-content: space-between;
   align-items: center;
   box-shadow: var(--mv-shadow-card);
+}
+
+.hero-avatar-pane {
+  min-height: clamp(220px, 28vw, 320px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.profile-avatar {
+  width: clamp(140px, 20vw, 220px);
+  height: clamp(140px, 20vw, 220px);
+  border-radius: 32px;
+  border: 1px solid var(--mv-border);
+  background: var(--mv-surface-soft);
+  object-fit: cover;
+  box-shadow: var(--mv-shadow-elevated);
 }
 
 .hero-copy { max-width: 560px; display: flex; flex-direction: column; gap: 1rem; }
@@ -451,9 +474,13 @@ const handleGraduationYearSave = async () => {
 
 @media (max-width: 720px) {
   .profile-hero {
-    flex-direction: column;
+    grid-template-columns: 1fr;
     padding: 1.5rem;
     border-radius: 24px;
+  }
+
+  .hero-avatar-pane {
+    min-height: 180px;
   }
 
   .hero-copy {


### PR DESCRIPTION
## Summary
- Fix the homepage `Active clubs` stat by reading the live backend club count instead of the first 50 loaded clubs.
- Add a backend Instagram avatar cache endpoint and local SVG avatar fallbacks so club/member avatars do not depend on slow or blocked external fallback image services.
- Fix member roster serialization by adding the missing `joinedAt` field expected by the MyBatis member result map.
- Keep profile avatar placement, member/president management, single-president assignment, and terms gate fixes from the original PR.

## Validation
- `npm run build`
- `./mvnw test`

## Notes
- This directly addresses the screenshots: homepage count was still using `clubs.length`, member management 500 was likely the missing roster DTO property, and broken avatar images now have local/cached fallbacks.