### PR TITLE
Fix homepage count, roster 500, and avatar loading

### DIFF
--- a/backend/src/main/java/com/example/demo/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/demo/auth/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/api/clubs").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/clubs/calendar").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/clubs/*").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/avatars/instagram/*").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/summary").permitAll()
                 // Everything else under /api requires authentication
                 .requestMatchers("/api/**").authenticated()
@@ -122,6 +123,7 @@ public class SecurityConfig {
  *   GET  /api/clubs                 — club listing
  *   GET  /api/clubs/calendar        — weekly schedule
  *   GET  /api/clubs/{id}            — club detail (permissions applied optionally)
+ *   GET  /api/avatars/instagram/{handle} — cached public club avatar image
  *   GET  /api/summary               — aggregated stats for aggregator
  *
  * All other /api/** endpoints require authentication.

--- a/backend/src/main/java/com/example/demo/club/controller/AvatarCacheController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/AvatarCacheController.java
@@ -133,7 +133,7 @@ public class AvatarCacheController {
             <svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160">
               <rect width="160" height="160" rx="32" fill="#0f766e"/>
               <circle cx="122" cy="32" r="48" fill="#67e8f9" opacity="0.18"/>
-              <text x="50%" y="54%" text-anchor="middle" dominant-baseline="middle" font-family="Arial, sans-serif" font-size="54" font-weight="700" fill="#67e8f9">%s</text>
+              <text x="50%%" y="54%%" text-anchor="middle" dominant-baseline="middle" font-family="Arial, sans-serif" font-size="54" font-weight="700" fill="#67e8f9">%s</text>
             </svg>
             """.formatted(label);
         return svg.getBytes(StandardCharsets.UTF_8);

--- a/backend/src/main/java/com/example/demo/club/controller/AvatarCacheController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/AvatarCacheController.java
@@ -1,0 +1,169 @@
+package com.example.demo.club.controller;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.CacheControl;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@RestController
+@RequestMapping("/api/avatars")
+public class AvatarCacheController {
+
+    private static final long MAX_AVATAR_BYTES = 1024 * 1024;
+    private static final String HANDLE_PATTERN = "^[A-Za-z0-9._]{1,64}$";
+
+    private final Path instagramCacheDir;
+    private final HttpClient httpClient;
+
+    public AvatarCacheController(@Value("${app.upload.dir:uploads}") String uploadDirPath) {
+        Path uploadDir = Paths.get(uploadDirPath).toAbsolutePath().normalize();
+        this.instagramCacheDir = uploadDir.resolve("avatar-cache").resolve("instagram").normalize();
+        this.httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(2))
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
+        try {
+            Files.createDirectories(this.instagramCacheDir);
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot create avatar cache directory: " + this.instagramCacheDir, e);
+        }
+    }
+
+    @GetMapping("/instagram/{handle}")
+    public ResponseEntity<byte[]> instagramAvatar(@PathVariable String handle) {
+        String safeHandle = normalizeHandle(handle);
+        Optional<CachedAvatar> cached = readCachedAvatar(safeHandle);
+        if (cached.isPresent()) {
+            return avatarResponse(cached.get().bytes(), cached.get().mediaType(), 30, TimeUnit.DAYS);
+        }
+
+        try {
+            CachedAvatar fetched = fetchInstagramAvatar(safeHandle);
+            cacheAvatar(safeHandle, fetched);
+            return avatarResponse(fetched.bytes(), fetched.mediaType(), 30, TimeUnit.DAYS);
+        } catch (Exception ignored) {
+            return avatarResponse(fallbackSvg(safeHandle), MediaType.valueOf("image/svg+xml"), 10, TimeUnit.MINUTES);
+        }
+    }
+
+    private String normalizeHandle(String handle) {
+        String normalized = handle == null ? "" : handle.trim().replaceFirst("^@", "");
+        if (!normalized.matches(HANDLE_PATTERN)) {
+            return "hsclubs";
+        }
+        return normalized.toLowerCase(Locale.ROOT);
+    }
+
+    private Optional<CachedAvatar> readCachedAvatar(String safeHandle) {
+        for (String extension : new String[] { "png", "jpg", "jpeg", "webp", "gif", "svg" }) {
+            Path file = instagramCacheDir.resolve(safeHandle + "." + extension).normalize();
+            if (!file.startsWith(instagramCacheDir) || !Files.isRegularFile(file)) {
+                continue;
+            }
+            try {
+                return Optional.of(new CachedAvatar(Files.readAllBytes(file), mediaTypeForExtension(extension)));
+            } catch (IOException ignored) {
+                return Optional.empty();
+            }
+        }
+        return Optional.empty();
+    }
+
+    private CachedAvatar fetchInstagramAvatar(String safeHandle) throws IOException, InterruptedException {
+        String encodedHandle = URLEncoder.encode(safeHandle, StandardCharsets.UTF_8);
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create("https://unavatar.io/instagram/" + encodedHandle))
+            .timeout(Duration.ofSeconds(3))
+            .GET()
+            .build();
+        HttpResponse<byte[]> response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new IOException("Avatar provider returned " + response.statusCode());
+        }
+        byte[] bytes = response.body();
+        if (bytes.length == 0 || bytes.length > MAX_AVATAR_BYTES) {
+            throw new IOException("Avatar response size is invalid");
+        }
+        MediaType mediaType = response.headers()
+            .firstValue("content-type")
+            .map((value) -> value.split(";")[0].trim().toLowerCase(Locale.ROOT))
+            .map(MediaType::valueOf)
+            .filter((value) -> value.getType().equals("image"))
+            .orElse(MediaType.IMAGE_PNG);
+        return new CachedAvatar(bytes, mediaType);
+    }
+
+    private void cacheAvatar(String safeHandle, CachedAvatar avatar) throws IOException {
+        String extension = extensionForMediaType(avatar.mediaType());
+        Path file = instagramCacheDir.resolve(safeHandle + "." + extension).normalize();
+        if (file.startsWith(instagramCacheDir)) {
+            Files.write(file, avatar.bytes());
+        }
+    }
+
+    private ResponseEntity<byte[]> avatarResponse(byte[] bytes, MediaType mediaType, long maxAge, TimeUnit unit) {
+        return ResponseEntity.ok()
+            .cacheControl(CacheControl.maxAge(maxAge, unit).cachePublic())
+            .contentType(mediaType)
+            .body(bytes);
+    }
+
+    private byte[] fallbackSvg(String safeHandle) {
+        String label = safeHandle.substring(0, Math.min(2, safeHandle.length())).toUpperCase(Locale.ROOT);
+        String svg = """
+            <svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160">
+              <rect width="160" height="160" rx="32" fill="#0f766e"/>
+              <circle cx="122" cy="32" r="48" fill="#67e8f9" opacity="0.18"/>
+              <text x="50%" y="54%" text-anchor="middle" dominant-baseline="middle" font-family="Arial, sans-serif" font-size="54" font-weight="700" fill="#67e8f9">%s</text>
+            </svg>
+            """.formatted(label);
+        return svg.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private MediaType mediaTypeForExtension(String extension) {
+        return switch (extension) {
+            case "jpg", "jpeg" -> MediaType.IMAGE_JPEG;
+            case "gif" -> MediaType.IMAGE_GIF;
+            case "svg" -> MediaType.valueOf("image/svg+xml");
+            case "webp" -> MediaType.valueOf("image/webp");
+            default -> MediaType.IMAGE_PNG;
+        };
+    }
+
+    private String extensionForMediaType(MediaType mediaType) {
+        if (MediaType.IMAGE_JPEG.includes(mediaType)) {
+            return "jpg";
+        }
+        if (MediaType.IMAGE_GIF.includes(mediaType)) {
+            return "gif";
+        }
+        if (MediaType.valueOf("image/svg+xml").includes(mediaType)) {
+            return "svg";
+        }
+        if (MediaType.valueOf("image/webp").includes(mediaType)) {
+            return "webp";
+        }
+        return "png";
+    }
+
+    private record CachedAvatar(byte[] bytes, MediaType mediaType) {}
+}

--- a/backend/src/main/java/com/example/demo/club/model/ClubMemberView.java
+++ b/backend/src/main/java/com/example/demo/club/model/ClubMemberView.java
@@ -1,5 +1,7 @@
 package com.example.demo.club.model;
 
+import java.time.LocalDateTime;
+
 /**
  * Projection used for exposing club members to management tooling.
  */
@@ -10,6 +12,7 @@ public class ClubMemberView {
     private String email;
     private String avatarUrl;
     private String roleName;
+    private LocalDateTime joinedAt;
 
     public Long getOauthUserId() {
         return oauthUserId;
@@ -49,5 +52,13 @@ public class ClubMemberView {
 
     public void setRoleName(String roleName) {
         this.roleName = roleName;
+    }
+
+    public LocalDateTime getJoinedAt() {
+        return joinedAt;
+    }
+
+    public void setJoinedAt(LocalDateTime joinedAt) {
+        this.joinedAt = joinedAt;
     }
 }

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -8,6 +8,7 @@ import {
   logout as apiLogout,
 } from '../services/authService'
 import { buildApiUrl } from '../services/httpClient'
+import { localAvatar, userAvatar } from '../utils/avatarImages'
 
 export const useAuthStore = defineStore('auth', () => {
   const currentUser = ref<AuthUser | null>(null)
@@ -38,15 +39,16 @@ export const useAuthStore = defineStore('auth', () => {
 
   const buildFallbackAvatar = (user: AuthUser) => {
     const seed = user.displayName?.trim() || user.email || user.id || 'Member'
-    return `https://api.dicebear.com/7.x/thumbs/svg?seed=${encodeURIComponent(seed)}`
+    return localAvatar(seed)
   }
 
   const normalizeUser = (user: AuthUser | null): AuthUser | null => {
     if (!user) return null
     const trimmed = user.avatarUrl?.trim()
+    const seed = user.displayName?.trim() || user.email || user.id || 'Member'
     return {
       ...user,
-      avatarUrl: trimmed ? buildApiUrl(trimmed) : buildFallbackAvatar(user),
+      avatarUrl: trimmed ? userAvatar(trimmed, seed) : buildFallbackAvatar(user),
       // Support both isOwner (backward compat) and isPlatformOwner
       isOwner: user.isOwner ?? user.isPlatformOwner ?? false,
     }

--- a/frontend/src/types/club.ts
+++ b/frontend/src/types/club.ts
@@ -28,6 +28,7 @@ export interface ClubMember {
   email: string
   avatarUrl: string | null
   roleName: string | null
+  joinedAt?: string | null
 }
 
 export interface ClubMembershipRequest {

--- a/frontend/src/utils/avatarImages.ts
+++ b/frontend/src/utils/avatarImages.ts
@@ -1,0 +1,60 @@
+import { buildApiUrl } from '../services/httpClient'
+
+const palette = [
+  ['#0f766e', '#67e8f9'],
+  ['#1d4ed8', '#93c5fd'],
+  ['#7c3aed', '#c4b5fd'],
+  ['#be123c', '#fda4af'],
+  ['#a16207', '#fde68a'],
+  ['#166534', '#86efac'],
+]
+
+const hashSeed = (seed: string) => {
+  let hash = 0
+  for (let index = 0; index < seed.length; index += 1) {
+    hash = (hash * 31 + seed.charCodeAt(index)) >>> 0
+  }
+  return hash
+}
+
+const escapeXml = (value: string) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+
+const initialsFor = (seed: string) => {
+  const words = seed
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+  const initials = words.length > 1
+    ? `${words[0]?.[0] ?? ''}${words[1]?.[0] ?? ''}`
+    : seed.trim().slice(0, 2)
+  return escapeXml((initials || 'HC').toUpperCase())
+}
+
+export const localAvatar = (seed: string) => {
+  const normalizedSeed = seed.trim() || 'HS Clubs'
+  const [background, foreground] =
+    palette[hashSeed(normalizedSeed) % palette.length] ?? ['#0f766e', '#67e8f9']
+  const initials = initialsFor(normalizedSeed)
+  const svg = `
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160">
+  <rect width="160" height="160" rx="32" fill="${background}"/>
+  <circle cx="124" cy="30" r="48" fill="${foreground}" opacity="0.18"/>
+  <circle cx="28" cy="136" r="54" fill="#ffffff" opacity="0.08"/>
+  <text x="50%" y="54%" text-anchor="middle" dominant-baseline="middle" font-family="Inter, Arial, sans-serif" font-size="54" font-weight="700" fill="${foreground}">${initials}</text>
+</svg>`
+
+  return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`
+}
+
+export const userAvatar = (avatarUrl: string | null | undefined, seed: string) => {
+  const trimmed = avatarUrl?.trim()
+  if (!trimmed || trimmed.includes('api.dicebear.com')) {
+    return localAvatar(seed)
+  }
+  return buildApiUrl(trimmed)
+}

--- a/frontend/src/utils/clubImages.ts
+++ b/frontend/src/utils/clubImages.ts
@@ -1,25 +1,58 @@
 import type { Club } from '../types/club'
+import { buildApiUrl } from '../services/httpClient'
+import { localAvatar } from './avatarImages'
 
-const fallbackAvatar = (name: string) =>
-  `https://api.dicebear.com/7.x/thumbs/svg?seed=${encodeURIComponent(name)}`
-
-const instagramAvatar = (url?: string | null) => {
+const instagramHandle = (url?: string | null) => {
   if (!url) {
     return null
   }
 
-  const normalized = url.trim().replace(/\/+$/, '')
-  if (!normalized) {
+  const trimmed = url.trim()
+  if (!trimmed) {
     return null
   }
 
-  const withoutQuery = normalized.split('?')[0] ?? ''
-  const parts = withoutQuery.split('/')
-  const lastPart = parts[parts.length - 1] ?? ''
-  const handle = lastPart.startsWith('@') ? lastPart.slice(1) : lastPart
+  const cleanHandle = (value: string) => {
+    const handle = value.trim().replace(/^@/, '')
+    return /^[A-Za-z0-9._]{1,64}$/.test(handle) ? handle : null
+  }
 
-  return handle ? `https://unavatar.io/instagram/${encodeURIComponent(handle)}` : null
+  const directHandle = cleanHandle(trimmed)
+  if (directHandle) {
+    return directHandle
+  }
+
+  const normalizedUrl = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`
+  try {
+    const parsed = new URL(normalizedUrl)
+    const host = parsed.hostname.toLowerCase().replace(/^www\./, '')
+    if (!host.endsWith('instagram.com')) {
+      return null
+    }
+    const firstSegment = parsed.pathname
+      .split('/')
+      .map((part) => part.trim())
+      .filter(Boolean)[0]
+    if (!firstSegment || ['p', 'reel', 'reels', 'stories', 'explore'].includes(firstSegment)) {
+      return null
+    }
+    return cleanHandle(firstSegment)
+  } catch {
+    const withoutQuery = trimmed.split('?')[0]?.replace(/\/+$/, '') ?? ''
+    const parts = withoutQuery.split('/').filter(Boolean)
+    const lastPart = parts[parts.length - 1] ?? ''
+    return cleanHandle(lastPart)
+  }
 }
 
-export const clubImage = (club: Club): string =>
-  club.imageUrl ?? instagramAvatar(club.instagramUrl) ?? fallbackAvatar(club.name)
+const cachedInstagramAvatar = (url?: string | null) => {
+  const handle = instagramHandle(url)
+  return handle ? buildApiUrl(`/api/avatars/instagram/${encodeURIComponent(handle)}`) : null
+}
+
+export const clubImage = (club: Club): string => {
+  if (club.imageUrl) {
+    return buildApiUrl(club.imageUrl)
+  }
+  return cachedInstagramAvatar(club.instagramUrl) ?? localAvatar(club.name)
+}

--- a/frontend/src/views/ClubAdminView.vue
+++ b/frontend/src/views/ClubAdminView.vue
@@ -10,6 +10,7 @@ import { useAuthStore } from '../stores/auth'
 import { clubCategoryOptions } from '../utils/clubCategories'
 import { buildApiUrl } from '../services/httpClient'
 import { clubImage } from '../utils/clubImages'
+import { userAvatar } from '../utils/avatarImages'
 
 const route = useRoute()
 const club = ref<Club | null>(null)
@@ -500,7 +501,7 @@ watch(
               <li v-for="member in members" :key="member.oauthUserId" class="member-entry">
                 <div class="member-avatar">
                   <img
-                    :src="member.avatarUrl || 'https://api.dicebear.com/7.x/thumbs/svg?seed=' + encodeURIComponent(member.displayName || 'Member')"
+                    :src="userAvatar(member.avatarUrl, member.displayName || 'Member')"
                     :alt="member.displayName || 'Club member'"
                   />
                 </div>

--- a/frontend/src/views/ClubPendingView.vue
+++ b/frontend/src/views/ClubPendingView.vue
@@ -10,6 +10,7 @@ import {
 import type { Club, ClubMembershipRequest } from '../types/club'
 import { useAuthStore } from '../stores/auth'
 import { clubImage } from '../utils/clubImages'
+import { userAvatar } from '../utils/avatarImages'
 
 const route = useRoute()
 const club = ref<Club | null>(null)
@@ -209,7 +210,7 @@ watch(
             <li v-for="request in pendingRequests" :key="request.id" class="member-entry pending-entry">
               <div class="member-avatar">
                 <img
-                  :src="request.avatarUrl || 'https://api.dicebear.com/7.x/thumbs/svg?seed=' + encodeURIComponent(request.displayName || 'Member')"
+                  :src="userAvatar(request.avatarUrl, request.displayName || 'Member')"
                   :alt="request.displayName || 'Pending member'"
                 />
               </div>

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -2,7 +2,7 @@
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
 import SkeletonLoader from '../components/SkeletonLoader.vue'
-import { fetchClubs } from '../services/clubService'
+import { fetchClubCount, fetchClubs } from '../services/clubService'
 import type { Club } from '../types/club'
 import { clubImage } from '../utils/clubImages'
 import { sampleClubs, schoolTemplate } from '../config/schoolTemplate'
@@ -16,6 +16,7 @@ const schoolDisplayName = computed(() => schoolTemplate.schoolName)
 const schoolShortName = computed(() => schoolTemplate.shortName)
 const usingPreviewData = ref(false)
 const currentHeroImageIndex = ref(0)
+const totalClubCount = ref(0)
 let heroInterval: number | undefined
 
 const page = ref(0)
@@ -27,12 +28,17 @@ const loadClubs = async () => {
   loading.value = true
   error.value = ''
   try {
-    const newClubs = await fetchClubs({ page: 0, size: pageSize })
+    const [newClubs, clubCount] = await Promise.all([
+      fetchClubs({ force: true, page: 0, size: pageSize }),
+      fetchClubCount(),
+    ])
     clubs.value = newClubs
+    totalClubCount.value = clubCount
     hasMore.value = newClubs.length >= pageSize
     usingPreviewData.value = false
   } catch {
     clubs.value = sampleClubs
+    totalClubCount.value = sampleClubs.length
     hasMore.value = false
     usingPreviewData.value = true
   } finally {
@@ -73,7 +79,7 @@ const topClubs = computed(() =>
 const heroImages = computed(() => {
   const clubImages = topClubs.value
     .map((c) => clubImage(c))
-    .filter((url) => url && !url.includes('dicebear'))
+    .filter((url) => url && !url.startsWith('data:'))
   return clubImages.length >= 2
     ? clubImages.slice(0, 4)
     : ['/hsclubs1.jpg', '/hsclubs2.png', '/hsclubs3.png']
@@ -109,7 +115,7 @@ const showHeroImage = (index: number) => {
         <div class="hero-stats-inline">
           <div class="stat-card">
             <span class="stat-label">Active clubs</span>
-            <p class="stat-value">{{ clubs.length }}</p>
+            <p class="stat-value">{{ totalClubCount }}</p>
           </div>
           <div class="stat-card">
             <span class="stat-label">Template status</span>


### PR DESCRIPTION
## Summary
- Fix the homepage `Active clubs` stat by reading the backend club count instead of showing the first page length (`50`).
- Fix member management 500s by adding the `joinedAt` property expected by the member result map.
- Add local SVG avatar fallbacks and a backend-cached Instagram avatar endpoint so broken/slow external avatar services no longer block rendering.
- Route every club with an Instagram profile URL through the backend cache, with robust handle parsing for `@handle`, bare handles, and Instagram URLs with trailing slashes or query strings.

## Validation
- `npm run build`
- `./mvnw test`

## Notes
- The first request for `/api/avatars/instagram/{handle}` downloads and stores the profile image under the backend upload cache; later displays are served locally from that cache.