### PR TITLE
Improve Instagram avatar cache refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ pip install -r requirements-instaloader.txt  # optional: enables Instagram avata
 ./mvnw spring-boot:run
 ```
 
+Instagram may reject anonymous Instaloader requests with 403 responses. For reliable club avatar refreshes, create an Instaloader session with `instaloader --login your_username` and set `APP_INSTAGRAM_AVATAR_SESSION_USER` / `APP_INSTAGRAM_AVATAR_SESSION_FILE` in `backend/.env`.
+
 Frontend:
 
 ```bash

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -42,7 +42,8 @@ FRONTEND_ORIGIN=http://localhost:4173
 # APP_INSTAGRAM_AVATAR_CACHE_ENABLED=true
 # APP_INSTAGRAM_AVATAR_PYTHON_COMMAND=python3
 #
-# Optional: use an Instaloader session if anonymous profile access is rate-limited.
+# Recommended: use an Instaloader session. Anonymous Instagram profile access
+# often returns 403, so real avatar refreshes may fall back without a session.
 # Create it separately with `instaloader --login your_username`.
 # APP_INSTAGRAM_AVATAR_SESSION_USER=your_username
 # APP_INSTAGRAM_AVATAR_SESSION_FILE=/absolute/path/to/session-your_username

--- a/backend/src/main/java/com/example/demo/club/service/InstagramAvatarCacheService.java
+++ b/backend/src/main/java/com/example/demo/club/service/InstagramAvatarCacheService.java
@@ -433,7 +433,7 @@ public class InstagramAvatarCacheService {
         }
 
         private static ResolvedAvatar fallback(byte[] bytes) {
-            return new ResolvedAvatar(bytes, SVG_MEDIA_TYPE, 10, TimeUnit.MINUTES);
+            return new ResolvedAvatar(bytes, SVG_MEDIA_TYPE, 15, TimeUnit.SECONDS);
         }
     }
 }

--- a/backend/src/test/java/com/example/demo/club/service/InstagramAvatarCacheServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/InstagramAvatarCacheServiceTest.java
@@ -67,8 +67,8 @@ class InstagramAvatarCacheServiceTest {
 
         assertThat(avatar.mediaType().toString()).isEqualTo("image/svg+xml");
         assertThat(new String(avatar.bytes())).contains("MV");
-        assertThat(avatar.maxAge()).isEqualTo(10);
-        assertThat(avatar.maxAgeUnit()).isEqualTo(TimeUnit.MINUTES);
+        assertThat(avatar.maxAge()).isEqualTo(15);
+        assertThat(avatar.maxAgeUnit()).isEqualTo(TimeUnit.SECONDS);
     }
 
     @Test
@@ -89,7 +89,7 @@ class InstagramAvatarCacheServiceTest {
     @Test
     void resolveAvatarCoalescesConcurrentCacheMisses() throws Exception {
         byte[] bytes = new byte[] { 9, 8, 7 };
-        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
         server.createContext("/avatar.png", exchange -> {
             exchange.getResponseHeaders().add("Content-Type", "image/png");
             exchange.sendResponseHeaders(200, bytes.length);
@@ -97,14 +97,15 @@ class InstagramAvatarCacheServiceTest {
             exchange.close();
         });
         server.start();
+        int port = server.getAddress().getPort();
 
         Path invocations = tempDir.resolve("coalesced-invocations.txt");
         Files.writeString(invocations, "", StandardCharsets.UTF_8);
         Path script = tempDir.resolve("coalesced-instaloader.sh");
         Files.writeString(
             script,
-            "#!/bin/sh\nprintf 'x\\n' >> \"%s\"\nsleep 1\nprintf 'http://127.0.0.1:%d/avatar.png\\n'\n"
-                .formatted(invocations, server.getAddress().getPort()),
+            "#!/bin/sh\necho x >> \"%s\"\nsleep 1\necho \"http://127.0.0.1:%d/avatar.png\"\n"
+                .formatted(invocations, port),
             StandardCharsets.UTF_8
         );
         assertThat(script.toFile().setExecutable(true)).isTrue();

--- a/frontend/src/types/club.ts
+++ b/frontend/src/types/club.ts
@@ -20,6 +20,8 @@ export interface Club {
   viewerIsMember?: boolean
   canManage?: boolean
   viewerHasPendingRequest?: boolean
+  createdAt?: string | null
+  updatedAt?: string | null
 }
 
 export interface ClubMember {

--- a/frontend/src/utils/clubImages.ts
+++ b/frontend/src/utils/clubImages.ts
@@ -45,14 +45,18 @@ const instagramHandle = (url?: string | null) => {
   }
 }
 
-const cachedInstagramAvatar = (url?: string | null) => {
-  const handle = instagramHandle(url)
-  return handle ? buildApiUrl(`/api/avatars/instagram/${encodeURIComponent(handle)}`) : null
+const cachedInstagramAvatar = (club: Club) => {
+  const handle = instagramHandle(club.instagramUrl)
+  if (!handle) {
+    return null
+  }
+  const version = encodeURIComponent(`${club.id}:${club.updatedAt ?? club.createdAt ?? club.instagramUrl ?? handle}`)
+  return buildApiUrl(`/api/avatars/instagram/${encodeURIComponent(handle)}?v=${version}`)
 }
 
 export const clubImage = (club: Club): string => {
   if (club.imageUrl) {
     return buildApiUrl(club.imageUrl)
   }
-  return cachedInstagramAvatar(club.instagramUrl) ?? localAvatar(club.name)
+  return cachedInstagramAvatar(club) ?? localAvatar(club.name)
 }


### PR DESCRIPTION
## Summary

- Shorten fallback Instagram avatar cache responses so stale SVG placeholders clear quickly.
- Add a stable cache-busting query to club Instagram avatar URLs so browsers do not hold old fallback responses after a refresh.
- Document that Instaloader should be configured with a logged-in session because anonymous Instagram profile access can return 403.

## Validation

- `cd backend && ./mvnw test`
- `cd frontend && npm run build`

## Notes

Local verification showed the backend avatar endpoint now returns fallback SVGs with `Cache-Control: max-age=15`. Real Instagram avatars still require an Instaloader session configured in `backend/.env`.