### PR TITLE
cache instagram avatars with instaloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Backend:
 ```bash
 cd backend
 cp .env.example .env   # fill in DB_PASSWORD and Google OAuth credentials
+pip install -r requirements-instaloader.txt  # optional: enables Instagram avatar caching
 ./mvnw spring-boot:run
 ```
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -36,5 +36,20 @@ FRONTEND_ORIGIN=http://localhost:4173
 # Override the local upload directory (default: backend/uploads).
 # APP_UPLOAD_DIR=uploads
 
+# Instagram club avatars are cached through Instaloader.
+# Install Python dependency with:
+#   pip install -r backend/requirements-instaloader.txt
+# APP_INSTAGRAM_AVATAR_CACHE_ENABLED=true
+# APP_INSTAGRAM_AVATAR_PYTHON_COMMAND=python3
+#
+# Optional: use an Instaloader session if anonymous profile access is rate-limited.
+# Create it separately with `instaloader --login your_username`.
+# APP_INSTAGRAM_AVATAR_SESSION_USER=your_username
+# APP_INSTAGRAM_AVATAR_SESSION_FILE=/absolute/path/to/session-your_username
+#
+# APP_INSTAGRAM_AVATAR_FETCH_TIMEOUT_MS=10000
+# APP_INSTAGRAM_AVATAR_CACHE_TTL_MS=2592000000
+# APP_INSTAGRAM_AVATAR_REFRESH_FIXED_DELAY_MS=43200000
+
 # Override the OAuth authorization base path (default: /api/auth/authorize).
 # APP_AUTHORIZATION_REQUEST_BASE_URI=/api/auth/authorize

--- a/backend/requirements-instaloader.txt
+++ b/backend/requirements-instaloader.txt
@@ -1,0 +1,1 @@
+instaloader>=4.15,<5

--- a/backend/src/main/java/com/example/demo/club/controller/AvatarCacheController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/AvatarCacheController.java
@@ -1,169 +1,29 @@
 package com.example.demo.club.controller;
 
-import org.springframework.beans.factory.annotation.Value;
+import com.example.demo.club.service.InstagramAvatarCacheService;
 import org.springframework.http.CacheControl;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.URLEncoder;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.Duration;
-import java.util.Locale;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-
 @RestController
 @RequestMapping("/api/avatars")
 public class AvatarCacheController {
 
-    private static final long MAX_AVATAR_BYTES = 1024 * 1024;
-    private static final String HANDLE_PATTERN = "^[A-Za-z0-9._]{1,64}$";
+    private final InstagramAvatarCacheService instagramAvatarCacheService;
 
-    private final Path instagramCacheDir;
-    private final HttpClient httpClient;
-
-    public AvatarCacheController(@Value("${app.upload.dir:uploads}") String uploadDirPath) {
-        Path uploadDir = Paths.get(uploadDirPath).toAbsolutePath().normalize();
-        this.instagramCacheDir = uploadDir.resolve("avatar-cache").resolve("instagram").normalize();
-        this.httpClient = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(2))
-            .followRedirects(HttpClient.Redirect.NORMAL)
-            .build();
-        try {
-            Files.createDirectories(this.instagramCacheDir);
-        } catch (IOException e) {
-            throw new RuntimeException("Cannot create avatar cache directory: " + this.instagramCacheDir, e);
-        }
+    public AvatarCacheController(InstagramAvatarCacheService instagramAvatarCacheService) {
+        this.instagramAvatarCacheService = instagramAvatarCacheService;
     }
 
     @GetMapping("/instagram/{handle}")
     public ResponseEntity<byte[]> instagramAvatar(@PathVariable String handle) {
-        String safeHandle = normalizeHandle(handle);
-        Optional<CachedAvatar> cached = readCachedAvatar(safeHandle);
-        if (cached.isPresent()) {
-            return avatarResponse(cached.get().bytes(), cached.get().mediaType(), 30, TimeUnit.DAYS);
-        }
-
-        try {
-            CachedAvatar fetched = fetchInstagramAvatar(safeHandle);
-            cacheAvatar(safeHandle, fetched);
-            return avatarResponse(fetched.bytes(), fetched.mediaType(), 30, TimeUnit.DAYS);
-        } catch (Exception ignored) {
-            return avatarResponse(fallbackSvg(safeHandle), MediaType.valueOf("image/svg+xml"), 10, TimeUnit.MINUTES);
-        }
-    }
-
-    private String normalizeHandle(String handle) {
-        String normalized = handle == null ? "" : handle.trim().replaceFirst("^@", "");
-        if (!normalized.matches(HANDLE_PATTERN)) {
-            return "hsclubs";
-        }
-        return normalized.toLowerCase(Locale.ROOT);
-    }
-
-    private Optional<CachedAvatar> readCachedAvatar(String safeHandle) {
-        for (String extension : new String[] { "png", "jpg", "jpeg", "webp", "gif", "svg" }) {
-            Path file = instagramCacheDir.resolve(safeHandle + "." + extension).normalize();
-            if (!file.startsWith(instagramCacheDir) || !Files.isRegularFile(file)) {
-                continue;
-            }
-            try {
-                return Optional.of(new CachedAvatar(Files.readAllBytes(file), mediaTypeForExtension(extension)));
-            } catch (IOException ignored) {
-                return Optional.empty();
-            }
-        }
-        return Optional.empty();
-    }
-
-    private CachedAvatar fetchInstagramAvatar(String safeHandle) throws IOException, InterruptedException {
-        String encodedHandle = URLEncoder.encode(safeHandle, StandardCharsets.UTF_8);
-        HttpRequest request = HttpRequest.newBuilder()
-            .uri(URI.create("https://unavatar.io/instagram/" + encodedHandle))
-            .timeout(Duration.ofSeconds(3))
-            .GET()
-            .build();
-        HttpResponse<byte[]> response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
-        if (response.statusCode() < 200 || response.statusCode() >= 300) {
-            throw new IOException("Avatar provider returned " + response.statusCode());
-        }
-        byte[] bytes = response.body();
-        if (bytes.length == 0 || bytes.length > MAX_AVATAR_BYTES) {
-            throw new IOException("Avatar response size is invalid");
-        }
-        MediaType mediaType = response.headers()
-            .firstValue("content-type")
-            .map((value) -> value.split(";")[0].trim().toLowerCase(Locale.ROOT))
-            .map(MediaType::valueOf)
-            .filter((value) -> value.getType().equals("image"))
-            .orElse(MediaType.IMAGE_PNG);
-        return new CachedAvatar(bytes, mediaType);
-    }
-
-    private void cacheAvatar(String safeHandle, CachedAvatar avatar) throws IOException {
-        String extension = extensionForMediaType(avatar.mediaType());
-        Path file = instagramCacheDir.resolve(safeHandle + "." + extension).normalize();
-        if (file.startsWith(instagramCacheDir)) {
-            Files.write(file, avatar.bytes());
-        }
-    }
-
-    private ResponseEntity<byte[]> avatarResponse(byte[] bytes, MediaType mediaType, long maxAge, TimeUnit unit) {
+        InstagramAvatarCacheService.ResolvedAvatar avatar = instagramAvatarCacheService.resolveAvatar(handle);
         return ResponseEntity.ok()
-            .cacheControl(CacheControl.maxAge(maxAge, unit).cachePublic())
-            .contentType(mediaType)
-            .body(bytes);
+            .cacheControl(CacheControl.maxAge(avatar.maxAge(), avatar.maxAgeUnit()).cachePublic())
+            .contentType(avatar.mediaType())
+            .body(avatar.bytes());
     }
-
-    private byte[] fallbackSvg(String safeHandle) {
-        String label = safeHandle.substring(0, Math.min(2, safeHandle.length())).toUpperCase(Locale.ROOT);
-        String svg = """
-            <svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160">
-              <rect width="160" height="160" rx="32" fill="#0f766e"/>
-              <circle cx="122" cy="32" r="48" fill="#67e8f9" opacity="0.18"/>
-              <text x="50%%" y="54%%" text-anchor="middle" dominant-baseline="middle" font-family="Arial, sans-serif" font-size="54" font-weight="700" fill="#67e8f9">%s</text>
-            </svg>
-            """.formatted(label);
-        return svg.getBytes(StandardCharsets.UTF_8);
-    }
-
-    private MediaType mediaTypeForExtension(String extension) {
-        return switch (extension) {
-            case "jpg", "jpeg" -> MediaType.IMAGE_JPEG;
-            case "gif" -> MediaType.IMAGE_GIF;
-            case "svg" -> MediaType.valueOf("image/svg+xml");
-            case "webp" -> MediaType.valueOf("image/webp");
-            default -> MediaType.IMAGE_PNG;
-        };
-    }
-
-    private String extensionForMediaType(MediaType mediaType) {
-        if (MediaType.IMAGE_JPEG.includes(mediaType)) {
-            return "jpg";
-        }
-        if (MediaType.IMAGE_GIF.includes(mediaType)) {
-            return "gif";
-        }
-        if (MediaType.valueOf("image/svg+xml").includes(mediaType)) {
-            return "svg";
-        }
-        if (MediaType.valueOf("image/webp").includes(mediaType)) {
-            return "webp";
-        }
-        return "png";
-    }
-
-    private record CachedAvatar(byte[] bytes, MediaType mediaType) {}
 }

--- a/backend/src/main/java/com/example/demo/club/service/InstagramAvatarCacheService.java
+++ b/backend/src/main/java/com/example/demo/club/service/InstagramAvatarCacheService.java
@@ -1,0 +1,375 @@
+package com.example.demo.club.service;
+
+import com.example.demo.club.mapper.ClubMapper;
+import com.example.demo.club.model.Club;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+@Service
+public class InstagramAvatarCacheService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InstagramAvatarCacheService.class);
+    private static final long MAX_AVATAR_BYTES = 1024 * 1024;
+    private static final Pattern HANDLE_PATTERN = Pattern.compile("^[A-Za-z0-9._]{1,64}$");
+    private static final List<String> IMAGE_EXTENSIONS = List.of("png", "jpg", "jpeg", "webp", "gif");
+    private static final MediaType SVG_MEDIA_TYPE = MediaType.valueOf("image/svg+xml");
+    private static final MediaType WEBP_MEDIA_TYPE = MediaType.valueOf("image/webp");
+    private static final String INSTALOADER_SCRIPT = """
+        import sys
+        import instaloader
+
+        handle = sys.argv[1]
+        session_user = sys.argv[2].strip() if len(sys.argv) > 2 else ""
+        session_file = sys.argv[3].strip() if len(sys.argv) > 3 else ""
+
+        loader = instaloader.Instaloader(
+            download_pictures=False,
+            download_videos=False,
+            download_video_thumbnails=False,
+            download_geotags=False,
+            download_comments=False,
+            save_metadata=False,
+            compress_json=False,
+            quiet=True,
+            max_connection_attempts=1,
+            request_timeout=8.0,
+        )
+        if session_user:
+            loader.load_session_from_file(session_user, session_file or None)
+        profile = instaloader.Profile.from_username(loader.context, handle)
+        url = profile.profile_pic_url or profile.get_profile_pic_url()
+        print(url)
+        """;
+
+    private final ClubMapper clubMapper;
+    private final Path instagramCacheDir;
+    private final HttpClient httpClient;
+    private final String pythonCommand;
+    private final String sessionUser;
+    private final String sessionFile;
+    private final boolean enabled;
+    private final long fetchTimeoutMillis;
+    private final long cacheTtlMillis;
+    private final int maxRefreshPerRun;
+
+    public InstagramAvatarCacheService(
+        ClubMapper clubMapper,
+        @Value("${app.upload.dir:uploads}") String uploadDirPath,
+        @Value("${app.avatar.instagram.enabled:true}") boolean enabled,
+        @Value("${app.avatar.instagram.python-command:python3}") String pythonCommand,
+        @Value("${app.avatar.instagram.session-user:}") String sessionUser,
+        @Value("${app.avatar.instagram.session-file:}") String sessionFile,
+        @Value("${app.avatar.instagram.fetch-timeout-ms:10000}") long fetchTimeoutMillis,
+        @Value("${app.avatar.instagram.cache-ttl-ms:2592000000}") long cacheTtlMillis,
+        @Value("${app.avatar.instagram.max-refresh-per-run:80}") int maxRefreshPerRun
+    ) {
+        this.clubMapper = clubMapper;
+        Path uploadDir = Paths.get(uploadDirPath).toAbsolutePath().normalize();
+        this.instagramCacheDir = uploadDir.resolve("avatar-cache").resolve("instagram").normalize();
+        this.httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(4))
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
+        this.enabled = enabled;
+        this.pythonCommand = pythonCommand;
+        this.sessionUser = sessionUser == null ? "" : sessionUser.trim();
+        this.sessionFile = sessionFile == null ? "" : sessionFile.trim();
+        this.fetchTimeoutMillis = Math.max(1000, fetchTimeoutMillis);
+        this.cacheTtlMillis = Math.max(TimeUnit.HOURS.toMillis(1), cacheTtlMillis);
+        this.maxRefreshPerRun = Math.max(1, maxRefreshPerRun);
+        try {
+            Files.createDirectories(this.instagramCacheDir);
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot create Instagram avatar cache directory: " + this.instagramCacheDir, e);
+        }
+    }
+
+    public ResolvedAvatar resolveAvatar(String handle) {
+        String safeHandle = normalizeHandle(handle);
+        Optional<CachedAvatar> cached = readCachedAvatar(safeHandle);
+        if (cached.isPresent()) {
+            return ResolvedAvatar.cached(cached.get());
+        }
+        if (!enabled) {
+            return ResolvedAvatar.fallback(fallbackSvg(safeHandle));
+        }
+        try {
+            CachedAvatar fetched = refreshAvatar(safeHandle);
+            return ResolvedAvatar.cached(fetched);
+        } catch (Exception ex) {
+            LOGGER.debug("Unable to fetch Instagram avatar for {}", safeHandle, ex);
+            return ResolvedAvatar.fallback(fallbackSvg(safeHandle));
+        }
+    }
+
+    @Scheduled(
+        initialDelayString = "${app.avatar.instagram.refresh-initial-delay-ms:30000}",
+        fixedDelayString = "${app.avatar.instagram.refresh-fixed-delay-ms:43200000}"
+    )
+    public void refreshClubInstagramAvatars() {
+        if (!enabled) {
+            return;
+        }
+        Set<String> handles = instagramHandlesFromClubs(clubMapper.findAll());
+        int refreshed = 0;
+        for (String handle : handles) {
+            if (refreshed >= maxRefreshPerRun) {
+                break;
+            }
+            if (hasFreshCachedAvatar(handle)) {
+                continue;
+            }
+            try {
+                refreshAvatar(handle);
+                refreshed++;
+            } catch (Exception ex) {
+                LOGGER.debug("Unable to prewarm Instagram avatar for {}", handle, ex);
+            }
+        }
+        if (refreshed > 0) {
+            LOGGER.info("Prewarmed {} Instagram club avatar(s)", refreshed);
+        }
+    }
+
+    public String normalizeHandle(String handle) {
+        String normalized = handle == null ? "" : handle.trim().replaceFirst("^@", "");
+        if (!HANDLE_PATTERN.matcher(normalized).matches()) {
+            return "hsclubs";
+        }
+        return normalized.toLowerCase(Locale.ROOT);
+    }
+
+    private Set<String> instagramHandlesFromClubs(List<Club> clubs) {
+        Set<String> handles = new LinkedHashSet<>();
+        for (Club club : clubs) {
+            extractInstagramHandle(club.getInstagramUrl()).ifPresent(handles::add);
+        }
+        return handles;
+    }
+
+    private Optional<String> extractInstagramHandle(String value) {
+        if (value == null || value.isBlank()) {
+            return Optional.empty();
+        }
+        String trimmed = value.trim();
+        String direct = trimmed.replaceFirst("^@", "");
+        if (HANDLE_PATTERN.matcher(direct).matches()) {
+            return Optional.of(direct.toLowerCase(Locale.ROOT));
+        }
+        String normalizedUrl = trimmed.matches("(?i)^https?://.*") ? trimmed : "https://" + trimmed;
+        try {
+            URI uri = URI.create(normalizedUrl);
+            String host = uri.getHost() == null ? "" : uri.getHost().toLowerCase(Locale.ROOT).replaceFirst("^www\\.", "");
+            if (!host.endsWith("instagram.com")) {
+                return Optional.empty();
+            }
+            String path = uri.getPath() == null ? "" : uri.getPath();
+            for (String segment : path.split("/")) {
+                String candidate = segment.trim();
+                if (candidate.isEmpty()) {
+                    continue;
+                }
+                String lower = candidate.toLowerCase(Locale.ROOT);
+                if (Set.of("p", "reel", "reels", "stories", "explore").contains(lower)) {
+                    return Optional.empty();
+                }
+                return HANDLE_PATTERN.matcher(candidate).matches()
+                    ? Optional.of(candidate.toLowerCase(Locale.ROOT))
+                    : Optional.empty();
+            }
+        } catch (IllegalArgumentException ignored) {
+            return Optional.empty();
+        }
+        return Optional.empty();
+    }
+
+    private boolean hasFreshCachedAvatar(String safeHandle) {
+        for (String extension : IMAGE_EXTENSIONS) {
+            Path file = instagramCacheDir.resolve(safeHandle + "." + extension).normalize();
+            if (!file.startsWith(instagramCacheDir) || !Files.isRegularFile(file)) {
+                continue;
+            }
+            try {
+                Instant modified = Files.getLastModifiedTime(file).toInstant();
+                return modified.plusMillis(cacheTtlMillis).isAfter(Instant.now());
+            } catch (IOException ignored) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    private Optional<CachedAvatar> readCachedAvatar(String safeHandle) {
+        for (String extension : IMAGE_EXTENSIONS) {
+            Path file = instagramCacheDir.resolve(safeHandle + "." + extension).normalize();
+            if (!file.startsWith(instagramCacheDir) || !Files.isRegularFile(file)) {
+                continue;
+            }
+            try {
+                return Optional.of(new CachedAvatar(Files.readAllBytes(file), mediaTypeForExtension(extension)));
+            } catch (IOException ignored) {
+                return Optional.empty();
+            }
+        }
+        return Optional.empty();
+    }
+
+    private CachedAvatar refreshAvatar(String safeHandle) throws IOException, InterruptedException {
+        String profilePicUrl = fetchProfilePicUrl(safeHandle);
+        CachedAvatar avatar = downloadAvatar(profilePicUrl);
+        cacheAvatar(safeHandle, avatar);
+        return avatar;
+    }
+
+    private String fetchProfilePicUrl(String safeHandle) throws IOException, InterruptedException {
+        ProcessBuilder processBuilder = new ProcessBuilder(
+            pythonCommand,
+            "-c",
+            INSTALOADER_SCRIPT,
+            safeHandle,
+            sessionUser,
+            sessionFile
+        );
+        processBuilder.redirectErrorStream(true);
+        processBuilder.environment().put("PYTHONUNBUFFERED", "1");
+        Process process = processBuilder.start();
+        boolean finished = process.waitFor(fetchTimeoutMillis, TimeUnit.MILLISECONDS);
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+        if (!finished) {
+            process.destroyForcibly();
+            throw new IOException("Instaloader timed out for " + safeHandle);
+        }
+        if (process.exitValue() != 0) {
+            throw new IOException("Instaloader failed for " + safeHandle + ": " + abbreviate(output));
+        }
+        return lastHttpUrl(output)
+            .orElseThrow(() -> new IOException("Instaloader did not return an avatar URL for " + safeHandle));
+    }
+
+    private Optional<String> lastHttpUrl(String output) {
+        String[] lines = output.split("\\R");
+        for (int i = lines.length - 1; i >= 0; i--) {
+            String line = lines[i].trim();
+            if (line.startsWith("https://") || line.startsWith("http://")) {
+                return Optional.of(line);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private CachedAvatar downloadAvatar(String imageUrl) throws IOException, InterruptedException {
+        URI uri = URI.create(imageUrl);
+        if (!"https".equalsIgnoreCase(uri.getScheme()) && !"http".equalsIgnoreCase(uri.getScheme())) {
+            throw new IOException("Unsupported avatar URL scheme");
+        }
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(uri)
+            .timeout(Duration.ofMillis(fetchTimeoutMillis))
+            .header("User-Agent", "HSclubs Avatar Cache")
+            .GET()
+            .build();
+        HttpResponse<byte[]> response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new IOException("Avatar URL returned " + response.statusCode());
+        }
+        byte[] bytes = response.body();
+        if (bytes.length == 0 || bytes.length > MAX_AVATAR_BYTES) {
+            throw new IOException("Avatar response size is invalid");
+        }
+        MediaType mediaType = response.headers()
+            .firstValue("content-type")
+            .map((value) -> value.split(";")[0].trim().toLowerCase(Locale.ROOT))
+            .map(MediaType::valueOf)
+            .filter((value) -> value.getType().equals("image"))
+            .orElse(MediaType.IMAGE_JPEG);
+        return new CachedAvatar(bytes, mediaType);
+    }
+
+    private void cacheAvatar(String safeHandle, CachedAvatar avatar) throws IOException {
+        String extension = extensionForMediaType(avatar.mediaType());
+        for (String existingExtension : IMAGE_EXTENSIONS) {
+            Path oldFile = instagramCacheDir.resolve(safeHandle + "." + existingExtension).normalize();
+            if (oldFile.startsWith(instagramCacheDir)) {
+                Files.deleteIfExists(oldFile);
+            }
+        }
+        Path file = instagramCacheDir.resolve(safeHandle + "." + extension).normalize();
+        if (!file.startsWith(instagramCacheDir)) {
+            throw new IOException("Avatar cache path escaped cache directory");
+        }
+        Files.write(file, avatar.bytes());
+    }
+
+    private byte[] fallbackSvg(String safeHandle) {
+        String label = safeHandle.substring(0, Math.min(2, safeHandle.length())).toUpperCase(Locale.ROOT);
+        String svg = """
+            <svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160">
+              <rect width="160" height="160" rx="32" fill="#0f766e"/>
+              <circle cx="122" cy="32" r="48" fill="#67e8f9" opacity="0.18"/>
+              <text x="50%%" y="54%%" text-anchor="middle" dominant-baseline="middle" font-family="Arial, sans-serif" font-size="54" font-weight="700" fill="#67e8f9">%s</text>
+            </svg>
+            """.formatted(label);
+        return svg.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private String abbreviate(String value) {
+        return value.length() > 200 ? value.substring(0, 200) + "..." : value;
+    }
+
+    private MediaType mediaTypeForExtension(String extension) {
+        return switch (extension) {
+            case "jpg", "jpeg" -> MediaType.IMAGE_JPEG;
+            case "gif" -> MediaType.IMAGE_GIF;
+            case "webp" -> WEBP_MEDIA_TYPE;
+            default -> MediaType.IMAGE_PNG;
+        };
+    }
+
+    private String extensionForMediaType(MediaType mediaType) {
+        if (MediaType.IMAGE_JPEG.includes(mediaType)) {
+            return "jpg";
+        }
+        if (MediaType.IMAGE_GIF.includes(mediaType)) {
+            return "gif";
+        }
+        if (WEBP_MEDIA_TYPE.includes(mediaType)) {
+            return "webp";
+        }
+        return "png";
+    }
+
+    public record CachedAvatar(byte[] bytes, MediaType mediaType) {}
+
+    public record ResolvedAvatar(byte[] bytes, MediaType mediaType, long maxAge, TimeUnit maxAgeUnit) {
+        private static ResolvedAvatar cached(CachedAvatar avatar) {
+            return new ResolvedAvatar(avatar.bytes(), avatar.mediaType(), 30, TimeUnit.DAYS);
+        }
+
+        private static ResolvedAvatar fallback(byte[] bytes) {
+            return new ResolvedAvatar(bytes, SVG_MEDIA_TYPE, 10, TimeUnit.MINUTES);
+        }
+    }
+}

--- a/backend/src/main/java/com/example/demo/club/service/InstagramAvatarCacheService.java
+++ b/backend/src/main/java/com/example/demo/club/service/InstagramAvatarCacheService.java
@@ -257,11 +257,12 @@ public class InstagramAvatarCacheService {
         processBuilder.environment().put("PYTHONUNBUFFERED", "1");
         Process process = processBuilder.start();
         boolean finished = process.waitFor(fetchTimeoutMillis, TimeUnit.MILLISECONDS);
-        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
         if (!finished) {
             process.destroyForcibly();
+            process.waitFor(1, TimeUnit.SECONDS);
             throw new IOException("Instaloader timed out for " + safeHandle);
         }
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
         if (process.exitValue() != 0) {
             throw new IOException("Instaloader failed for " + safeHandle + ": " + abbreviate(output));
         }

--- a/backend/src/main/java/com/example/demo/club/service/InstagramAvatarCacheService.java
+++ b/backend/src/main/java/com/example/demo/club/service/InstagramAvatarCacheService.java
@@ -25,6 +25,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
@@ -74,6 +78,7 @@ public class InstagramAvatarCacheService {
     private final long fetchTimeoutMillis;
     private final long cacheTtlMillis;
     private final int maxRefreshPerRun;
+    private final ConcurrentMap<String, CompletableFuture<RefreshResult>> inFlightRefreshes;
 
     public InstagramAvatarCacheService(
         ClubMapper clubMapper,
@@ -100,6 +105,7 @@ public class InstagramAvatarCacheService {
         this.fetchTimeoutMillis = Math.max(1000, fetchTimeoutMillis);
         this.cacheTtlMillis = Math.max(TimeUnit.HOURS.toMillis(1), cacheTtlMillis);
         this.maxRefreshPerRun = Math.max(1, maxRefreshPerRun);
+        this.inFlightRefreshes = new ConcurrentHashMap<>();
         try {
             Files.createDirectories(this.instagramCacheDir);
         } catch (IOException e) {
@@ -117,8 +123,9 @@ public class InstagramAvatarCacheService {
             return ResolvedAvatar.fallback(fallbackSvg(safeHandle));
         }
         try {
-            CachedAvatar fetched = refreshAvatar(safeHandle);
-            return ResolvedAvatar.cached(fetched);
+            return refreshAvatarIfNeeded(safeHandle, false).avatar()
+                .map(ResolvedAvatar::cached)
+                .orElseGet(() -> ResolvedAvatar.fallback(fallbackSvg(safeHandle)));
         } catch (Exception ex) {
             LOGGER.debug("Unable to fetch Instagram avatar for {}", safeHandle, ex);
             return ResolvedAvatar.fallback(fallbackSvg(safeHandle));
@@ -134,17 +141,20 @@ public class InstagramAvatarCacheService {
             return;
         }
         Set<String> handles = instagramHandlesFromClubs(clubMapper.findAll());
+        int attempted = 0;
         int refreshed = 0;
         for (String handle : handles) {
-            if (refreshed >= maxRefreshPerRun) {
+            if (attempted >= maxRefreshPerRun) {
                 break;
             }
             if (hasFreshCachedAvatar(handle)) {
                 continue;
             }
+            attempted++;
             try {
-                refreshAvatar(handle);
-                refreshed++;
+                if (refreshAvatarIfNeeded(handle, true).refreshed()) {
+                    refreshed++;
+                }
             } catch (Exception ex) {
                 LOGGER.debug("Unable to prewarm Instagram avatar for {}", handle, ex);
             }
@@ -242,6 +252,57 @@ public class InstagramAvatarCacheService {
         CachedAvatar avatar = downloadAvatar(profilePicUrl);
         cacheAvatar(safeHandle, avatar);
         return avatar;
+    }
+
+    private RefreshResult refreshAvatarIfNeeded(String safeHandle, boolean requireFreshCache)
+        throws IOException, InterruptedException {
+        CompletableFuture<RefreshResult> future = new CompletableFuture<>();
+        CompletableFuture<RefreshResult> inFlight = inFlightRefreshes.putIfAbsent(safeHandle, future);
+        if (inFlight != null) {
+            return waitForInFlightRefresh(safeHandle, inFlight);
+        }
+        try {
+            Optional<CachedAvatar> cached = readCachedAvatar(safeHandle);
+            if (cached.isPresent() && (!requireFreshCache || hasFreshCachedAvatar(safeHandle))) {
+                RefreshResult result = new RefreshResult(cached, false);
+                future.complete(result);
+                return result;
+            }
+            RefreshResult result = new RefreshResult(Optional.of(refreshAvatar(safeHandle)), true);
+            future.complete(result);
+            return result;
+        } catch (IOException | InterruptedException | RuntimeException ex) {
+            future.completeExceptionally(ex);
+            throw ex;
+        } finally {
+            inFlightRefreshes.remove(safeHandle, future);
+        }
+    }
+
+    private RefreshResult waitForInFlightRefresh(String safeHandle, CompletableFuture<RefreshResult> inFlight)
+        throws IOException, InterruptedException {
+        try {
+            return inFlight.get();
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw ex;
+        } catch (ExecutionException ex) {
+            Throwable cause = ex.getCause();
+            if (cause instanceof IOException ioException) {
+                throw ioException;
+            }
+            if (cause instanceof InterruptedException interruptedException) {
+                Thread.currentThread().interrupt();
+                throw interruptedException;
+            }
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            if (cause instanceof Error error) {
+                throw error;
+            }
+            throw new IOException("Unable to join in-flight Instagram avatar refresh for " + safeHandle, cause);
+        }
     }
 
     private String fetchProfilePicUrl(String safeHandle) throws IOException, InterruptedException {
@@ -363,6 +424,8 @@ public class InstagramAvatarCacheService {
     }
 
     public record CachedAvatar(byte[] bytes, MediaType mediaType) {}
+
+    private record RefreshResult(Optional<CachedAvatar> avatar, boolean refreshed) {}
 
     public record ResolvedAvatar(byte[] bytes, MediaType mediaType, long maxAge, TimeUnit maxAgeUnit) {
         private static ResolvedAvatar cached(CachedAvatar avatar) {

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -17,6 +17,17 @@ app:
     authorization-request-base-uri: ${APP_AUTHORIZATION_REQUEST_BASE_URI:/api/auth/authorize}
   upload:
     dir: ${APP_UPLOAD_DIR:uploads}
+  avatar:
+    instagram:
+      enabled: ${APP_INSTAGRAM_AVATAR_CACHE_ENABLED:true}
+      python-command: ${APP_INSTAGRAM_AVATAR_PYTHON_COMMAND:python3}
+      session-user: ${APP_INSTAGRAM_AVATAR_SESSION_USER:}
+      session-file: ${APP_INSTAGRAM_AVATAR_SESSION_FILE:}
+      fetch-timeout-ms: ${APP_INSTAGRAM_AVATAR_FETCH_TIMEOUT_MS:10000}
+      cache-ttl-ms: ${APP_INSTAGRAM_AVATAR_CACHE_TTL_MS:2592000000}
+      max-refresh-per-run: ${APP_INSTAGRAM_AVATAR_MAX_REFRESH_PER_RUN:80}
+      refresh-initial-delay-ms: ${APP_INSTAGRAM_AVATAR_REFRESH_INITIAL_DELAY_MS:30000}
+      refresh-fixed-delay-ms: ${APP_INSTAGRAM_AVATAR_REFRESH_FIXED_DELAY_MS:43200000}
   summary:
     school-name: ${APP_SUMMARY_SCHOOL_NAME:HS Clubs}
     short-name: ${APP_SUMMARY_SHORT_NAME:HS Clubs}

--- a/backend/src/test/java/com/example/demo/club/service/InstagramAvatarCacheServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/InstagramAvatarCacheServiceTest.java
@@ -3,15 +3,25 @@ package com.example.demo.club.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
+import com.example.demo.club.mapper.ClubMapper;
+import com.example.demo.club.model.Club;
+import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.http.MediaType;
 
 import java.io.IOException;
+import java.lang.reflect.Proxy;
+import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 class InstagramAvatarCacheServiceTest {
@@ -76,6 +86,82 @@ class InstagramAvatarCacheServiceTest {
         assertThat(avatar.mediaType().toString()).isEqualTo("image/svg+xml");
     }
 
+    @Test
+    void resolveAvatarCoalescesConcurrentCacheMisses() throws Exception {
+        byte[] bytes = new byte[] { 9, 8, 7 };
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/avatar.png", exchange -> {
+            exchange.getResponseHeaders().add("Content-Type", "image/png");
+            exchange.sendResponseHeaders(200, bytes.length);
+            exchange.getResponseBody().write(bytes);
+            exchange.close();
+        });
+        server.start();
+
+        Path invocations = tempDir.resolve("coalesced-invocations.txt");
+        Files.writeString(invocations, "", StandardCharsets.UTF_8);
+        Path script = tempDir.resolve("coalesced-instaloader.sh");
+        Files.writeString(
+            script,
+            "#!/bin/sh\nprintf 'x\\n' >> \"%s\"\nsleep 1\nprintf 'http://127.0.0.1:%d/avatar.png\\n'\n"
+                .formatted(invocations, server.getAddress().getPort()),
+            StandardCharsets.UTF_8
+        );
+        assertThat(script.toFile().setExecutable(true)).isTrue();
+        InstagramAvatarCacheService service = service(true, script.toString(), 4000);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            Future<InstagramAvatarCacheService.ResolvedAvatar> first = executor.submit(() -> {
+                start.await();
+                return service.resolveAvatar("mvhsclubs");
+            });
+            Future<InstagramAvatarCacheService.ResolvedAvatar> second = executor.submit(() -> {
+                start.await();
+                return service.resolveAvatar("mvhsclubs");
+            });
+
+            start.countDown();
+
+            assertThat(first.get(5, TimeUnit.SECONDS).bytes()).isEqualTo(bytes);
+            assertThat(second.get(5, TimeUnit.SECONDS).bytes()).isEqualTo(bytes);
+        } finally {
+            executor.shutdownNow();
+            server.stop(0);
+        }
+
+        assertThat(Files.readAllLines(invocations, StandardCharsets.UTF_8)).hasSize(1);
+    }
+
+    @Test
+    void refreshClubInstagramAvatarsCapsFailedAttempts() throws IOException {
+        Path invocations = tempDir.resolve("failed-prewarm-invocations.txt");
+        Files.writeString(invocations, "", StandardCharsets.UTF_8);
+        Path script = tempDir.resolve("failing-instaloader.sh");
+        Files.writeString(
+            script,
+            "#!/bin/sh\nprintf '%s\\n' \"$3\" >> \"%s\"\nexit 1\n".formatted("%s", invocations),
+            StandardCharsets.UTF_8
+        );
+        assertThat(script.toFile().setExecutable(true)).isTrue();
+        InstagramAvatarCacheService service = new InstagramAvatarCacheService(
+            clubMapper(List.of(club("alpha"), club("beta"), club("gamma"))),
+            tempDir.toString(),
+            true,
+            script.toString(),
+            "",
+            "",
+            1000,
+            TimeUnit.DAYS.toMillis(30),
+            2
+        );
+
+        service.refreshClubInstagramAvatars();
+
+        assertThat(Files.readAllLines(invocations, StandardCharsets.UTF_8)).containsExactly("alpha", "beta");
+    }
+
     private InstagramAvatarCacheService service(boolean enabled) {
         return service(enabled, "python3", 1000);
     }
@@ -92,5 +178,27 @@ class InstagramAvatarCacheServiceTest {
             TimeUnit.DAYS.toMillis(30),
             10
         );
+    }
+
+    private ClubMapper clubMapper(List<Club> clubs) {
+        return (ClubMapper) Proxy.newProxyInstance(
+            ClubMapper.class.getClassLoader(),
+            new Class<?>[] { ClubMapper.class },
+            (proxy, method, args) -> {
+                if (method.getName().equals("findAll")) {
+                    return clubs;
+                }
+                if (method.getReturnType().equals(int.class)) {
+                    return 0;
+                }
+                return null;
+            }
+        );
+    }
+
+    private Club club(String handle) {
+        Club club = new Club();
+        club.setInstagramUrl("https://instagram.com/" + handle);
+        return club;
     }
 }

--- a/backend/src/test/java/com/example/demo/club/service/InstagramAvatarCacheServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/InstagramAvatarCacheServiceTest.java
@@ -1,13 +1,17 @@
 package com.example.demo.club.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.http.MediaType;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 class InstagramAvatarCacheServiceTest {
@@ -57,15 +61,34 @@ class InstagramAvatarCacheServiceTest {
         assertThat(avatar.maxAgeUnit()).isEqualTo(TimeUnit.MINUTES);
     }
 
+    @Test
+    void resolveAvatarTimesOutHungInstaloaderProcess() throws IOException {
+        Path sleeper = tempDir.resolve("sleepy-instaloader.sh");
+        Files.writeString(sleeper, "#!/bin/sh\nsleep 5\n", StandardCharsets.UTF_8);
+        assertThat(sleeper.toFile().setExecutable(true)).isTrue();
+        InstagramAvatarCacheService service = service(true, sleeper.toString(), 1000);
+
+        InstagramAvatarCacheService.ResolvedAvatar avatar = assertTimeoutPreemptively(
+            Duration.ofSeconds(3),
+            () -> service.resolveAvatar("mvhsclubs")
+        );
+
+        assertThat(avatar.mediaType().toString()).isEqualTo("image/svg+xml");
+    }
+
     private InstagramAvatarCacheService service(boolean enabled) {
+        return service(enabled, "python3", 1000);
+    }
+
+    private InstagramAvatarCacheService service(boolean enabled, String pythonCommand, long fetchTimeoutMillis) {
         return new InstagramAvatarCacheService(
             null,
             tempDir.toString(),
             enabled,
-            "python3",
+            pythonCommand,
             "",
             "",
-            1000,
+            fetchTimeoutMillis,
             TimeUnit.DAYS.toMillis(30),
             10
         );

--- a/backend/src/test/java/com/example/demo/club/service/InstagramAvatarCacheServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/InstagramAvatarCacheServiceTest.java
@@ -1,0 +1,73 @@
+package com.example.demo.club.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.http.MediaType;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+class InstagramAvatarCacheServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void normalizeHandleStripsAtAndLowercases() {
+        InstagramAvatarCacheService service = service(false);
+
+        assertThat(service.normalizeHandle("@MVHS.Clubs")).isEqualTo("mvhs.clubs");
+    }
+
+    @Test
+    void normalizeHandleFallsBackForUnsafeInput() {
+        InstagramAvatarCacheService service = service(false);
+
+        assertThat(service.normalizeHandle("../secret")).isEqualTo("hsclubs");
+    }
+
+    @Test
+    void resolveAvatarReturnsLocalCacheBeforeFetching() throws Exception {
+        Path cacheDir = tempDir.resolve("avatar-cache").resolve("instagram");
+        Files.createDirectories(cacheDir);
+        byte[] bytes = new byte[] { 1, 2, 3 };
+        Files.write(cacheDir.resolve("mvhsclubs.png"), bytes);
+        InstagramAvatarCacheService service = service(true);
+
+        InstagramAvatarCacheService.ResolvedAvatar avatar = service.resolveAvatar("mvhsclubs");
+
+        assertThat(avatar.bytes()).isEqualTo(bytes);
+        assertThat(avatar.mediaType()).isEqualTo(MediaType.IMAGE_PNG);
+        assertThat(avatar.maxAge()).isEqualTo(30);
+        assertThat(avatar.maxAgeUnit()).isEqualTo(TimeUnit.DAYS);
+    }
+
+    @Test
+    void resolveAvatarFallsBackWhenFetchingIsDisabled() {
+        InstagramAvatarCacheService service = service(false);
+
+        InstagramAvatarCacheService.ResolvedAvatar avatar = service.resolveAvatar("mvhsclubs");
+
+        assertThat(avatar.mediaType().toString()).isEqualTo("image/svg+xml");
+        assertThat(new String(avatar.bytes())).contains("MV");
+        assertThat(avatar.maxAge()).isEqualTo(10);
+        assertThat(avatar.maxAgeUnit()).isEqualTo(TimeUnit.MINUTES);
+    }
+
+    private InstagramAvatarCacheService service(boolean enabled) {
+        return new InstagramAvatarCacheService(
+            null,
+            tempDir.toString(),
+            enabled,
+            "python3",
+            "",
+            "",
+            1000,
+            TimeUnit.DAYS.toMillis(30),
+            10
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- replace the direct unavatar.io Instagram avatar fetcher with an Instaloader-backed cache service
- keep `/api/avatars/instagram/{handle}` as the public frontend image URL while storing fetched images under `uploads/avatar-cache/instagram`
- add scheduled prewarming for club Instagram avatars plus config/docs for Python command, optional Instaloader session, cache TTL, and refresh cadence
- add backend unit coverage for handle normalization, cached image reads, and fallback behavior

## Why

Club cards already route Instagram avatars through the backend, but cache misses still depended on a third-party avatar proxy. This makes our server own the fetch/cache path so users load local cached images after the first refresh.

## Validation

- `cd backend && ./mvnw test`
- `cd frontend && npm run build`

## Notes

Install the Python dependency on hosts that should refresh Instagram avatars:

```bash
cd backend
pip install -r requirements-instaloader.txt
```

If anonymous Instagram access is rate-limited, configure `APP_INSTAGRAM_AVATAR_SESSION_USER` and `APP_INSTAGRAM_AVATAR_SESSION_FILE` with an Instaloader session.