### PR TITLE
Simplify category page and add club match quiz

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,6 +1,14 @@
 # Frontend variables are read by Vite when the app is built.
 VITE_API_BASE_URL=http://localhost:8080
 
+# School branding and initial color mode.
+VITE_BRAND_NAME=HS Clubs
+VITE_SCHOOL_NAME=Sample High School
+VITE_SCHOOL_SHORT_NAME=School Clubs
+VITE_SCHOOL_TAGLINE=A reusable club directory template for one school community.
+VITE_SCHOOL_INTRO=Browse active clubs, discover meeting times, and start membership workflows from a simple school-owned directory.
+VITE_DEFAULT_COLOR_MODE=light
+
 # Calendar schedule in 24-hour HH:mm format.
 VITE_CALENDAR_LUNCH_START=11:30
 VITE_CALENDAR_LUNCH_END=13:30

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,7 +9,7 @@ This template should help get you started developing with Vue 3 in Vite.
 ## Recommended Browser Setup
 
 - Chromium-based browsers (Chrome, Edge, Brave, etc.):
-  - [Vue.js devtools](https://chromewebstore.google.com/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd) 
+  - [Vue.js devtools](https://chromewebstore.google.com/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd)
   - [Turn on Custom Object Formatter in Chrome DevTools](http://bit.ly/object-formatters)
 - Firefox:
   - [Vue.js devtools](https://addons.mozilla.org/en-US/firefox/addon/vue-js-devtools/)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -29,6 +29,19 @@ See [Vite Configuration Reference](https://vite.dev/config/).
 npm install
 ```
 
+### Configure School Branding
+
+Copy `.env.example` to `.env` and customize the school-facing options before building:
+
+```sh
+VITE_BRAND_NAME=HS Clubs
+VITE_SCHOOL_NAME=Sample High School
+VITE_SCHOOL_SHORT_NAME=School Clubs
+VITE_DEFAULT_COLOR_MODE=light
+```
+
+`VITE_DEFAULT_COLOR_MODE` accepts `light` or `dark`. A visitor's saved theme preference takes priority after they use the theme toggle.
+
 ### Compile and Hot-Reload for Development
 
 ```sh

--- a/frontend/env.d.ts
+++ b/frontend/env.d.ts
@@ -1,6 +1,12 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  readonly VITE_BRAND_NAME?: string
+  readonly VITE_SCHOOL_NAME?: string
+  readonly VITE_SCHOOL_SHORT_NAME?: string
+  readonly VITE_SCHOOL_TAGLINE?: string
+  readonly VITE_SCHOOL_INTRO?: string
+  readonly VITE_DEFAULT_COLOR_MODE?: 'light' | 'dark'
   readonly VITE_CALENDAR_LUNCH_START?: string
   readonly VITE_CALENDAR_LUNCH_END?: string
   readonly VITE_CALENDAR_AFTER_SCHOOL_START?: string

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>HS Clubs</title>
+    <title></title>
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,9 +1,9 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
-    <link rel="icon" href="/favicon.ico">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>HS Clubs</title>
   </head>
   <body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Mountain View High School Clubs</title>
+    <title>HS Clubs</title>
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -64,6 +64,9 @@ const themeLabel = computed(() => (theme.value === 'light' ? 'Dark mode' : 'Ligh
 
 const applyTheme = (value: ColorMode) => {
   document.documentElement.dataset.theme = value
+}
+
+const persistTheme = (value: ColorMode) => {
   try {
     localStorage.setItem('theme', value)
   } catch (error) {
@@ -72,7 +75,9 @@ const applyTheme = (value: ColorMode) => {
 }
 
 const toggleTheme = () => {
-  theme.value = theme.value === 'light' ? 'dark' : 'light'
+  const nextTheme = theme.value === 'light' ? 'dark' : 'light'
+  theme.value = nextTheme
+  persistTheme(nextTheme)
 }
 
 try {
@@ -158,16 +163,10 @@ watch(
             </RouterLink>
           </div>
           <nav class="nav">
-            <RouterLink
-              to="/"
-              class="nav-link"
-              :class="{ active: route.name === 'home' }"
+            <RouterLink to="/" class="nav-link" :class="{ active: route.name === 'home' }"
               >Home</RouterLink
             >
-            <RouterLink
-              to="/about"
-              class="nav-link"
-              :class="{ active: route.name === 'about' }"
+            <RouterLink to="/about" class="nav-link" :class="{ active: route.name === 'about' }"
               >Category</RouterLink
             >
             <RouterLink
@@ -251,14 +250,28 @@ watch(
           </form>
           <nav class="mobile-nav">
             <RouterLink to="/" class="mobile-nav-link" @click="closeMobileMenu">Home</RouterLink>
-            <RouterLink to="/about" class="mobile-nav-link" @click="closeMobileMenu">Category</RouterLink>
-            <RouterLink to="/calendar" class="mobile-nav-link" @click="closeMobileMenu">Calendar</RouterLink>
-            <RouterLink v-if="currentUser?.isOwner" to="/admin" class="mobile-nav-link" @click="closeMobileMenu">Admin</RouterLink>
+            <RouterLink to="/about" class="mobile-nav-link" @click="closeMobileMenu"
+              >Category</RouterLink
+            >
+            <RouterLink to="/calendar" class="mobile-nav-link" @click="closeMobileMenu"
+              >Calendar</RouterLink
+            >
+            <RouterLink
+              v-if="currentUser?.isOwner"
+              to="/admin"
+              class="mobile-nav-link"
+              @click="closeMobileMenu"
+              >Admin</RouterLink
+            >
           </nav>
           <div class="mobile-actions">
             <template v-if="isAuthenticated">
-              <RouterLink to="/profile" class="mobile-nav-link" @click="closeMobileMenu">Profile</RouterLink>
-              <button type="button" class="auth-btn ghost" @click="handleMobileLogout">Log out</button>
+              <RouterLink to="/profile" class="mobile-nav-link" @click="closeMobileMenu"
+                >Profile</RouterLink
+              >
+              <button type="button" class="auth-btn ghost" @click="handleMobileLogout">
+                Log out
+              </button>
             </template>
             <template v-else>
               <RouterLink to="/auth?intent=login" class="mobile-nav-link" @click="closeMobileMenu"
@@ -431,7 +444,9 @@ watch(
   color: var(--mv-profile-text);
   text-decoration: none;
   font-size: 0.9rem;
-  transition: background 0.2s, border-color 0.2s;
+  transition:
+    background 0.2s,
+    border-color 0.2s;
 }
 
 .profile-link:hover {
@@ -546,8 +561,12 @@ watch(
   transition: transform 0.25s;
 }
 
-.hamburger::before { top: -7px; }
-.hamburger::after { top: 7px; }
+.hamburger::before {
+  top: -7px;
+}
+.hamburger::after {
+  top: 7px;
+}
 
 .mobile-menu {
   padding: 1rem var(--page-padding-inline) 1.5rem;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,6 +5,7 @@ import { storeToRefs } from 'pinia'
 
 import { useAuthStore } from './stores/auth'
 import ErrorDisplay from './components/ErrorDisplay.vue'
+import { schoolTemplate, type ColorMode } from './config/schoolTemplate'
 
 const searchQuery = ref('')
 const route = useRoute()
@@ -45,7 +46,7 @@ watch(
   },
 )
 
-const logoText = 'HS Clubs'
+const logoText = schoolTemplate.brandName
 const searchPlaceholder = 'Search clubs, advisors, categories, or keywords'
 
 const handleLogout = () => {
@@ -57,10 +58,10 @@ const handleMobileLogout = () => {
   handleLogout()
 }
 
-const theme = ref<'light' | 'dark'>('light')
+const theme = ref<ColorMode>(schoolTemplate.defaultColorMode)
 const themeLabel = computed(() => (theme.value === 'light' ? 'Dark mode' : 'Light mode'))
 
-const applyTheme = (value: 'light' | 'dark') => {
+const applyTheme = (value: ColorMode) => {
   document.documentElement.dataset.theme = value
   try {
     localStorage.setItem('theme', value)
@@ -151,7 +152,7 @@ watch(
         <div class="header-left">
           <div class="logo">
             <RouterLink to="/" class="logo-link">
-              <img class="logo-icon" src="/android-chrome-512x512.png" alt="HS Clubs logo" />
+              <img class="logo-icon" src="/android-chrome-512x512.png" :alt="`${logoText} logo`" />
               <span class="logo-text">{{ logoText }}</span>
             </RouterLink>
           </div>
@@ -281,7 +282,7 @@ watch(
 
     <footer class="app-footer">
       <div class="footer-inner page-shell">
-        <span class="footer-brand">HS Clubs</span>
+        <span class="footer-brand">{{ logoText }}</span>
         <nav class="footer-links">
           <RouterLink to="/terms">Terms of Use</RouterLink>
           <RouterLink to="/privacy">Privacy Policy</RouterLink>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -48,6 +48,7 @@ watch(
 
 const logoText = schoolTemplate.brandName
 const searchPlaceholder = 'Search clubs, advisors, categories, or keywords'
+document.title = logoText
 
 const handleLogout = () => {
   authStore.logout()

--- a/frontend/src/config/schoolTemplate.ts
+++ b/frontend/src/config/schoolTemplate.ts
@@ -1,4 +1,9 @@
+export type ColorMode = 'light' | 'dark'
+
+const configuredColorMode = import.meta.env.VITE_DEFAULT_COLOR_MODE?.trim().toLowerCase()
+
 export const schoolTemplate = {
+  brandName: import.meta.env.VITE_BRAND_NAME || 'HS Clubs',
   schoolName: import.meta.env.VITE_SCHOOL_NAME || 'Sample High School',
   shortName: import.meta.env.VITE_SCHOOL_SHORT_NAME || 'School Clubs',
   tagline:
@@ -7,4 +12,5 @@ export const schoolTemplate = {
   intro:
     import.meta.env.VITE_SCHOOL_INTRO ||
     'Browse active clubs, discover meeting times, and start membership workflows from a simple school-owned directory.',
+  defaultColorMode: (configuredColorMode === 'dark' ? 'dark' : 'light') as ColorMode,
 }

--- a/frontend/src/utils/avatarImages.ts
+++ b/frontend/src/utils/avatarImages.ts
@@ -1,4 +1,5 @@
 import { buildApiUrl } from '../services/httpClient'
+import { schoolTemplate } from '../config/schoolTemplate'
 
 const palette = [
   ['#0f766e', '#67e8f9'],
@@ -18,27 +19,21 @@ const hashSeed = (seed: string) => {
 }
 
 const escapeXml = (value: string) =>
-  value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
+  value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
 
 const initialsFor = (seed: string) => {
-  const words = seed
-    .trim()
-    .split(/\s+/)
-    .filter(Boolean)
-  const initials = words.length > 1
-    ? `${words[0]?.[0] ?? ''}${words[1]?.[0] ?? ''}`
-    : seed.trim().slice(0, 2)
+  const words = seed.trim().split(/\s+/).filter(Boolean)
+  const initials =
+    words.length > 1 ? `${words[0]?.[0] ?? ''}${words[1]?.[0] ?? ''}` : seed.trim().slice(0, 2)
   return escapeXml((initials || 'HC').toUpperCase())
 }
 
 export const localAvatar = (seed: string) => {
-  const normalizedSeed = seed.trim() || 'HS Clubs'
-  const [background, foreground] =
-    palette[hashSeed(normalizedSeed) % palette.length] ?? ['#0f766e', '#67e8f9']
+  const normalizedSeed = seed.trim() || schoolTemplate.brandName
+  const [background, foreground] = palette[hashSeed(normalizedSeed) % palette.length] ?? [
+    '#0f766e',
+    '#67e8f9',
+  ]
   const initials = initialsFor(normalizedSeed)
   const svg = `
 <svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160">

--- a/frontend/src/utils/clubRecommendations.spec.ts
+++ b/frontend/src/utils/clubRecommendations.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Club } from '../types/club'
+import { selectWeightedClubRecommendations } from './clubRecommendations'
+
+const makeClub = (id: number, category: string, memberCount = 0): Club => ({
+  id,
+  name: `Club ${id}`,
+  aliasName: null,
+  description: '',
+  category,
+  meetingSchedule: '',
+  location: null,
+  contactEmail: null,
+  advisor: null,
+  imageUrl: null,
+  memberCount,
+  achievements: [],
+})
+
+describe('selectWeightedClubRecommendations', () => {
+  it('allocates recommendations in proportion to category scores', () => {
+    const clubs = [
+      ...Array.from({ length: 12 }, (_, index) => makeClub(index + 1, 'Primary')),
+      ...Array.from({ length: 12 }, (_, index) => makeClub(index + 101, 'Secondary')),
+    ]
+
+    const recommendations = selectWeightedClubRecommendations(
+      clubs,
+      [
+        { title: 'Primary', score: 12 },
+        { title: 'Secondary', score: 4 },
+      ],
+      12,
+    )
+
+    expect(recommendations.filter((club) => club.category === 'Primary')).toHaveLength(9)
+    expect(recommendations.filter((club) => club.category === 'Secondary')).toHaveLength(3)
+  })
+
+  it('excludes categories with a zero score', () => {
+    const recommendations = selectWeightedClubRecommendations(
+      [makeClub(1, 'Matched'), makeClub(2, 'Unmatched')],
+      [
+        { title: 'Matched', score: 3 },
+        { title: 'Unmatched', score: 0 },
+      ],
+    )
+
+    expect(recommendations.map((club) => club.category)).toEqual(['Matched'])
+  })
+
+  it('uses lower-ranked categories when a stronger match runs out of clubs', () => {
+    const recommendations = selectWeightedClubRecommendations(
+      [makeClub(1, 'Primary'), makeClub(2, 'Secondary'), makeClub(3, 'Secondary')],
+      [
+        { title: 'Primary', score: 6 },
+        { title: 'Secondary', score: 2 },
+      ],
+      3,
+    )
+
+    expect(recommendations).toHaveLength(3)
+    expect(recommendations.filter((club) => club.category === 'Secondary')).toHaveLength(2)
+  })
+})

--- a/frontend/src/utils/clubRecommendations.ts
+++ b/frontend/src/utils/clubRecommendations.ts
@@ -20,7 +20,7 @@ export const selectWeightedClubRecommendations = (
         .sort((a, b) => {
           const memberDelta = (b.memberCount ?? 0) - (a.memberCount ?? 0)
           return memberDelta !== 0 ? memberDelta : a.name.localeCompare(b.name)
-      }),
+        }),
       nextIndex: 0,
     }))
   const matches: Club[] = []

--- a/frontend/src/utils/clubRecommendations.ts
+++ b/frontend/src/utils/clubRecommendations.ts
@@ -20,9 +20,8 @@ export const selectWeightedClubRecommendations = (
         .sort((a, b) => {
           const memberDelta = (b.memberCount ?? 0) - (a.memberCount ?? 0)
           return memberDelta !== 0 ? memberDelta : a.name.localeCompare(b.name)
-        }),
+      }),
       nextIndex: 0,
-      selectedCount: 0,
     }))
   const matches: Club[] = []
 
@@ -31,14 +30,13 @@ export const selectWeightedClubRecommendations = (
     if (!availableQueues.length) break
 
     availableQueues.sort((a, b) => {
-      const allocationDelta = a.selectedCount / a.score - b.selectedCount / b.score
+      const allocationDelta = a.nextIndex / a.score - b.nextIndex / b.score
       return allocationDelta || a.rank - b.rank
     })
 
     const queue = availableQueues[0]!
     matches.push(queue.clubs[queue.nextIndex]!)
     queue.nextIndex++
-    queue.selectedCount++
   }
 
   return matches

--- a/frontend/src/utils/clubRecommendations.ts
+++ b/frontend/src/utils/clubRecommendations.ts
@@ -1,0 +1,45 @@
+import type { Club } from '../types/club'
+
+export type ScoredCategory = {
+  title: string
+  score: number
+}
+
+export const selectWeightedClubRecommendations = (
+  clubs: Club[],
+  categories: ScoredCategory[],
+  limit = 12,
+) => {
+  const categoryQueues = categories
+    .filter((category) => category.score > 0)
+    .map((category, rank) => ({
+      score: category.score,
+      rank,
+      clubs: clubs
+        .filter((club) => club.category === category.title)
+        .sort((a, b) => {
+          const memberDelta = (b.memberCount ?? 0) - (a.memberCount ?? 0)
+          return memberDelta !== 0 ? memberDelta : a.name.localeCompare(b.name)
+        }),
+      nextIndex: 0,
+      selectedCount: 0,
+    }))
+  const matches: Club[] = []
+
+  while (matches.length < limit) {
+    const availableQueues = categoryQueues.filter((queue) => queue.clubs[queue.nextIndex])
+    if (!availableQueues.length) break
+
+    availableQueues.sort((a, b) => {
+      const allocationDelta = a.selectedCount / a.score - b.selectedCount / b.score
+      return allocationDelta || a.rank - b.rank
+    })
+
+    const queue = availableQueues[0]!
+    matches.push(queue.clubs[queue.nextIndex]!)
+    queue.nextIndex++
+    queue.selectedCount++
+  }
+
+  return matches
+}

--- a/frontend/src/views/AboutView.vue
+++ b/frontend/src/views/AboutView.vue
@@ -78,16 +78,6 @@ const activeCategory = computed(
         </button>
       </div>
 
-      <article v-if="activeCategory" class="category-panel">
-        <div class="panel-hero" :style="{ background: activeCategory.gradient }">
-          <span class="panel-icon">{{ activeCategory.icon }}</span>
-          <p class="panel-count">{{ activeCategory.clubCount }} clubs in this category</p>
-          <h2>{{ activeCategory.title }}</h2>
-          <p>{{ activeCategory.description }}</p>
-          <span class="panel-focus">{{ activeCategory.focus }}</span>
-        </div>
-      </article>
-
       <section v-if="activeCategory" class="category-clubs">
         <header class="clubs-header">
           <div>
@@ -180,42 +170,6 @@ const activeCategory = computed(
   background: var(--mv-surface-accent);
   border-color: var(--mv-border-strong);
   color: var(--mv-gold);
-}
-
-.category-panel {
-  border-radius: 32px;
-  border: 1px solid var(--mv-border);
-  overflow: hidden;
-  background: var(--mv-surface-card-strong);
-  box-shadow: var(--mv-shadow-elevated);
-}
-
-.panel-hero {
-  padding: clamp(1.5rem, 4vw, 2.8rem);
-  color: #f8fafc;
-  display: flex;
-  flex-direction: column;
-  gap: 0.55rem;
-}
-
-.panel-icon {
-  font-size: 2rem;
-}
-
-.panel-count {
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 0.85rem;
-  color: rgba(255, 253, 247, 0.9);
-}
-
-.panel-focus {
-  width: fit-content;
-  margin-top: 0.35rem;
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.18);
 }
 
 .category-clubs {
@@ -347,10 +301,6 @@ const activeCategory = computed(
 }
 
 @media (max-width: 640px) {
-  .category-panel {
-    border-radius: 24px;
-  }
-
   .category-pill {
     width: 100%;
     justify-content: space-between;
@@ -368,27 +318,10 @@ const activeCategory = computed(
     border-radius: 18px;
   }
 
-  .panel-hero {
-    padding: 1.35rem;
-  }
-
-  .category-panel {
-    border-radius: 20px;
-  }
-
   .clubs-header {
     flex-direction: column;
     align-items: flex-start;
   }
 }
 
-@media (max-width: 480px) {
-  .panel-hero {
-    padding: 1.1rem;
-  }
-
-  .panel-icon {
-    font-size: 1.6rem;
-  }
-}
 </style>

--- a/frontend/src/views/AboutView.vue
+++ b/frontend/src/views/AboutView.vue
@@ -68,7 +68,7 @@ const activeCategory = computed(
 
     <template v-else>
       <RouterLink to="/recommendations" class="quiz-link">
-        <span>Start quiz</span>
+        <span>Get your interest club</span>
         <span aria-hidden="true">→</span>
       </RouterLink>
 
@@ -157,10 +157,11 @@ const activeCategory = computed(
 .quiz-link {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
+  position: relative;
   width: 100%;
-  min-height: 72px;
-  padding: 1rem clamp(1.25rem, 3vw, 2rem);
+  min-height: 144px;
+  padding: 2rem clamp(3.5rem, 6vw, 5rem);
   border: 1px solid var(--mv-primary-bg);
   border-radius: 22px;
   background: var(--mv-primary-bg);
@@ -184,6 +185,8 @@ const activeCategory = computed(
 }
 
 .quiz-link span:last-child {
+  position: absolute;
+  right: clamp(1.25rem, 3vw, 2rem);
   font-size: 1.5rem;
 }
 

--- a/frontend/src/views/AboutView.vue
+++ b/frontend/src/views/AboutView.vue
@@ -67,16 +67,10 @@ const activeCategory = computed(
     <section v-else-if="error" class="status-card error">{{ error }}</section>
 
     <template v-else>
-      <section class="quiz-callout">
-        <div>
-          <p class="section-label">Not sure where to start?</p>
-          <h2>Find your club match</h2>
-          <p>
-            Answer four quick questions to discover categories and clubs that fit your interests.
-          </p>
-        </div>
-        <RouterLink to="/recommendations" class="quiz-link">Start quiz</RouterLink>
-      </section>
+      <RouterLink to="/recommendations" class="quiz-link">
+        <span>Start quiz</span>
+        <span aria-hidden="true">→</span>
+      </RouterLink>
 
       <div class="category-picker">
         <button
@@ -160,39 +154,37 @@ const activeCategory = computed(
   color: var(--mv-status-danger);
 }
 
-.quiz-callout {
+.quiz-link {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1.5rem;
-  padding: clamp(1.25rem, 3vw, 2rem);
-  border: 1px solid var(--mv-border-strong);
-  border-radius: 26px;
-  background: var(--mv-surface-accent);
-  box-shadow: var(--mv-shadow-card);
-}
-
-.quiz-callout h2 {
-  margin: 0.55rem 0 0.35rem;
-}
-
-.quiz-callout > div > p:last-child {
-  max-width: 650px;
-  color: var(--mv-text-muted);
-}
-
-.quiz-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 130px;
-  min-height: 46px;
-  padding: 0.7rem 1.15rem;
+  width: 100%;
+  min-height: 72px;
+  padding: 1rem clamp(1.25rem, 3vw, 2rem);
   border: 1px solid var(--mv-primary-bg);
-  border-radius: 999px;
+  border-radius: 22px;
   background: var(--mv-primary-bg);
   color: var(--mv-primary-text);
+  box-shadow: var(--mv-primary-shadow);
+  font-size: clamp(1rem, 2vw, 1.2rem);
   font-weight: 700;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.quiz-link:hover,
+.quiz-link:focus-visible {
+  transform: translateY(-2px);
+}
+
+.quiz-link:focus-visible {
+  outline: 3px solid var(--mv-gold);
+  outline-offset: 3px;
+}
+
+.quiz-link span:last-child {
+  font-size: 1.5rem;
 }
 
 .category-picker {
@@ -358,15 +350,6 @@ const activeCategory = computed(
 }
 
 @media (max-width: 640px) {
-  .quiz-callout {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-
-  .quiz-link {
-    width: 100%;
-  }
-
   .category-pill {
     width: 100%;
     justify-content: space-between;

--- a/frontend/src/views/AboutView.vue
+++ b/frontend/src/views/AboutView.vue
@@ -63,14 +63,6 @@ const activeCategory = computed(
     <section v-else-if="error" class="status-card error">{{ error }}</section>
 
     <template v-else>
-      <section class="overview-grid">
-        <article v-for="category in categories" :key="category.title" class="overview-card">
-          <span class="overview-icon">{{ category.icon }}</span>
-          <strong>{{ category.clubCount }}</strong>
-          <span>{{ category.title }}</span>
-        </article>
-      </section>
-
       <div class="category-picker">
         <button
           v-for="category in categories"
@@ -156,32 +148,6 @@ const activeCategory = computed(
 .status-card.error {
   border-color: rgba(239, 68, 68, 0.35);
   color: var(--mv-status-danger);
-}
-
-.overview-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 1rem;
-}
-
-.overview-card {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  padding: 1.05rem 1.2rem;
-  border-radius: 22px;
-  border: 1px solid var(--mv-border);
-  background: var(--mv-surface-card);
-  box-shadow: var(--mv-shadow-card);
-}
-
-.overview-card strong {
-  font-size: 1.8rem;
-  color: var(--mv-gold);
-}
-
-.overview-icon {
-  font-size: 1.2rem;
 }
 
 .category-picker {
@@ -392,20 +358,6 @@ const activeCategory = computed(
 }
 
 @media (max-width: 720px) {
-  .overview-grid {
-    grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
-    gap: 0.75rem;
-  }
-
-  .overview-card {
-    padding: 0.85rem 0.9rem;
-    border-radius: 18px;
-  }
-
-  .overview-card strong {
-    font-size: 1.3rem;
-  }
-
   .top-grid {
     grid-template-columns: 1fr;
     gap: 0.85rem;
@@ -431,10 +383,6 @@ const activeCategory = computed(
 }
 
 @media (max-width: 480px) {
-  .overview-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
   .panel-hero {
     padding: 1.1rem;
   }

--- a/frontend/src/views/AboutView.vue
+++ b/frontend/src/views/AboutView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
-import { RouterLink, useRoute } from 'vue-router'
+import { RouterLink } from 'vue-router'
 
 import { fetchAllClubs } from '../services/clubService'
 import type { Club } from '../types/club'
@@ -11,7 +11,6 @@ const clubs = ref<Club[]>([])
 const loading = ref(true)
 const error = ref('')
 
-const route = useRoute()
 const selectedCategoryTitle = ref(clubCategoryOptions[0]?.title ?? '')
 
 const loadClubs = async () => {
@@ -40,12 +39,16 @@ const categories = computed(() =>
     return {
       ...category,
       clubCount: categoryClubs.length,
-      clubs: categoryClubs}
+      clubs: categoryClubs,
+    }
   }),
 )
 
 const activeCategory = computed(
-  () => categories.value.find((category) => category.title === selectedCategoryTitle.value) ?? categories.value[0] ?? null,
+  () =>
+    categories.value.find((category) => category.title === selectedCategoryTitle.value) ??
+    categories.value[0] ??
+    null,
 )
 </script>
 
@@ -55,7 +58,8 @@ const activeCategory = computed(
       <p class="section-label">Explore</p>
       <h1>Browse clubs by category</h1>
       <p>
-        Clubs are grouped by their saved category, and club admins can now maintain that type directly from the admin page.
+        Clubs are grouped by their saved category, and club admins can now maintain that type
+        directly from the admin page.
       </p>
     </header>
 
@@ -63,6 +67,17 @@ const activeCategory = computed(
     <section v-else-if="error" class="status-card error">{{ error }}</section>
 
     <template v-else>
+      <section class="quiz-callout">
+        <div>
+          <p class="section-label">Not sure where to start?</p>
+          <h2>Find your club match</h2>
+          <p>
+            Answer four quick questions to discover categories and clubs that fit your interests.
+          </p>
+        </div>
+        <RouterLink to="/recommendations" class="quiz-link">Start quiz</RouterLink>
+      </section>
+
       <div class="category-picker">
         <button
           v-for="category in categories"
@@ -91,7 +106,12 @@ const activeCategory = computed(
           <article v-if="!activeCategory.clubs.length" class="empty-card">
             <p>No clubs have been assigned to {{ activeCategory.title }} yet.</p>
           </article>
-          <RouterLink v-for="club in activeCategory.clubs" :key="club.id" class="top-card" :to="`/clubs/${club.id}`">
+          <RouterLink
+            v-for="club in activeCategory.clubs"
+            :key="club.id"
+            class="top-card"
+            :to="`/clubs/${club.id}`"
+          >
             <div class="club-avatar large">
               <img :src="clubImage(club)" :alt="`${club.name} avatar`" loading="lazy" />
             </div>
@@ -138,6 +158,41 @@ const activeCategory = computed(
 .status-card.error {
   border-color: rgba(239, 68, 68, 0.35);
   color: var(--mv-status-danger);
+}
+
+.quiz-callout {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: clamp(1.25rem, 3vw, 2rem);
+  border: 1px solid var(--mv-border-strong);
+  border-radius: 26px;
+  background: var(--mv-surface-accent);
+  box-shadow: var(--mv-shadow-card);
+}
+
+.quiz-callout h2 {
+  margin: 0.55rem 0 0.35rem;
+}
+
+.quiz-callout > div > p:last-child {
+  max-width: 650px;
+  color: var(--mv-text-muted);
+}
+
+.quiz-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 130px;
+  min-height: 46px;
+  padding: 0.7rem 1.15rem;
+  border: 1px solid var(--mv-primary-bg);
+  border-radius: 999px;
+  background: var(--mv-primary-bg);
+  color: var(--mv-primary-text);
+  font-weight: 700;
 }
 
 .category-picker {
@@ -212,7 +267,9 @@ const activeCategory = computed(
   color: inherit;
   text-decoration: none;
   cursor: pointer;
-  transition: border-color 0.2s ease, transform 0.2s ease;
+  transition:
+    border-color 0.2s ease,
+    transform 0.2s ease;
   content-visibility: auto;
   contain-intrinsic-size: 320px;
 }
@@ -301,6 +358,15 @@ const activeCategory = computed(
 }
 
 @media (max-width: 640px) {
+  .quiz-callout {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .quiz-link {
+    width: 100%;
+  }
+
   .category-pill {
     width: 100%;
     justify-content: space-between;
@@ -323,5 +389,4 @@ const activeCategory = computed(
     align-items: flex-start;
   }
 }
-
 </style>

--- a/frontend/src/views/AcceptTermsView.vue
+++ b/frontend/src/views/AcceptTermsView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { schoolTemplate } from '../config/schoolTemplate'
 import { useAuthStore } from '../stores/auth'
 import { buildApiUrl } from '../services/httpClient'
 import { normalizeAuthRedirect } from '../utils/authRedirect'
@@ -8,6 +9,7 @@ import { normalizeAuthRedirect } from '../utils/authRedirect'
 const route = useRoute()
 const router = useRouter()
 const authStore = useAuthStore()
+const brandName = schoolTemplate.brandName
 const agreed = ref(false)
 const loading = ref(false)
 const error = ref('')
@@ -41,7 +43,7 @@ const handleAccept = async () => {
     <header class="terms-hero">
       <p class="section-label">Welcome</p>
       <h1>Before you continue</h1>
-      <p>Please review and accept our terms to start using HS Clubs.</p>
+      <p>Please review and accept our terms to start using {{ brandName }}.</p>
     </header>
 
     <div class="terms-summary">
@@ -60,7 +62,7 @@ const handleAccept = async () => {
         <h2>Privacy Policy</h2>
         <ul>
           <li>We collect your name, email, and profile picture via Google</li>
-          <li>Your data stays within the HS Clubs platform</li>
+          <li>Your data stays within the {{ brandName }} platform</li>
           <li>We do not sell or share your personal information</li>
           <li>You can request account deletion anytime</li>
         </ul>
@@ -77,7 +79,7 @@ const handleAccept = async () => {
       <p v-if="error" class="form-error">{{ error }}</p>
 
       <button type="submit" class="btn primary" :disabled="!agreed || loading">
-        {{ loading ? 'Saving…' : 'Continue to HS Clubs' }}
+        {{ loading ? 'Saving…' : `Continue to ${brandName}` }}
       </button>
     </form>
   </div>

--- a/frontend/src/views/AuthChoiceView.vue
+++ b/frontend/src/views/AuthChoiceView.vue
@@ -3,11 +3,13 @@ import { computed, onMounted, ref } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
 import { storeToRefs } from 'pinia'
 
+import { schoolTemplate } from '../config/schoolTemplate'
 import { useAuthStore } from '../stores/auth'
 import BackButton from '../components/BackButton.vue'
 
 const route = useRoute()
 const authStore = useAuthStore()
+const brandName = schoolTemplate.brandName
 const { providers, providersLoading, providersError } = storeToRefs(authStore)
 const acceptedTerms = ref(false)
 const termsError = ref('')
@@ -16,10 +18,14 @@ onMounted(() => {
   authStore.ensureProvidersLoaded()
 })
 
-const intentLabel = computed(() => (route.query.intent === 'register' ? 'Create account' : 'Sign in'))
+const intentLabel = computed(() =>
+  route.query.intent === 'register' ? 'Create account' : 'Sign in',
+)
 
 const routeError = computed(() => {
-  return typeof route.query.error === 'string' ? 'We could not complete your sign in. Please try again.' : ''
+  return typeof route.query.error === 'string'
+    ? 'We could not complete your sign in. Please try again.'
+    : ''
 })
 
 const redirectTarget = computed(() => {
@@ -43,8 +49,8 @@ const handleProviderLogin = (providerId: string) => {
       <p class="page-label">{{ intentLabel }}</p>
       <h1>Continue with your school account</h1>
       <p class="description">
-        Use OAuth2 to sign in safely with your school-provided Google account. We only request basic profile details so you can
-        access HS Clubs across devices.
+        Use OAuth2 to sign in safely with your school-provided Google account. We only request basic
+        profile details so you can access {{ brandName }} across devices.
       </p>
       <div class="alerts">
         <p v-if="routeError" class="alert error">{{ routeError }}</p>
@@ -73,7 +79,9 @@ const handleProviderLogin = (providerId: string) => {
           <span class="provider-icon" aria-hidden="true">{{ provider.name.charAt(0) }}</span>
           Sign in with {{ provider.name }}
         </button>
-        <p v-if="providers.length === 0" class="alert muted">No OAuth providers are configured yet.</p>
+        <p v-if="providers.length === 0" class="alert muted">
+          No OAuth providers are configured yet.
+        </p>
       </div>
       <BackButton>Back to club catalog</BackButton>
     </div>
@@ -89,8 +97,7 @@ const handleProviderLogin = (providerId: string) => {
   padding: 2rem;
   background:
     radial-gradient(circle at 20% 20%, var(--mv-gold-soft), transparent 55%),
-    radial-gradient(circle at 80% 0%, var(--mv-surface-accent), transparent 60%),
-    var(--app-body-bg);
+    radial-gradient(circle at 80% 0%, var(--mv-surface-accent), transparent 60%), var(--app-body-bg);
   color: var(--mv-text);
 }
 
@@ -149,7 +156,9 @@ const handleProviderLogin = (providerId: string) => {
   color: var(--mv-text);
   background: var(--mv-surface-card-strong);
   box-shadow: var(--mv-shadow-card);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .provider-btn:hover {
@@ -195,7 +204,13 @@ const handleProviderLogin = (providerId: string) => {
   justify-content: center;
   font-weight: 700;
   color: #ea4335;
-  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family:
+    'Inter',
+    'Segoe UI',
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
 }
 
 .alerts {

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { schoolTemplate } from '../config/schoolTemplate'
 import { useAuthStore } from '../stores/auth'
 import { updateGraduationYear } from '../services/userService'
 import { normalizeAuthRedirect } from '../utils/authRedirect'
@@ -8,6 +9,7 @@ import { normalizeAuthRedirect } from '../utils/authRedirect'
 const route = useRoute()
 const router = useRouter()
 const authStore = useAuthStore()
+const brandName = schoolTemplate.brandName
 
 const saving = ref(false)
 const error = ref('')
@@ -60,7 +62,7 @@ const handleSkip = () => {
 <template>
   <div class="onboarding-page">
     <div class="onboarding-card">
-      <h1>Welcome to HS Clubs!</h1>
+      <h1>Welcome to {{ brandName }}!</h1>
       <p class="subtitle">Set up your profile to get the most out of the club directory.</p>
 
       <form @submit.prevent="handleSave" class="onboarding-form">
@@ -203,7 +205,11 @@ legend {
   font: inherit;
   font-weight: 700;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, opacity 0.2s ease;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease,
+    opacity 0.2s ease;
 }
 
 .ghost-btn {

--- a/frontend/src/views/PrivacyPolicyView.vue
+++ b/frontend/src/views/PrivacyPolicyView.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import { schoolTemplate } from '../config/schoolTemplate'
+
+const brandName = schoolTemplate.brandName
 </script>
 
 <template>
@@ -27,7 +30,7 @@
       <h2>3. Data Sharing</h2>
       <p>
         We do not sell or share your personal information with third parties. Your data stays within
-        the HS Clubs platform and your school's instance.
+        the {{ brandName }} platform and your school's instance.
       </p>
 
       <h2>4. Data Retention</h2>
@@ -44,14 +47,14 @@
 
       <h2>6. Children's Privacy</h2>
       <p>
-        The Platform is designed for high school students. We comply with applicable student
-        data privacy laws. Parents or guardians with concerns may contact the platform administrator.
+        The Platform is designed for high school students. We comply with applicable student data
+        privacy laws. Parents or guardians with concerns may contact the platform administrator.
       </p>
 
       <h2>7. Contact</h2>
       <p>
-        For privacy-related questions, contact the platform administrator through your school's
-        club directory page.
+        For privacy-related questions, contact the platform administrator through your school's club
+        directory page.
       </p>
     </section>
   </div>

--- a/frontend/src/views/RecommendationView.spec.ts
+++ b/frontend/src/views/RecommendationView.spec.ts
@@ -1,0 +1,43 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import RecommendationView from './RecommendationView.vue'
+
+vi.mock('../services/clubService', () => ({
+  fetchAllClubs: vi.fn().mockResolvedValue([]),
+}))
+
+describe('RecommendationView', () => {
+  beforeEach(() => {
+    vi.stubGlobal('scrollTo', vi.fn())
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.unstubAllGlobals()
+  })
+
+  it('moves focus to each new question and then to the results heading', async () => {
+    const wrapper = mount(RecommendationView, {
+      attachTo: document.body,
+      global: {
+        stubs: { RouterLink: true },
+      },
+    })
+    await flushPromises()
+
+    for (let questionIndex = 0; questionIndex < 4; questionIndex++) {
+      await wrapper.find<HTMLInputElement>('.answer-input').setValue(true)
+      await wrapper.find<HTMLButtonElement>('.primary-button').trigger('click')
+      await flushPromises()
+
+      const expectedHeading =
+        questionIndex < 3
+          ? wrapper.find<HTMLElement>('#quiz-question').element
+          : wrapper.find<HTMLElement>('.results-header h1').element
+      expect(document.activeElement).toBe(expectedHeading)
+    }
+
+    wrapper.unmount()
+  })
+})

--- a/frontend/src/views/RecommendationView.vue
+++ b/frontend/src/views/RecommendationView.vue
@@ -725,6 +725,22 @@ onMounted(loadClubs)
   color: var(--mv-status-danger);
 }
 
+@media (min-width: 761px) {
+  .quiz-header,
+  .quiz-card {
+    align-self: center;
+  }
+
+  .quiz-header {
+    width: min(900px, 100%);
+    text-align: center;
+  }
+
+  .quiz-header > p:last-child {
+    margin-inline: auto;
+  }
+}
+
 @media (max-width: 760px) {
   .answer-grid,
   .match-summary {

--- a/frontend/src/views/RecommendationView.vue
+++ b/frontend/src/views/RecommendationView.vue
@@ -6,6 +6,7 @@ import { fetchAllClubs } from '../services/clubService'
 import type { Club } from '../types/club'
 import { clubCategoryOptions } from '../utils/clubCategories'
 import { clubImage } from '../utils/clubImages'
+import { selectWeightedClubRecommendations } from '../utils/clubRecommendations'
 
 type QuizOption = {
   label: string
@@ -197,35 +198,12 @@ const rankedCategories = computed(() => {
     .sort((a, b) => b.score - a.score || a.index - b.index)
 })
 
-const topCategories = computed(() => rankedCategories.value.slice(0, 3))
-const recommendedClubs = computed(() => {
-  const categoryQueues = topCategories.value.map((category) => ({
-    title: category.title,
-    clubs: clubs.value
-      .filter((club) => club.category === category.title)
-      .sort((a, b) => {
-        const memberDelta = (b.memberCount ?? 0) - (a.memberCount ?? 0)
-        return memberDelta !== 0 ? memberDelta : a.name.localeCompare(b.name)
-      }),
-    nextIndex: 0,
-  }))
-  const matches: Club[] = []
-
-  while (matches.length < 12) {
-    let addedClub = false
-    categoryQueues.forEach((queue) => {
-      const club = queue.clubs[queue.nextIndex]
-      if (club && matches.length < 12) {
-        matches.push(club)
-        queue.nextIndex++
-        addedClub = true
-      }
-    })
-    if (!addedClub) break
-  }
-
-  return matches
-})
+const topCategories = computed(() =>
+  rankedCategories.value.filter((category) => category.score > 0).slice(0, 3),
+)
+const recommendedClubs = computed(() =>
+  selectWeightedClubRecommendations(clubs.value, topCategories.value),
+)
 
 const loadClubs = async () => {
   loading.value = true

--- a/frontend/src/views/RecommendationView.vue
+++ b/frontend/src/views/RecommendationView.vue
@@ -1,157 +1,737 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { RouterLink } from 'vue-router'
-import { useAuthStore } from '../stores/auth'
-import { storeToRefs } from 'pinia'
-import type { Club } from '../types/club'
-import { clubImage } from '../utils/clubImages'
-import { buildApiUrl } from '../services/httpClient'
 
-const authStore = useAuthStore()
-const { isAuthenticated } = storeToRefs(authStore)
+import { fetchAllClubs } from '../services/clubService'
+import type { Club } from '../types/club'
+import { clubCategoryOptions } from '../utils/clubCategories'
+import { clubImage } from '../utils/clubImages'
+
+type QuizOption = {
+  label: string
+  description: string
+  scores: Record<string, number>
+}
+
+type QuizQuestion = {
+  prompt: string
+  helper: string
+  options: QuizOption[]
+}
+
+const questions: QuizQuestion[] = [
+  {
+    prompt: 'Which activity sounds most exciting?',
+    helper: 'Choose the option you would be happiest to spend an afternoon doing.',
+    options: [
+      {
+        label: 'Build and experiment',
+        description: 'Code, engineer, research, or solve a technical problem.',
+        scores: { 'STEM & Innovation': 3, 'Competition & Strategy': 1 },
+      },
+      {
+        label: 'Create and perform',
+        description: 'Make art, music, writing, film, or live performances.',
+        scores: { 'Creative Arts & Media': 3, 'Culture & Identity': 1 },
+      },
+      {
+        label: 'Serve and lead',
+        description: 'Support a cause, organize people, or improve the community.',
+        scores: { 'Service & Leadership': 3, 'Culture & Identity': 1 },
+      },
+      {
+        label: 'Move and recharge',
+        description: 'Play a sport, stay active, or support personal wellbeing.',
+        scores: { 'Wellness & Athletics': 3, 'Competition & Strategy': 1 },
+      },
+      {
+        label: 'Compete and strategize',
+        description: 'Debate, play games, or prepare for an academic competition.',
+        scores: { 'Competition & Strategy': 3, 'STEM & Innovation': 1 },
+      },
+      {
+        label: 'Connect through identity',
+        description: 'Share traditions, languages, experiences, and community.',
+        scores: { 'Culture & Identity': 3, 'Service & Leadership': 1 },
+      },
+    ],
+  },
+  {
+    prompt: 'What do you most want from a club?',
+    helper: 'Think about what would make the experience worthwhile for you.',
+    options: [
+      {
+        label: 'Practical skills',
+        description: 'Learn tools and techniques I can use in future projects.',
+        scores: { 'STEM & Innovation': 3, 'Creative Arts & Media': 1 },
+      },
+      {
+        label: 'A creative outlet',
+        description: 'Express ideas and make something I am proud to share.',
+        scores: { 'Creative Arts & Media': 3, 'Culture & Identity': 1 },
+      },
+      {
+        label: 'Meaningful impact',
+        description: 'Help others and make a visible difference at school or beyond.',
+        scores: { 'Service & Leadership': 3, 'Culture & Identity': 1 },
+      },
+      {
+        label: 'Belonging and connection',
+        description: 'Meet people who share my background, interests, or experiences.',
+        scores: { 'Culture & Identity': 3, 'Service & Leadership': 1 },
+      },
+      {
+        label: 'Healthy balance',
+        description: 'Reduce stress, move more, and make time for wellbeing.',
+        scores: { 'Wellness & Athletics': 3, 'Culture & Identity': 1 },
+      },
+      {
+        label: 'A challenge',
+        description: 'Test myself, improve through practice, and work toward a goal.',
+        scores: { 'Competition & Strategy': 3, 'STEM & Innovation': 1 },
+      },
+    ],
+  },
+  {
+    prompt: 'Which club environment fits you best?',
+    helper:
+      'There is no wrong answer. Pick the setting where you would feel comfortable participating.',
+    options: [
+      {
+        label: 'A focused workshop',
+        description: 'We learn by testing ideas and improving a project together.',
+        scores: { 'STEM & Innovation': 3, 'Creative Arts & Media': 1 },
+      },
+      {
+        label: 'An open studio',
+        description: 'Everyone brings a perspective and experiments with new forms.',
+        scores: { 'Creative Arts & Media': 3, 'Culture & Identity': 1 },
+      },
+      {
+        label: 'A community team',
+        description: 'We organize, collaborate, and take action around shared goals.',
+        scores: { 'Service & Leadership': 3, 'Culture & Identity': 1 },
+      },
+      {
+        label: 'A welcoming social space',
+        description: 'Conversation and shared experiences help people feel included.',
+        scores: { 'Culture & Identity': 3, 'Service & Leadership': 1 },
+      },
+      {
+        label: 'An active practice',
+        description: 'We learn by moving, training, and encouraging one another.',
+        scores: { 'Wellness & Athletics': 3, 'Competition & Strategy': 1 },
+      },
+      {
+        label: 'A prepared team',
+        description: 'We practice with purpose and enjoy measuring our progress.',
+        scores: { 'Competition & Strategy': 3, 'Wellness & Athletics': 1 },
+      },
+    ],
+  },
+  {
+    prompt: 'How would you like to contribute?',
+    helper: 'Choose the role you would be most likely to take once you feel settled in.',
+    options: [
+      {
+        label: 'Solve the hard problem',
+        description: 'Research options, understand the details, and find a working answer.',
+        scores: { 'STEM & Innovation': 3, 'Competition & Strategy': 1 },
+      },
+      {
+        label: 'Shape the story',
+        description: 'Design, write, perform, or help an idea connect with an audience.',
+        scores: { 'Creative Arts & Media': 3, 'Culture & Identity': 1 },
+      },
+      {
+        label: 'Bring people together',
+        description: 'Plan events, welcome members, and help the group move forward.',
+        scores: { 'Service & Leadership': 3, 'Culture & Identity': 1 },
+      },
+      {
+        label: 'Share my perspective',
+        description: 'Start conversations and help others understand different experiences.',
+        scores: { 'Culture & Identity': 3, 'Service & Leadership': 1 },
+      },
+      {
+        label: 'Keep the team motivated',
+        description: 'Show up consistently, encourage others, and build healthy habits.',
+        scores: { 'Wellness & Athletics': 3, 'Service & Leadership': 1 },
+      },
+      {
+        label: 'Prepare the strategy',
+        description: 'Study the challenge, practice, and help the team perform its best.',
+        scores: { 'Competition & Strategy': 3, 'STEM & Innovation': 1 },
+      },
+    ],
+  },
+]
 
 const clubs = ref<Club[]>([])
 const loading = ref(true)
 const error = ref('')
+const currentQuestionIndex = ref(0)
+const answers = ref<(number | null)[]>(questions.map(() => null))
+const showResults = ref(false)
 
-const loadRecommendations = async () => {
+const currentQuestion = computed(() => questions[currentQuestionIndex.value]!)
+const selectedOptionIndex = computed(() => answers.value[currentQuestionIndex.value])
+const progress = computed(() => ((currentQuestionIndex.value + 1) / questions.length) * 100)
+
+const rankedCategories = computed(() => {
+  const scores = new Map(clubCategoryOptions.map((category) => [category.title, 0]))
+
+  answers.value.forEach((answer, questionIndex) => {
+    if (answer === null) return
+    const option = questions[questionIndex]?.options[answer]
+    Object.entries(option?.scores ?? {}).forEach(([category, score]) => {
+      scores.set(category, (scores.get(category) ?? 0) + score)
+    })
+  })
+
+  return clubCategoryOptions
+    .map((category, index) => ({ ...category, score: scores.get(category.title) ?? 0, index }))
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+})
+
+const topCategories = computed(() => rankedCategories.value.slice(0, 3))
+const recommendedClubs = computed(() => {
+  const categoryQueues = topCategories.value.map((category) => ({
+    title: category.title,
+    clubs: clubs.value
+      .filter((club) => club.category === category.title)
+      .sort((a, b) => {
+        const memberDelta = (b.memberCount ?? 0) - (a.memberCount ?? 0)
+        return memberDelta !== 0 ? memberDelta : a.name.localeCompare(b.name)
+      }),
+    nextIndex: 0,
+  }))
+  const matches: Club[] = []
+
+  while (matches.length < 12) {
+    let addedClub = false
+    categoryQueues.forEach((queue) => {
+      const club = queue.clubs[queue.nextIndex]
+      if (club && matches.length < 12) {
+        matches.push(club)
+        queue.nextIndex++
+        addedClub = true
+      }
+    })
+    if (!addedClub) break
+  }
+
+  return matches
+})
+
+const loadClubs = async () => {
   loading.value = true
   error.value = ''
   try {
-    const url = buildApiUrl('/api/clubs/recommendations?limit=12')
-    const response = await fetch(url, { credentials: 'include' })
-    if (!response.ok) {
-      const msg = await response.text()
-      throw new Error(msg || 'Failed to load recommendations')
-    }
-    clubs.value = await response.json()
+    clubs.value = await fetchAllClubs()
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to load recommendations'
+    error.value = err instanceof Error ? err.message : 'Failed to load clubs'
   } finally {
     loading.value = false
   }
 }
 
-onMounted(() => {
-  loadRecommendations()
-})
+const selectOption = (optionIndex: number) => {
+  answers.value[currentQuestionIndex.value] = optionIndex
+}
+
+const goBack = () => {
+  if (currentQuestionIndex.value > 0) currentQuestionIndex.value--
+}
+
+const continueQuiz = () => {
+  if (selectedOptionIndex.value === null) return
+  if (currentQuestionIndex.value < questions.length - 1) {
+    currentQuestionIndex.value++
+    return
+  }
+  showResults.value = true
+  window.scrollTo({ top: 0, behavior: 'smooth' })
+}
+
+const restartQuiz = () => {
+  answers.value = questions.map(() => null)
+  currentQuestionIndex.value = 0
+  showResults.value = false
+  window.scrollTo({ top: 0, behavior: 'smooth' })
+}
+
+onMounted(loadClubs)
 </script>
 
 <template>
-  <div class="recommendations-page page-shell">
-    <header class="rec-hero">
-      <h1>Recommended for You</h1>
-      <p v-if="isAuthenticated">
-        Clubs picked based on your interests and memberships.
-      </p>
-      <p v-else>
-        Popular clubs across all categories. <RouterLink to="/auth">Sign in</RouterLink> for personalized picks.
-      </p>
-    </header>
+  <main class="quiz-page page-shell">
+    <template v-if="!showResults">
+      <header class="quiz-header">
+        <p class="section-label">Club match quiz</p>
+        <h1>Find clubs that fit you</h1>
+        <p>
+          Answer four quick questions and we will match your interests with clubs at your school.
+        </p>
+      </header>
 
-    <div v-if="loading" class="status-card">Finding clubs for you…</div>
-    <div v-else-if="error" class="status-card error">
-      <p>{{ error }}</p>
-      <button type="button" class="ghost-btn" @click="loadRecommendations">Try again</button>
-    </div>
-    <div v-else-if="clubs.length" class="rec-grid">
-      <RouterLink
-        v-for="club in clubs"
-        :key="club.id"
-        :to="`/clubs/${club.id}`"
-        class="rec-card"
-      >
-        <div class="rec-avatar">
-          <img :src="clubImage(club)" :alt="club.name" loading="lazy" />
+      <section class="quiz-card" aria-labelledby="quiz-question">
+        <div class="progress-row">
+          <span>Question {{ currentQuestionIndex + 1 }} of {{ questions.length }}</span>
+          <span>{{ Math.round(progress) }}% complete</span>
         </div>
-        <div class="rec-info">
-          <h3>{{ club.name }}</h3>
-          <span class="rec-category">{{ club.category }}</span>
-          <span class="rec-meta">{{ club.memberCount }} members · {{ club.meetingSchedule }}</span>
+        <div class="progress-track" aria-hidden="true">
+          <span :style="{ width: `${progress}%` }"></span>
         </div>
-      </RouterLink>
-    </div>
-    <div v-else class="status-card muted">
-      <p>No recommendations available yet. Join some clubs to get personalized suggestions!</p>
-      <RouterLink to="/" class="primary-btn">Browse all clubs</RouterLink>
-    </div>
-  </div>
+
+        <div class="question-copy">
+          <h2 id="quiz-question">{{ currentQuestion.prompt }}</h2>
+          <p>{{ currentQuestion.helper }}</p>
+        </div>
+
+        <div class="answer-grid" role="radiogroup" :aria-label="currentQuestion.prompt">
+          <button
+            v-for="(option, optionIndex) in currentQuestion.options"
+            :key="option.label"
+            type="button"
+            class="answer-card"
+            :class="{ selected: selectedOptionIndex === optionIndex }"
+            role="radio"
+            :aria-checked="selectedOptionIndex === optionIndex"
+            @click="selectOption(optionIndex)"
+          >
+            <span class="answer-marker">{{
+              selectedOptionIndex === optionIndex ? '✓' : optionIndex + 1
+            }}</span>
+            <span>
+              <strong>{{ option.label }}</strong>
+              <small>{{ option.description }}</small>
+            </span>
+          </button>
+        </div>
+
+        <footer class="quiz-actions">
+          <button
+            type="button"
+            class="secondary-button"
+            :disabled="currentQuestionIndex === 0"
+            @click="goBack"
+          >
+            Back
+          </button>
+          <button
+            type="button"
+            class="primary-button"
+            :disabled="selectedOptionIndex === null"
+            @click="continueQuiz"
+          >
+            {{ currentQuestionIndex === questions.length - 1 ? 'See my matches' : 'Next question' }}
+          </button>
+        </footer>
+      </section>
+    </template>
+
+    <template v-else>
+      <header class="results-header">
+        <div>
+          <p class="section-label">Your results</p>
+          <h1>Your best club matches</h1>
+          <p>These recommendations are based on the interests and environment you selected.</p>
+        </div>
+        <button type="button" class="secondary-button" @click="restartQuiz">Retake quiz</button>
+      </header>
+
+      <section class="match-summary" aria-label="Top category matches">
+        <article
+          v-for="(category, index) in topCategories"
+          :key="category.title"
+          class="match-category"
+        >
+          <span class="match-rank">#{{ index + 1 }} match</span>
+          <span class="match-icon" aria-hidden="true">{{ category.icon }}</span>
+          <h2>{{ category.title }}</h2>
+          <p>{{ category.description }}</p>
+        </article>
+      </section>
+
+      <section class="club-results" aria-labelledby="recommended-clubs-heading">
+        <div class="results-title-row">
+          <div>
+            <p class="section-label">Recommended clubs</p>
+            <h2 id="recommended-clubs-heading">Start exploring</h2>
+          </div>
+          <RouterLink to="/about" class="text-link">Browse every category</RouterLink>
+        </div>
+
+        <div v-if="loading" class="status-card">Finding clubs for you…</div>
+        <div v-else-if="error" class="status-card error">
+          <p>{{ error }}</p>
+          <button type="button" class="secondary-button" @click="loadClubs">Try again</button>
+        </div>
+        <div v-else-if="recommendedClubs.length" class="club-grid">
+          <RouterLink
+            v-for="club in recommendedClubs"
+            :key="club.id"
+            :to="`/clubs/${club.id}`"
+            class="club-card"
+          >
+            <img :src="clubImage(club)" :alt="`${club.name} avatar`" loading="lazy" />
+            <div>
+              <span>{{ club.category }}</span>
+              <h3>{{ club.name }}</h3>
+              <p>{{ club.description }}</p>
+              <small
+                >{{ club.memberCount }} members ·
+                {{ club.meetingSchedule || 'Schedule TBD' }}</small
+              >
+            </div>
+          </RouterLink>
+        </div>
+        <div v-else class="status-card">
+          No matching clubs are available yet. Try browsing all categories instead.
+        </div>
+      </section>
+    </template>
+  </main>
 </template>
 
 <style scoped>
-.recommendations-page {
-  padding-block: clamp(2rem, 5vw, 3.5rem);
+.quiz-page {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 2rem;
+  padding-block: clamp(2rem, 5vw, 4rem);
 }
 
-.rec-hero h1 {
-  font-size: 1.75rem;
-  margin: 0 0 0.5rem;
+.quiz-header,
+.results-header {
+  max-width: 880px;
 }
 
-.rec-hero p {
-  color: var(--mv-text-faint);
-  margin: 0;
+.quiz-header h1,
+.results-header h1 {
+  margin: 0.5rem 0 0.75rem;
+  font-size: clamp(2rem, 4vw, 3.2rem);
 }
 
-.rec-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 1rem;
+.quiz-header > p:last-child,
+.results-header > div > p:last-child {
+  max-width: 720px;
+  color: var(--mv-text-muted);
 }
 
-.rec-card {
-  display: flex;
-  gap: 1rem;
-  padding: 1.25rem;
-  border-radius: 20px;
+.quiz-card {
+  width: min(900px, 100%);
+  padding: clamp(1.25rem, 4vw, 2.5rem);
   border: 1px solid var(--mv-border);
+  border-radius: 30px;
   background: var(--mv-surface-card);
-  text-decoration: none;
-  color: inherit;
-  transition: border-color 0.2s, transform 0.2s;
+  box-shadow: var(--mv-shadow-elevated);
 }
 
-.rec-card:hover {
+.progress-row,
+.quiz-actions,
+.results-header,
+.results-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.progress-row {
+  color: var(--mv-text-faint);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.progress-track {
+  height: 7px;
+  margin-top: 0.65rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--mv-surface-soft);
+}
+
+.progress-track span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--mv-gold);
+  transition: width 0.25s ease;
+}
+
+.question-copy {
+  margin: 2rem 0 1.25rem;
+}
+
+.question-copy h2 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.45rem, 3vw, 2rem);
+}
+
+.question-copy p {
+  color: var(--mv-text-muted);
+}
+
+.answer-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.answer-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+  min-height: 112px;
+  padding: 1rem;
+  border: 1px solid var(--mv-border);
+  border-radius: 18px;
+  background: var(--mv-surface-muted);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 0.2s ease,
+    background 0.2s ease,
+    transform 0.2s ease;
+}
+
+.answer-card:hover,
+.answer-card:focus-visible,
+.answer-card.selected {
+  border-color: var(--mv-gold);
+  background: var(--mv-surface-accent);
+  transform: translateY(-1px);
+}
+
+.answer-card:focus-visible {
+  outline: 2px solid var(--mv-gold);
+  outline-offset: 3px;
+}
+
+.answer-marker {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 30px;
+  place-items: center;
+  border: 1px solid var(--mv-border-strong);
+  border-radius: 50%;
+  color: var(--mv-gold);
+  font-weight: 700;
+}
+
+.answer-card strong,
+.answer-card small {
+  display: block;
+}
+
+.answer-card small {
+  margin-top: 0.35rem;
+  color: var(--mv-text-faint);
+  font-size: 0.85rem;
+  line-height: 1.45;
+}
+
+.quiz-actions {
+  margin-top: 1.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--mv-border);
+}
+
+.primary-button,
+.secondary-button,
+.text-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0.7rem 1.1rem;
+  border-radius: 999px;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.primary-button {
+  border: 1px solid var(--mv-primary-bg);
+  background: var(--mv-primary-bg);
+  color: var(--mv-primary-text);
+}
+
+.secondary-button,
+.text-link {
+  border: 1px solid var(--mv-border-strong);
+  background: var(--mv-surface-muted);
+  color: var(--mv-text);
+}
+
+.primary-button:disabled,
+.secondary-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.match-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.match-category {
+  padding: 1.4rem;
+  border: 1px solid var(--mv-border);
+  border-radius: 24px;
+  background: var(--mv-surface-card);
+  box-shadow: var(--mv-shadow-card);
+}
+
+.match-category:first-child {
+  border-color: var(--mv-border-strong);
+  background: var(--mv-surface-accent);
+}
+
+.match-rank {
+  color: var(--mv-gold);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.match-icon {
+  display: block;
+  margin: 1.2rem 0 0.65rem;
+  font-size: 1.7rem;
+}
+
+.match-category h2 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.match-category p {
+  margin-top: 0.5rem;
+  color: var(--mv-text-faint);
+  font-size: 0.9rem;
+}
+
+.club-results {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.results-title-row h2 {
+  margin: 0.4rem 0 0;
+}
+
+.club-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1rem;
+}
+
+.club-card {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
+  gap: 1rem;
+  padding: 1.15rem;
+  border: 1px solid var(--mv-border);
+  border-radius: 20px;
+  background: var(--mv-surface-card);
+  color: inherit;
+  transition:
+    border-color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.club-card:hover,
+.club-card:focus-visible {
   border-color: var(--mv-gold);
   transform: translateY(-2px);
 }
 
-.rec-avatar {
-  width: 56px;
-  height: 56px;
-  border-radius: 14px;
-  overflow: hidden;
-  flex-shrink: 0;
-}
-
-.rec-avatar img {
-  width: 100%;
-  height: 100%;
+.club-card img {
+  width: 72px;
+  height: 72px;
+  border-radius: 18px;
   object-fit: cover;
 }
 
-.rec-info {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  min-width: 0;
+.club-card span {
+  color: var(--mv-gold);
+  font-size: 0.75rem;
+  font-weight: 600;
 }
 
-.rec-info h3 {
-  margin: 0;
+.club-card h3 {
+  margin: 0.2rem 0 0.4rem;
   font-size: 1rem;
 }
 
-.rec-category {
-  font-size: 0.8rem;
-  color: var(--mv-gold);
+.club-card p {
+  display: -webkit-box;
+  margin: 0 0 0.65rem;
+  overflow: hidden;
+  color: var(--mv-text-faint);
+  font-size: 0.85rem;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
-.rec-meta {
-  font-size: 0.8rem;
-  color: var(--mv-text-faint);
+.club-card small {
+  color: var(--mv-text-muted);
+}
+
+.status-card {
+  padding: 1.25rem;
+  border: 1px solid var(--mv-border);
+  border-radius: 20px;
+  background: var(--mv-surface-card);
+}
+
+.status-card.error {
+  color: var(--mv-status-danger);
+}
+
+@media (max-width: 760px) {
+  .answer-grid,
+  .match-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .answer-card {
+    min-height: 0;
+  }
+
+  .results-header,
+  .results-title-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 480px) {
+  .quiz-card {
+    padding: 1rem;
+    border-radius: 22px;
+  }
+
+  .progress-row {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+
+  .quiz-actions .primary-button {
+    flex: 1;
+  }
+
+  .club-grid {
+    grid-template-columns: 1fr;
+  }
 }
 </style>

--- a/frontend/src/views/RecommendationView.vue
+++ b/frontend/src/views/RecommendationView.vue
@@ -176,7 +176,10 @@ const showResults = ref(false)
 
 const currentQuestion = computed(() => questions[currentQuestionIndex.value]!)
 const selectedOptionIndex = computed(() => answers.value[currentQuestionIndex.value])
-const progress = computed(() => ((currentQuestionIndex.value + 1) / questions.length) * 100)
+const completedAnswerCount = computed(
+  () => answers.value.filter((answer) => answer !== null).length,
+)
+const progress = computed(() => (completedAnswerCount.value / questions.length) * 100)
 
 const rankedCategories = computed(() => {
   const scores = new Map(clubCategoryOptions.map((category) => [category.title, 0]))
@@ -289,26 +292,33 @@ onMounted(loadClubs)
           <p>{{ currentQuestion.helper }}</p>
         </div>
 
-        <div class="answer-grid" role="radiogroup" :aria-label="currentQuestion.prompt">
-          <button
-            v-for="(option, optionIndex) in currentQuestion.options"
-            :key="option.label"
-            type="button"
-            class="answer-card"
-            :class="{ selected: selectedOptionIndex === optionIndex }"
-            role="radio"
-            :aria-checked="selectedOptionIndex === optionIndex"
-            @click="selectOption(optionIndex)"
-          >
-            <span class="answer-marker">{{
-              selectedOptionIndex === optionIndex ? '✓' : optionIndex + 1
-            }}</span>
-            <span>
-              <strong>{{ option.label }}</strong>
-              <small>{{ option.description }}</small>
-            </span>
-          </button>
-        </div>
+        <fieldset class="answer-fieldset">
+          <legend class="answer-legend">{{ currentQuestion.prompt }}</legend>
+          <div class="answer-grid">
+            <label
+              v-for="(option, optionIndex) in currentQuestion.options"
+              :key="option.label"
+              class="answer-card"
+              :class="{ selected: selectedOptionIndex === optionIndex }"
+            >
+              <input
+                class="answer-input"
+                type="radio"
+                :name="`quiz-question-${currentQuestionIndex}`"
+                :value="optionIndex"
+                :checked="selectedOptionIndex === optionIndex"
+                @change="selectOption(optionIndex)"
+              />
+              <span class="answer-marker">{{
+                selectedOptionIndex === optionIndex ? '✓' : optionIndex + 1
+              }}</span>
+              <span>
+                <strong>{{ option.label }}</strong>
+                <small>{{ option.description }}</small>
+              </span>
+            </label>
+          </div>
+        </fieldset>
 
         <footer class="quiz-actions">
           <button
@@ -474,6 +484,25 @@ onMounted(loadClubs)
   color: var(--mv-text-muted);
 }
 
+.answer-fieldset {
+  min-width: 0;
+  padding: 0;
+  border: 0;
+}
+
+.answer-legend,
+.answer-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 .answer-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -499,14 +528,13 @@ onMounted(loadClubs)
 }
 
 .answer-card:hover,
-.answer-card:focus-visible,
 .answer-card.selected {
   border-color: var(--mv-gold);
   background: var(--mv-surface-accent);
   transform: translateY(-1px);
 }
 
-.answer-card:focus-visible {
+.answer-input:focus-visible + .answer-marker {
   outline: 2px solid var(--mv-gold);
   outline-offset: 3px;
 }
@@ -715,9 +743,18 @@ onMounted(loadClubs)
 }
 
 @media (max-width: 480px) {
+  .quiz-page {
+    gap: 1.5rem;
+    padding-block: 1.5rem 2.5rem;
+  }
+
   .quiz-card {
     padding: 1rem;
     border-radius: 22px;
+  }
+
+  .question-copy {
+    margin-block: 1.5rem 1rem;
   }
 
   .progress-row {
@@ -732,6 +769,25 @@ onMounted(loadClubs)
 
   .club-grid {
     grid-template-columns: 1fr;
+  }
+
+  .results-header > .secondary-button,
+  .results-title-row .text-link {
+    width: 100%;
+  }
+}
+
+@media (max-width: 360px) {
+  .club-card {
+    grid-template-columns: 60px minmax(0, 1fr);
+    gap: 0.75rem;
+    padding: 0.9rem;
+  }
+
+  .club-card img {
+    width: 60px;
+    height: 60px;
+    border-radius: 15px;
   }
 }
 </style>

--- a/frontend/src/views/RecommendationView.vue
+++ b/frontend/src/views/RecommendationView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, nextTick, onMounted, ref } from 'vue'
 import { RouterLink } from 'vue-router'
 
 import { fetchAllClubs } from '../services/clubService'
@@ -174,6 +174,8 @@ const error = ref('')
 const currentQuestionIndex = ref(0)
 const answers = ref<(number | null)[]>(questions.map(() => null))
 const showResults = ref(false)
+const questionHeading = ref<HTMLElement | null>(null)
+const resultsHeading = ref<HTMLElement | null>(null)
 
 const currentQuestion = computed(() => questions[currentQuestionIndex.value]!)
 const selectedOptionIndex = computed(() => answers.value[currentQuestionIndex.value])
@@ -221,24 +223,35 @@ const selectOption = (optionIndex: number) => {
   answers.value[currentQuestionIndex.value] = optionIndex
 }
 
-const goBack = () => {
-  if (currentQuestionIndex.value > 0) currentQuestionIndex.value--
+const focusQuestionHeading = async () => {
+  await nextTick()
+  questionHeading.value?.focus()
 }
 
-const continueQuiz = () => {
+const goBack = async () => {
+  if (currentQuestionIndex.value === 0) return
+  currentQuestionIndex.value--
+  await focusQuestionHeading()
+}
+
+const continueQuiz = async () => {
   if (selectedOptionIndex.value === null) return
   if (currentQuestionIndex.value < questions.length - 1) {
     currentQuestionIndex.value++
+    await focusQuestionHeading()
     return
   }
   showResults.value = true
+  await nextTick()
+  resultsHeading.value?.focus()
   window.scrollTo({ top: 0, behavior: 'smooth' })
 }
 
-const restartQuiz = () => {
+const restartQuiz = async () => {
   answers.value = questions.map(() => null)
   currentQuestionIndex.value = 0
   showResults.value = false
+  await focusQuestionHeading()
   window.scrollTo({ top: 0, behavior: 'smooth' })
 }
 
@@ -266,7 +279,9 @@ onMounted(loadClubs)
         </div>
 
         <div class="question-copy">
-          <h2 id="quiz-question">{{ currentQuestion.prompt }}</h2>
+          <h2 id="quiz-question" ref="questionHeading" tabindex="-1">
+            {{ currentQuestion.prompt }}
+          </h2>
           <p>{{ currentQuestion.helper }}</p>
         </div>
 
@@ -323,7 +338,7 @@ onMounted(loadClubs)
       <header class="results-header">
         <div>
           <p class="section-label">Your results</p>
-          <h1>Your best club matches</h1>
+          <h1 ref="resultsHeading" tabindex="-1">Your best club matches</h1>
           <p>These recommendations are based on the interests and environment you selected.</p>
         </div>
         <button type="button" class="secondary-button" @click="restartQuiz">Retake quiz</button>

--- a/frontend/src/views/RecommendationView.vue
+++ b/frontend/src/views/RecommendationView.vue
@@ -225,7 +225,8 @@ const selectOption = (optionIndex: number) => {
 
 const focusQuestionHeading = async () => {
   await nextTick()
-  questionHeading.value?.focus()
+  questionHeading.value?.focus({ preventScroll: true })
+  questionHeading.value?.scrollIntoView?.({ behavior: 'smooth', block: 'start' })
 }
 
 const goBack = async () => {
@@ -243,7 +244,7 @@ const continueQuiz = async () => {
   }
   showResults.value = true
   await nextTick()
-  resultsHeading.value?.focus()
+  resultsHeading.value?.focus({ preventScroll: true })
   window.scrollTo({ top: 0, behavior: 'smooth' })
 }
 
@@ -252,7 +253,6 @@ const restartQuiz = async () => {
   currentQuestionIndex.value = 0
   showResults.value = false
   await focusQuestionHeading()
-  window.scrollTo({ top: 0, behavior: 'smooth' })
 }
 
 onMounted(loadClubs)
@@ -471,6 +471,7 @@ onMounted(loadClubs)
 .question-copy h2 {
   margin: 0 0 0.5rem;
   font-size: clamp(1.45rem, 3vw, 2rem);
+  scroll-margin-top: 7rem;
 }
 
 .question-copy p {

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -1,8 +1,15 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router'
+import { schoolTemplate } from '../config/schoolTemplate'
+
+const brandName = schoolTemplate.brandName
 
 const clearCache = () => {
-  try { localStorage.clear() } catch { /* ignore */ }
+  try {
+    localStorage.clear()
+  } catch {
+    /* ignore */
+  }
   window.location.reload()
 }
 </script>
@@ -12,7 +19,7 @@ const clearCache = () => {
     <header class="settings-hero">
       <p class="section-label">Settings</p>
       <h1>Preferences</h1>
-      <p>Customize your HS Clubs experience.</p>
+      <p>Customize your {{ brandName }} experience.</p>
     </header>
 
     <section class="settings-group">
@@ -51,7 +58,7 @@ const clearCache = () => {
       <h2>About</h2>
       <div class="setting-row">
         <div>
-          <strong>HS Clubs</strong>
+          <strong>{{ brandName }}</strong>
           <p>Single-school club directory platform. Built with Vue 3 + Spring Boot.</p>
         </div>
       </div>
@@ -68,8 +75,14 @@ const clearCache = () => {
   max-width: 640px;
 }
 
-.settings-hero { display: flex; flex-direction: column; gap: 0.5rem; }
-.settings-hero h1 { margin: 0; }
+.settings-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.settings-hero h1 {
+  margin: 0;
+}
 
 .settings-group {
   display: flex;
@@ -98,10 +111,18 @@ const clearCache = () => {
   color: inherit;
 }
 
-.setting-row.link:hover { background: var(--mv-surface-accent); }
+.setting-row.link:hover {
+  background: var(--mv-surface-accent);
+}
 
-.setting-row strong { font-size: 0.95rem; }
-.setting-row p { margin: 0.25rem 0 0; color: var(--mv-text-muted); font-size: 0.85rem; }
+.setting-row strong {
+  font-size: 0.95rem;
+}
+.setting-row p {
+  margin: 0.25rem 0 0;
+  color: var(--mv-text-muted);
+  font-size: 0.85rem;
+}
 
 .btn {
   padding: 0.4rem 1rem;
@@ -114,7 +135,9 @@ const clearCache = () => {
   color: var(--mv-ghost-text);
   flex-shrink: 0;
 }
-.btn:hover { background: var(--mv-surface-accent); }
+.btn:hover {
+  background: var(--mv-surface-accent);
+}
 
 @media (max-width: 480px) {
   .setting-row {

--- a/frontend/src/views/TermsOfUseView.vue
+++ b/frontend/src/views/TermsOfUseView.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import { schoolTemplate } from '../config/schoolTemplate'
+
+const brandName = schoolTemplate.brandName
 </script>
 
 <template>
@@ -12,8 +15,8 @@
     <section class="legal-content">
       <h2>1. Acceptance of Terms</h2>
       <p>
-        By accessing or using HS Clubs ("the Platform"), you agree to be bound by these Terms of Use.
-        If you do not agree, do not use the Platform.
+        By accessing or using {{ brandName }} ("the Platform"), you agree to be bound by these Terms
+        of Use. If you do not agree, do not use the Platform.
       </p>
 
       <h2>2. Eligibility</h2>
@@ -33,8 +36,9 @@
 
       <h2>4. Platform Role</h2>
       <p>
-        HS Clubs provides a directory and management tool for school clubs. Individual schools and
-        club leaders are responsible for the content and accuracy of their club listings.
+        {{ brandName }} provides a directory and management tool for school clubs. Individual
+        schools and club leaders are responsible for the content and accuracy of their club
+        listings.
       </p>
 
       <h2>5. Account Termination</h2>
@@ -51,8 +55,8 @@
 
       <h2>7. Contact</h2>
       <p>
-        Questions about these terms? Contact the platform administrator through your school's
-        club directory page.
+        Questions about these terms? Contact the platform administrator through your school's club
+        directory page.
       </p>
     </section>
   </div>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,18 +1,38 @@
 import { fileURLToPath, URL } from 'node:url'
 
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv, type Plugin } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
 const resolvedPort = Number(process.env.FRONTEND_PORT ?? process.env.PORT ?? '4173')
 const devServerPort = Number.isFinite(resolvedPort) && resolvedPort > 0 ? resolvedPort : 4173
 
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;')
+
+const schoolBrandTitlePlugin = (): Plugin => {
+  let brandName = 'HS Clubs'
+
+  return {
+    name: 'school-brand-title',
+    configResolved(config) {
+      const env = loadEnv(config.mode, config.envDir, '')
+      brandName = process.env.VITE_BRAND_NAME?.trim() || env.VITE_BRAND_NAME?.trim() || brandName
+    },
+    transformIndexHtml(html) {
+      return html.replace('<title></title>', `<title>${escapeHtml(brandName)}</title>`)
+    },
+  }
+}
+
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [
-    vue(),
-    vueDevTools(),
-  ],
+  plugins: [vue(), vueDevTools(), schoolBrandTitlePlugin()],
   server: {
     host: '0.0.0.0',
     port: devServerPort,
@@ -26,13 +46,11 @@ export default defineConfig({
         changeOrigin: true,
       },
     },
-    allowedHosts: [
-    	'hsclubs.net'
-    ]
+    allowedHosts: ['hsclubs.net'],
   },
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
 })


### PR DESCRIPTION
## Changes
- remove the category overview cards and category detail banner
- add a four-question club match quiz with weighted category scoring
- recommend real clubs from the user's top three category matches
- add a responsive Start quiz callout above the category selector
- support retaking the quiz and browsing matched clubs

## Verification
- npm run build
- npx eslint src/views/AboutView.vue src/views/RecommendationView.vue
- npx prettier --check src/views/AboutView.vue src/views/RecommendationView.vue
- git diff --check