### PR TITLE
Automate Linux Instaloader setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,7 @@ frontend/dist/
 frontend/.eslintcache
 .env
 backend/uploads/
+backend/.venv/
+backend/.instaloader/
 
 CODET.md

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ Backend:
 ```bash
 cd backend
 cp .env.example .env   # fill in DB_PASSWORD and Google OAuth credentials
-../scripts/setup-instaloader.sh  # optional: enables authenticated Instagram avatar caching
-# Set APP_INSTAGRAM_AVATAR_PYTHON_COMMAND=./.venv/bin/python in backend/.env
+../scripts/setup-instaloader.sh --configure-env  # Linux: install and configure Instaloader
+../scripts/setup-instaloader.sh --configure-env --check
 ./mvnw spring-boot:run
 ```
 
-Instaloader must use an authenticated Instagram session; anonymous Instaloader access is not supported because Instagram rejects it with `403 Forbidden`. Set `APP_INSTAGRAM_AVATAR_COOKIE_BROWSER=firefox` after logging into Instagram in Firefox, or create a saved session with `instaloader --login your_username` and set `APP_INSTAGRAM_AVATAR_SESSION_USER` / `APP_INSTAGRAM_AVATAR_SESSION_FILE` in `backend/.env`. Other browsers can be used by installing `browser-cookie3` for the backend Python environment.
+Instaloader must use an authenticated Instagram session; anonymous access is not supported because Instagram rejects it with `403 Forbidden`. On a headless Linux server, create a saved session as the backend service user and set `APP_INSTAGRAM_AVATAR_SESSION_USER` / `APP_INSTAGRAM_AVATAR_SESSION_FILE` in `backend/.env`. Browser-cookie support is installed for local Linux development. See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md#instaloader-avatar-cache) for distribution-specific prerequisites and session commands.
 If Instaloader cannot resolve a profile picture, the backend also tries Instagram's web profile API before returning the short-lived SVG fallback.
 The backend preloads avatars for clubs with an `instagramUrl`, stores them under `backend/uploads/avatar-cache/instagram`, and refreshes cached files after 60 days. The scheduler checks twice daily, but it only contacts Instagram for missing or expired files. Keep the upload directory and Instaloader session file on persistent, private storage in production.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Backend:
 ```bash
 cd backend
 cp .env.example .env   # fill in DB_PASSWORD and Google OAuth credentials
-pip install -r requirements-instaloader.txt  # optional: enables authenticated Instagram avatar caching
+../scripts/setup-instaloader.sh  # optional: enables authenticated Instagram avatar caching
+# Set APP_INSTAGRAM_AVATAR_PYTHON_COMMAND=./.venv/bin/python in backend/.env
 ./mvnw spring-boot:run
 ```
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -37,10 +37,10 @@ FRONTEND_ORIGIN=http://localhost:4173
 # APP_UPLOAD_DIR=uploads
 
 # Instagram club avatars are cached through Instaloader.
-# Install Python dependency with:
-#   pip install -r backend/requirements-instaloader.txt
+# From the repository root, create the dedicated Python environment with:
+#   ./scripts/setup-instaloader.sh
 # APP_INSTAGRAM_AVATAR_CACHE_ENABLED=true
-# APP_INSTAGRAM_AVATAR_PYTHON_COMMAND=python3
+# APP_INSTAGRAM_AVATAR_PYTHON_COMMAND=./.venv/bin/python
 #
 # Required for Instaloader: configure one authenticated source below. Anonymous
 # Instaloader access is not supported because Instagram returns 403 Forbidden.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -37,17 +37,18 @@ FRONTEND_ORIGIN=http://localhost:4173
 # APP_UPLOAD_DIR=uploads
 
 # Instagram club avatars are cached through Instaloader.
-# From the repository root, create the dedicated Python environment with:
-#   ./scripts/setup-instaloader.sh
+# From the repository root, initialize and validate the Linux environment with:
+#   ./scripts/setup-instaloader.sh --configure-env
+#   ./scripts/setup-instaloader.sh --configure-env --check
+# The setup command writes these values with an absolute Python path:
 # APP_INSTAGRAM_AVATAR_CACHE_ENABLED=true
-# APP_INSTAGRAM_AVATAR_PYTHON_COMMAND=./.venv/bin/python
+# APP_INSTAGRAM_AVATAR_PYTHON_COMMAND=/absolute/path/to/backend/.venv/bin/python
 #
 # Required for Instaloader: configure one authenticated source below. Anonymous
 # Instaloader access is not supported because Instagram returns 403 Forbidden.
 #
 # Option A: import Instagram cookies from a browser already logged into Instagram.
-# Firefox works without extra Python packages. Other browsers require installing
-# browser-cookie3 into the backend Python environment.
+# Firefox and browser-cookie3 support are installed by the setup script.
 # Supported values include firefox, chrome, safari, edge, brave, and vivaldi.
 # APP_INSTAGRAM_AVATAR_COOKIE_BROWSER=firefox
 # APP_INSTAGRAM_AVATAR_COOKIE_FILE=/absolute/path/to/browser/cookies.sqlite

--- a/backend/requirements-instaloader.txt
+++ b/backend/requirements-instaloader.txt
@@ -1,1 +1,2 @@
 instaloader>=4.15,<5
+browser-cookie3>=0.20,<1

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -28,6 +28,7 @@
 | MySQL | 8.0+ | Database |
 | Node.js | 20+ | Frontend build |
 | npm | 10+ | Frontend dependencies |
+| Python | 3.10+ with `venv` and `pip` | Instaloader avatar cache |
 | Nginx | 1.24+ | Reverse proxy (production) |
 | Google Cloud Project | — | OAuth2 credentials |
 | Domain | — | HTTPS + OAuth redirect |
@@ -71,40 +72,65 @@ FRONTEND_ORIGIN=http://localhost:4173
 
 ### Instaloader avatar cache
 
-The backend uses a separate Python virtual environment for Instaloader. Set it
-up once on the host that runs the backend:
+The Linux initializer creates a private Python virtual environment, installs
+Instaloader and browser-cookie support, and can update the backend environment
+file. Install the operating-system packages first:
+
+```bash
+# Ubuntu, Debian, Linux Mint, or Pop!_OS
+sudo apt update
+sudo apt install -y python3 python3-venv python3-pip
+
+# Fedora, RHEL, Rocky Linux, AlmaLinux, or CentOS Stream
+sudo dnf install -y python3 python3-pip
+
+# Arch Linux or Manjaro
+sudo pacman -S --needed python python-pip
+
+# openSUSE or SLES
+sudo zypper install python3 python3-pip python3-virtualenv
+```
+
+Initialize the environment and write the absolute Python command to
+`backend/.env`:
 
 ```bash
 cd /opt/hsclubs
-./scripts/setup-instaloader.sh
+./scripts/setup-instaloader.sh --configure-env
+./scripts/setup-instaloader.sh --configure-env --check
 ```
 
-Add the following to `/opt/hsclubs/backend/.env`:
+The script is idempotent. It skips package installation when the virtual
+environment already matches `backend/requirements-instaloader.txt`. Use
+`PYTHON_BIN`, `INSTALOADER_VENV_DIR`, or `BACKEND_ENV_FILE` to override its
+defaults.
+
+Instaloader requires authentication. For a headless systemd host, create the
+session as the same account that runs the backend so the service can read it:
 
 ```bash
-APP_INSTAGRAM_AVATAR_CACHE_ENABLED=true
-APP_INSTAGRAM_AVATAR_PYTHON_COMMAND=/opt/hsclubs/backend/.venv/bin/python
+sudo install -d -m 0700 -o hsclubs -g hsclubs /opt/hsclubs/backend/.instaloader
+sudo -u hsclubs /opt/hsclubs/backend/.venv/bin/instaloader \
+  --sessionfile /opt/hsclubs/backend/.instaloader/session-your_instagram_username \
+  --login your_instagram_username
+sudo chmod 0600 /opt/hsclubs/backend/.instaloader/session-your_instagram_username
 ```
 
-Instaloader must use an authenticated Instagram source. A saved session is the
-most suitable option for a headless production host:
-
-```bash
-/opt/hsclubs/backend/.venv/bin/instaloader --login your_instagram_username
-```
-
-Copy the resulting session file to private persistent storage and configure it
-in `backend/.env`:
+Add the session identity and explicit file path to `backend/.env`:
 
 ```bash
 APP_INSTAGRAM_AVATAR_SESSION_USER=your_instagram_username
 APP_INSTAGRAM_AVATAR_SESSION_FILE=/opt/hsclubs/backend/.instaloader/session-your_instagram_username
 ```
 
+For local Linux development, browser cookies are also supported with
+`APP_INSTAGRAM_AVATAR_COOKIE_BROWSER=firefox` (or `chrome`, `edge`,
+`brave`, and the other supported browser values). A saved session is preferred
+on servers because browser profiles usually do not exist there.
+
 Do not commit session files or browser cookies. The repository ignores
-`backend/.venv/` and `backend/.instaloader/` for this reason. If the session is
-not configured, Instaloader requests may be rejected by Instagram and the
-backend will use its web-profile fallback or a generated placeholder.
+`backend/.venv/` and `backend/.instaloader/`. If authentication is missing or
+expired, the backend uses its web-profile fallback or a generated placeholder.
 
 ### Frontend (`frontend/.env` or `.env.production`)
 
@@ -215,13 +241,20 @@ sudo systemctl start hsclubs
 sudo systemctl status hsclubs
 ```
 
-The repository also includes `scripts/deploy-main.sh`, which builds both applications,
-installs or updates this persistent service, checks the backend, and then publishes the
-frontend. Its production defaults use the system service and the `hsclubs` user:
+The repository also includes `scripts/deploy-main.sh`, which initializes Instaloader when
+the avatar cache is enabled, builds both applications, installs or updates the persistent
+service, checks the backend, and then publishes the frontend. Its production defaults use
+the system service and the `hsclubs` user:
 
 ```bash
 ./scripts/deploy-main.sh
+
+# Skip Python initialization only when Instaloader is managed separately.
+SETUP_INSTALOADER=0 ./scripts/deploy-main.sh
 ```
+
+The deploy script respects `APP_INSTAGRAM_AVATAR_CACHE_ENABLED=false` and skips
+Instaloader initialization when the cache is disabled.
 
 ### Health check
 
@@ -377,7 +410,7 @@ The `/api/auth/providers` endpoint auto-discovers all configured providers.
 
 - [ ] MySQL database created with `utf8mb4` charset
 - [ ] `backend/.env` configured with real credentials
-- [ ] Instaloader virtualenv installed if Instagram avatar caching is enabled
+- [ ] `./scripts/setup-instaloader.sh --configure-env --check` passes
 - [ ] Authenticated Instaloader session stored on private persistent storage
 - [ ] `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` set
 - [ ] `APP_OWNER_EMAILS` populated (comma-separated)
@@ -413,6 +446,19 @@ sudo journalctl -u hsclubs -n 50 --no-pager
 # - Port 8080 in use: lsof -i :8080
 # - Google OAuth misconfig: check GOOGLE_CLIENT_ID
 ```
+
+### Instaloader check fails
+
+```bash
+./scripts/setup-instaloader.sh --configure-env --check
+sudo -u hsclubs /opt/hsclubs/backend/.venv/bin/python -c 'import instaloader, browser_cookie3'
+sudo journalctl -u hsclubs -n 100 --no-pager
+```
+
+If Python cannot create the virtual environment, install the distribution
+packages listed in the Instaloader section. If imports work but avatars still
+fall back to placeholders, recreate the saved session and verify that the
+`hsclubs` service account can read the configured session file.
 
 ### CORS errors in browser
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -69,6 +69,43 @@ FRONTEND_ORIGIN=http://localhost:4173
 # APP_AUTHORIZATION_REQUEST_BASE_URI=/api/auth/authorize
 ```
 
+### Instaloader avatar cache
+
+The backend uses a separate Python virtual environment for Instaloader. Set it
+up once on the host that runs the backend:
+
+```bash
+cd /opt/hsclubs
+./scripts/setup-instaloader.sh
+```
+
+Add the following to `/opt/hsclubs/backend/.env`:
+
+```bash
+APP_INSTAGRAM_AVATAR_CACHE_ENABLED=true
+APP_INSTAGRAM_AVATAR_PYTHON_COMMAND=/opt/hsclubs/backend/.venv/bin/python
+```
+
+Instaloader must use an authenticated Instagram source. A saved session is the
+most suitable option for a headless production host:
+
+```bash
+/opt/hsclubs/backend/.venv/bin/instaloader --login your_instagram_username
+```
+
+Copy the resulting session file to private persistent storage and configure it
+in `backend/.env`:
+
+```bash
+APP_INSTAGRAM_AVATAR_SESSION_USER=your_instagram_username
+APP_INSTAGRAM_AVATAR_SESSION_FILE=/opt/hsclubs/backend/.instaloader/session-your_instagram_username
+```
+
+Do not commit session files or browser cookies. The repository ignores
+`backend/.venv/` and `backend/.instaloader/` for this reason. If the session is
+not configured, Instaloader requests may be rejected by Instagram and the
+backend will use its web-profile fallback or a generated placeholder.
+
 ### Frontend (`frontend/.env` or `.env.production`)
 
 ```bash
@@ -340,6 +377,8 @@ The `/api/auth/providers` endpoint auto-discovers all configured providers.
 
 - [ ] MySQL database created with `utf8mb4` charset
 - [ ] `backend/.env` configured with real credentials
+- [ ] Instaloader virtualenv installed if Instagram avatar caching is enabled
+- [ ] Authenticated Instaloader session stored on private persistent storage
 - [ ] `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` set
 - [ ] `APP_OWNER_EMAILS` populated (comma-separated)
 - [ ] `FRONTEND_ORIGIN` matches production URL

--- a/scripts/deploy-main.sh
+++ b/scripts/deploy-main.sh
@@ -13,6 +13,7 @@ BACKEND_RUN_USER="${BACKEND_RUN_USER:-hsclubs}"
 SYSTEMD_SCOPE="${SYSTEMD_SCOPE:-system}"
 RUN_BACKEND_TESTS="${RUN_BACKEND_TESTS:-0}"
 SKIP_GIT_PULL="${SKIP_GIT_PULL:-0}"
+SETUP_INSTALOADER="${SETUP_INSTALOADER:-1}"
 
 log() {
   printf '\n[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
@@ -69,6 +70,43 @@ validate_configuration() {
     die "BACKEND_SERVICE must be a systemd service name ending in .service."
   [[ "$SYSTEMD_SCOPE" == "user" || "$SYSTEMD_SCOPE" == "system" ]] || \
     die "SYSTEMD_SCOPE must be either 'user' or 'system'."
+  [[ "$SETUP_INSTALOADER" == "0" || "$SETUP_INSTALOADER" == "1" ]] || \
+    die "SETUP_INSTALOADER must be either '0' or '1'."
+}
+
+read_env_value() {
+  local key="$1"
+
+  awk -v key="$key" '
+    index($0, key "=") == 1 {
+      sub("^[^=]*=", "")
+      sub("\r$", "")
+      print tolower($0)
+      exit
+    }
+  ' "$BACKEND_ENV_FILE"
+}
+
+initialize_instaloader() {
+  local cache_enabled
+
+  cache_enabled="$(read_env_value APP_INSTAGRAM_AVATAR_CACHE_ENABLED)"
+  cache_enabled="${cache_enabled:-true}"
+  case "$cache_enabled" in
+    false|0|no|off)
+      log "Skipping Instaloader setup because the Instagram avatar cache is disabled."
+      return
+      ;;
+  esac
+
+  if [[ "$SETUP_INSTALOADER" == "0" ]]; then
+    log "Skipping Instaloader setup because SETUP_INSTALOADER=0"
+    return
+  fi
+
+  [[ -x "$APP_DIR/scripts/setup-instaloader.sh" ]] || \
+    die "Instaloader setup script is missing or not executable."
+  run "$APP_DIR/scripts/setup-instaloader.sh" --configure-env --env-file "$BACKEND_ENV_FILE"
 }
 
 ensure_clean_worktree() {
@@ -205,6 +243,7 @@ main() {
   validate_configuration
   cd "$APP_DIR"
   update_source
+  initialize_instaloader
 
   log "Building frontend"
   cd "$APP_DIR/frontend"

--- a/scripts/deploy-main.sh
+++ b/scripts/deploy-main.sh
@@ -98,10 +98,36 @@ read_env_value() {
   ' "$BACKEND_ENV_FILE"
 }
 
+resolve_absolute_path() {
+  local path="$1"
+  local directory
+  local basename
+
+  [[ "$path" = /* ]] || path="$APP_DIR/$path"
+  directory="$(dirname "$path")"
+  basename="$(basename "$path")"
+
+  if [[ -d "$directory" ]]; then
+    printf '%s/%s\n' "$(cd "$directory" && pwd -P)" "$basename"
+    return
+  fi
+
+  local normalized_parent
+  local current="$path"
+  local suffix=""
+  while [[ ! -d "$current" ]]; do
+    suffix="/$(basename "$current")$suffix"
+    current="$(dirname "$current")"
+  done
+  normalized_parent="$(cd "$current" && pwd -P)"
+  printf '%s%s\n' "$normalized_parent" "$suffix"
+}
+
 initialize_instaloader() {
   local cache_enabled
   local configured_python
   local expected_python
+  local venv_dir
 
   cache_enabled="$(read_env_value APP_INSTAGRAM_AVATAR_CACHE_ENABLED)"
   cache_enabled="${cache_enabled:-true}"
@@ -121,7 +147,8 @@ initialize_instaloader() {
   [[ -x "$APP_DIR/scripts/setup-instaloader.sh" ]] || \
     die "Instaloader setup script is missing or not executable."
 
-  expected_python="${INSTALOADER_VENV_DIR:-$APP_DIR/backend/.venv}/bin/python"
+  venv_dir="$(resolve_absolute_path "${INSTALOADER_VENV_DIR:-$APP_DIR/backend/.venv}")"
+  expected_python="$venv_dir/bin/python"
   configured_python="$(read_env_value APP_INSTAGRAM_AVATAR_PYTHON_COMMAND)"
   if [[ "$configured_python" == "$expected_python" ]]; then
     run "$APP_DIR/scripts/setup-instaloader.sh" --env-file "$BACKEND_ENV_FILE"

--- a/scripts/deploy-main.sh
+++ b/scripts/deploy-main.sh
@@ -78,20 +78,34 @@ read_env_value() {
   local key="$1"
 
   awk -v key="$key" '
-    index($0, key "=") == 1 {
-      sub("^[^=]*=", "")
-      sub("\r$", "")
-      print tolower($0)
-      exit
+    {
+      line = $0
+      sub(/^[[:space:]]*/, "", line)
+      separator = index(line, "=")
+      if (separator == 0) {
+        next
+      }
+      candidate = substr(line, 1, separator - 1)
+      sub(/[[:space:]]*$/, "", candidate)
+      if (candidate == key) {
+        value = substr(line, separator + 1)
+        sub(/^[[:space:]]*/, "", value)
+        sub(/[[:space:]]*$/, "", value)
+        print value
+        exit
+      }
     }
   ' "$BACKEND_ENV_FILE"
 }
 
 initialize_instaloader() {
   local cache_enabled
+  local configured_python
+  local expected_python
 
   cache_enabled="$(read_env_value APP_INSTAGRAM_AVATAR_CACHE_ENABLED)"
   cache_enabled="${cache_enabled:-true}"
+  cache_enabled="$(printf '%s\n' "$cache_enabled" | awk '{print tolower($0)}')"
   case "$cache_enabled" in
     false|0|no|off)
       log "Skipping Instaloader setup because the Instagram avatar cache is disabled."
@@ -106,6 +120,16 @@ initialize_instaloader() {
 
   [[ -x "$APP_DIR/scripts/setup-instaloader.sh" ]] || \
     die "Instaloader setup script is missing or not executable."
+
+  expected_python="${INSTALOADER_VENV_DIR:-$APP_DIR/backend/.venv}/bin/python"
+  configured_python="$(read_env_value APP_INSTAGRAM_AVATAR_PYTHON_COMMAND)"
+  if [[ "$configured_python" == "$expected_python" ]]; then
+    run "$APP_DIR/scripts/setup-instaloader.sh" --env-file "$BACKEND_ENV_FILE"
+    return
+  fi
+
+  [[ -w "$BACKEND_ENV_FILE" ]] || \
+    die "Backend environment file must be writable to configure Instaloader: $BACKEND_ENV_FILE"
   run "$APP_DIR/scripts/setup-instaloader.sh" --configure-env --env-file "$BACKEND_ENV_FILE"
 }
 

--- a/scripts/setup-instaloader.sh
+++ b/scripts/setup-instaloader.sh
@@ -65,11 +65,22 @@ read_env_value() {
 
   [[ -r "$file" ]] || return 1
   awk -v key="$key" '
-    index($0, key "=") == 1 {
-      sub("^[^=]*=", "")
-      sub("\r$", "")
-      print
-      exit
+    {
+      line = $0
+      sub(/^[[:space:]]*/, "", line)
+      separator = index(line, "=")
+      if (separator == 0) {
+        next
+      }
+      candidate = substr(line, 1, separator - 1)
+      sub(/[[:space:]]*$/, "", candidate)
+      if (candidate == key) {
+        value = substr(line, separator + 1)
+        sub(/^[[:space:]]*/, "", value)
+        sub(/[[:space:]]*$/, "", value)
+        print value
+        exit
+      }
     }
   ' "$file"
 }
@@ -89,14 +100,21 @@ upsert_env_value() {
   temp_file="$(mktemp "${ENV_FILE}.tmp.XXXXXX")"
   if ! awk -v key="$key" -v value="$value" '
     BEGIN { updated = 0 }
-    index($0, key "=") == 1 {
-      if (!updated) {
-        print key "=" value
-        updated = 1
+    {
+      line = $0
+      sub(/^[[:space:]]*/, "", line)
+      separator = index(line, "=")
+      candidate = separator == 0 ? "" : substr(line, 1, separator - 1)
+      sub(/[[:space:]]*$/, "", candidate)
+      if (candidate == key) {
+        if (!updated) {
+          print key "=" value
+          updated = 1
+        }
+        next
       }
-      next
+      print
     }
-    { print }
     END {
       if (!updated) {
         print key "=" value

--- a/scripts/setup-instaloader.sh
+++ b/scripts/setup-instaloader.sh
@@ -4,17 +4,209 @@ set -Eeuo pipefail
 APP_DIR="${APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 PYTHON_BIN="${PYTHON_BIN:-python3}"
 VENV_DIR="${INSTALOADER_VENV_DIR:-$APP_DIR/backend/.venv}"
+ENV_FILE="${BACKEND_ENV_FILE:-$APP_DIR/backend/.env}"
+REQUIREMENTS_FILE="$APP_DIR/backend/requirements-instaloader.txt"
+REQUIREMENTS_MARKER="$VENV_DIR/.hsclubs-instaloader-requirements"
+CONFIGURE_ENV=0
+CHECK_ONLY=0
 
-if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
-  printf 'ERROR: Python executable not found: %s\n' "$PYTHON_BIN" >&2
+log() {
+  printf '\n[Instaloader setup] %s\n' "$*"
+}
+
+die() {
+  printf '\nERROR: %s\n' "$*" >&2
   exit 1
+}
+
+usage() {
+  printf '%s\n' \
+    'Usage: ./scripts/setup-instaloader.sh [options]' \
+    '' \
+    'Create or update the Linux environment used by the Instagram avatar cache.' \
+    '' \
+    '  --configure-env   Enable the cache and write its Python command to backend/.env.' \
+    '  --env-file PATH   Use PATH instead of backend/.env when configuring or checking.' \
+    '  --check           Check the existing installation without changing it.' \
+    '  -h, --help        Show this help.' \
+    '' \
+    'Environment overrides: PYTHON_BIN, INSTALOADER_VENV_DIR, BACKEND_ENV_FILE'
+}
+
+linux_package_hint() {
+  local distro_id=""
+
+  if [[ -r /etc/os-release ]]; then
+    distro_id="$(awk -F= '$1 == "ID" {gsub(/^"|"$/, "", $2); print tolower($2); exit}' /etc/os-release)"
+  fi
+
+  case "$distro_id" in
+    ubuntu|debian|linuxmint|pop)
+      printf 'Install prerequisites with:\n  sudo apt update && sudo apt install -y python3 python3-venv python3-pip\n' >&2
+      ;;
+    fedora|rhel|centos|rocky|almalinux)
+      printf 'Install prerequisites with:\n  sudo dnf install -y python3 python3-pip\n' >&2
+      ;;
+    arch|manjaro)
+      printf 'Install prerequisites with:\n  sudo pacman -S --needed python python-pip\n' >&2
+      ;;
+    opensuse*|sles)
+      printf 'Install prerequisites with:\n  sudo zypper install python3 python3-pip python3-virtualenv\n' >&2
+      ;;
+    *)
+      printf 'Install Python 3, pip, and the Python venv module with your Linux package manager.\n' >&2
+      ;;
+  esac
+}
+
+read_env_value() {
+  local key="$1"
+  local file="$2"
+
+  [[ -r "$file" ]] || return 1
+  awk -v key="$key" '
+    index($0, key "=") == 1 {
+      sub("^[^=]*=", "")
+      sub("\r$", "")
+      print
+      exit
+    }
+  ' "$file"
+}
+
+upsert_env_value() {
+  local key="$1"
+  local value="$2"
+  local temp_file
+
+  [[ "$value" != *$'\n'* ]] || die "Environment value for $key contains a newline."
+  mkdir -p "$(dirname "$ENV_FILE")"
+  if [[ ! -e "$ENV_FILE" ]]; then
+    (umask 077; : > "$ENV_FILE")
+  fi
+  [[ -f "$ENV_FILE" && -w "$ENV_FILE" ]] || die "Environment file is not writable: $ENV_FILE"
+
+  temp_file="$(mktemp "${ENV_FILE}.tmp.XXXXXX")"
+  if ! awk -v key="$key" -v value="$value" '
+    BEGIN { updated = 0 }
+    index($0, key "=") == 1 {
+      if (!updated) {
+        print key "=" value
+        updated = 1
+      }
+      next
+    }
+    { print }
+    END {
+      if (!updated) {
+        print key "=" value
+      }
+    }
+  ' "$ENV_FILE" > "$temp_file"; then
+    rm -f "$temp_file"
+    die "Could not update environment file: $ENV_FILE"
+  fi
+  chmod --reference="$ENV_FILE" "$temp_file"
+  mv "$temp_file" "$ENV_FILE"
+}
+
+check_installation() {
+  local configured_python=""
+  local failed=0
+
+  if [[ ! -x "$VENV_DIR/bin/python" ]]; then
+    printf 'ERROR: Instaloader Python is missing: %s\n' "$VENV_DIR/bin/python" >&2
+    failed=1
+  elif ! "$VENV_DIR/bin/python" -c 'import instaloader, browser_cookie3' >/dev/null 2>&1; then
+    printf 'ERROR: Instaloader dependencies cannot be imported from %s\n' "$VENV_DIR/bin/python" >&2
+    failed=1
+  else
+    "$VENV_DIR/bin/python" -c 'from importlib.metadata import version; print("Instaloader:", version("instaloader"))'
+  fi
+
+  if [[ ! -f "$REQUIREMENTS_MARKER" ]] || ! cmp -s "$REQUIREMENTS_FILE" "$REQUIREMENTS_MARKER"; then
+    printf 'ERROR: The environment is not synchronized with %s\n' "$REQUIREMENTS_FILE" >&2
+    failed=1
+  fi
+
+  if [[ "$CONFIGURE_ENV" == "1" ]]; then
+    configured_python="$(read_env_value APP_INSTAGRAM_AVATAR_PYTHON_COMMAND "$ENV_FILE" || true)"
+    if [[ "$configured_python" != "$VENV_DIR/bin/python" ]]; then
+      printf 'ERROR: %s does not configure APP_INSTAGRAM_AVATAR_PYTHON_COMMAND=%s\n' \
+        "$ENV_FILE" "$VENV_DIR/bin/python" >&2
+      failed=1
+    fi
+  fi
+
+  [[ "$failed" == "0" ]] || return 1
+  printf 'Instaloader environment check passed.\n'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --configure-env)
+      CONFIGURE_ENV=1
+      ;;
+    --env-file)
+      [[ $# -ge 2 ]] || die "--env-file requires a path."
+      ENV_FILE="$2"
+      shift
+      ;;
+    --check)
+      CHECK_ONLY=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      die "Unknown option: $1"
+      ;;
+  esac
+  shift
+done
+
+[[ "$(uname -s)" == "Linux" ]] || die "This initializer currently supports Linux hosts only."
+[[ -f "$REQUIREMENTS_FILE" ]] || die "Requirements file is missing: $REQUIREMENTS_FILE"
+
+if [[ "$CHECK_ONLY" == "1" ]]; then
+  check_installation
+  exit 0
 fi
 
-"$PYTHON_BIN" -m venv "$VENV_DIR"
-"$VENV_DIR/bin/python" -m pip install -r "$APP_DIR/backend/requirements-instaloader.txt"
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  linux_package_hint
+  die "Python executable not found: $PYTHON_BIN"
+fi
 
-printf '\nInstaloader environment ready.\n'
+if [[ ! -x "$VENV_DIR/bin/python" ]]; then
+  log "Creating Python virtual environment at $VENV_DIR"
+  if ! "$PYTHON_BIN" -m venv "$VENV_DIR"; then
+    linux_package_hint
+    die "Python could not create the virtual environment."
+  fi
+fi
+
+if ! "$VENV_DIR/bin/python" -c 'import instaloader, browser_cookie3' >/dev/null 2>&1 \
+  || [[ ! -f "$REQUIREMENTS_MARKER" ]] \
+  || ! cmp -s "$REQUIREMENTS_FILE" "$REQUIREMENTS_MARKER"; then
+  log "Installing Instaloader dependencies"
+  "$VENV_DIR/bin/python" -m pip install --disable-pip-version-check -r "$REQUIREMENTS_FILE"
+  cp "$REQUIREMENTS_FILE" "$REQUIREMENTS_MARKER"
+else
+  log "Instaloader dependencies are already current"
+fi
+
+if [[ "$CONFIGURE_ENV" == "1" ]]; then
+  log "Configuring $ENV_FILE"
+  upsert_env_value APP_INSTAGRAM_AVATAR_CACHE_ENABLED true
+  upsert_env_value APP_INSTAGRAM_AVATAR_PYTHON_COMMAND "$VENV_DIR/bin/python"
+fi
+
+check_installation
 printf 'Python: %s\n' "$VENV_DIR/bin/python"
-"$VENV_DIR/bin/python" -c 'import instaloader; print("Instaloader:", instaloader.__version__)'
-printf '\nSet this in backend/.env:\n'
-printf 'APP_INSTAGRAM_AVATAR_PYTHON_COMMAND=%s\n' "$VENV_DIR/bin/python"
+if [[ "$CONFIGURE_ENV" != "1" ]]; then
+  printf '\nTo enable the cache in %s, rerun with --configure-env.\n' "$ENV_FILE"
+fi
+printf 'Configure an authenticated Instagram session before relying on avatar refreshes.\n'

--- a/scripts/setup-instaloader.sh
+++ b/scripts/setup-instaloader.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+APP_DIR="${APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+VENV_DIR="${INSTALOADER_VENV_DIR:-$APP_DIR/backend/.venv}"
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  printf 'ERROR: Python executable not found: %s\n' "$PYTHON_BIN" >&2
+  exit 1
+fi
+
+"$PYTHON_BIN" -m venv "$VENV_DIR"
+"$VENV_DIR/bin/python" -m pip install -r "$APP_DIR/backend/requirements-instaloader.txt"
+
+printf '\nInstaloader environment ready.\n'
+printf 'Python: %s\n' "$VENV_DIR/bin/python"
+"$VENV_DIR/bin/python" -c 'import instaloader; print("Instaloader:", instaloader.__version__)'
+printf '\nSet this in backend/.env:\n'
+printf 'APP_INSTAGRAM_AVATAR_PYTHON_COMMAND=%s\n' "$VENV_DIR/bin/python"

--- a/scripts/setup-instaloader.sh
+++ b/scripts/setup-instaloader.sh
@@ -3,12 +3,39 @@ set -Eeuo pipefail
 
 APP_DIR="${APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 PYTHON_BIN="${PYTHON_BIN:-python3}"
-VENV_DIR="${INSTALOADER_VENV_DIR:-$APP_DIR/backend/.venv}"
 ENV_FILE="${BACKEND_ENV_FILE:-$APP_DIR/backend/.env}"
 REQUIREMENTS_FILE="$APP_DIR/backend/requirements-instaloader.txt"
-REQUIREMENTS_MARKER="$VENV_DIR/.hsclubs-instaloader-requirements"
 CONFIGURE_ENV=0
 CHECK_ONLY=0
+
+resolve_absolute_path() {
+  local path="$1"
+  local directory
+  local basename
+
+  [[ "$path" = /* ]] || path="$APP_DIR/$path"
+  directory="$(dirname "$path")"
+  basename="$(basename "$path")"
+
+  if [[ ! -d "$directory" ]]; then
+    local normalized_parent
+    local current="$directory"
+    local suffix=""
+
+    while [[ ! -d "$current" ]]; do
+      suffix="/$(basename "$current")$suffix"
+      current="$(dirname "$current")"
+    done
+    normalized_parent="$(cd "$current" && pwd -P)"
+    printf '%s%s/%s\n' "$normalized_parent" "$suffix" "$basename"
+    return
+  fi
+
+  printf '%s/%s\n' "$(cd "$directory" && pwd -P)" "$basename"
+}
+
+VENV_DIR="$(resolve_absolute_path "${INSTALOADER_VENV_DIR:-$APP_DIR/backend/.venv}")"
+REQUIREMENTS_MARKER="$VENV_DIR/.hsclubs-instaloader-requirements"
 
 log() {
   printf '\n[Instaloader setup] %s\n' "$*"
@@ -129,6 +156,7 @@ upsert_env_value() {
 }
 
 check_installation() {
+  local cache_enabled=""
   local configured_python=""
   local failed=0
 
@@ -154,6 +182,18 @@ check_installation() {
         "$ENV_FILE" "$VENV_DIR/bin/python" >&2
       failed=1
     fi
+
+    cache_enabled="$(read_env_value APP_INSTAGRAM_AVATAR_CACHE_ENABLED "$ENV_FILE" || true)"
+    cache_enabled="$(printf '%s\n' "$cache_enabled" | awk '{print tolower($0)}')"
+    case "$cache_enabled" in
+      true|1|yes|on)
+        ;;
+      *)
+        printf 'ERROR: %s does not enable APP_INSTAGRAM_AVATAR_CACHE_ENABLED\n' \
+          "$ENV_FILE" >&2
+        failed=1
+        ;;
+    esac
   fi
 
   [[ "$failed" == "0" ]] || return 1


### PR DESCRIPTION
## What changed

- add an idempotent Linux Instaloader initializer with `--configure-env` and `--check` modes
- install both Instaloader and browser-cookie support in the dedicated backend virtual environment
- make `deploy-main.sh` initialize Instaloader automatically when avatar caching is enabled
- document package prerequisites for Ubuntu/Debian, Fedora/RHEL, Arch, and openSUSE
- document secure session creation for the systemd backend account and troubleshooting commands
- include the previous isolated Instaloader setup and environment-template changes

## Why

Fresh Linux deployments previously started the Java service without ensuring that the configured Python environment contained Instaloader. Clients also had to manually determine Linux packages, environment values, and session ownership.

## Impact

A client can now initialize and validate the avatar-cache dependency with one repository script. Repeated deployments avoid reinstalling unchanged requirements, while operators can opt out with `SETUP_INSTALOADER=0` or disable the cache.

## Validation

- `bash -n scripts/setup-instaloader.sh scripts/deploy-main.sh`
- `./scripts/setup-instaloader.sh --configure-env` (installed Instaloader 4.15.2 and browser-cookie3 0.20.1 on Ubuntu 24.04)
- repeated setup confirmed the idempotent no-install path
- `./scripts/setup-instaloader.sh --configure-env --check`
- `backend/./mvnw test` — 12 tests passed
- `frontend/npm run type-check`
- `frontend/npm run build`
- `git diff --check`

`npm run test:unit` reports that the frontend currently contains no test files.