### PR TITLE
Fix post-auth redirect: new users skipped onboarding, invitation links lost their token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,4 +47,5 @@ jobs:
       working-directory: frontend
       run: |
         npm ci
+        npm run test:unit -- --run
         npm run build

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,7 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
 import { useAuthStore } from '../stores/auth'
-import { normalizeAuthRedirect } from '../utils/authRedirect'
+import { DEFAULT_POST_AUTH_PATH, resolvePostAuthRoute } from '../utils/authRedirect'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -159,7 +159,7 @@ router.beforeEach(async (to) => {
   }
 
   if (to.name === 'accept-terms' && authStore.currentUser?.acceptedTerms === true) {
-    return normalizeAuthRedirect(to.query.redirect) ?? { name: 'home' }
+    return resolvePostAuthRoute(authStore.currentUser, to.query.redirect) ?? DEFAULT_POST_AUTH_PATH
   }
 
   if (requiresOwner && !authStore.currentUser?.isOwner) {

--- a/frontend/src/utils/authRedirect.spec.ts
+++ b/frontend/src/utils/authRedirect.spec.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  consumePendingAuthRedirect,
+  normalizeAuthRedirect,
+  resolvePostAuthRoute,
+  sanitizeAuthRedirectTarget,
+  savePendingAuthRedirect,
+} from './authRedirect'
+
+describe('normalizeAuthRedirect', () => {
+  it('accepts a relative path', () => {
+    expect(normalizeAuthRedirect('/foo')).toBe('/foo')
+  })
+
+  it('rejects absolute URLs', () => {
+    expect(normalizeAuthRedirect('https://evil.com')).toBeNull()
+  })
+
+  it('rejects protocol-relative URLs', () => {
+    expect(normalizeAuthRedirect('//evil.com')).toBeNull()
+  })
+
+  it('rejects non-string values', () => {
+    expect(normalizeAuthRedirect(null)).toBeNull()
+    expect(normalizeAuthRedirect(undefined)).toBeNull()
+    expect(normalizeAuthRedirect(42)).toBeNull()
+  })
+
+  it('rejects empty or whitespace-only strings', () => {
+    expect(normalizeAuthRedirect('')).toBeNull()
+    expect(normalizeAuthRedirect('   ')).toBeNull()
+  })
+})
+
+describe('sanitizeAuthRedirectTarget', () => {
+  it('falls back to the default landing path for /onboarding', () => {
+    expect(sanitizeAuthRedirectTarget('/onboarding')).toBe('/profile')
+  })
+
+  it('falls back to the default landing path for /accept-terms (loop guard)', () => {
+    expect(sanitizeAuthRedirectTarget('/accept-terms')).toBe('/profile')
+  })
+
+  it('falls back to the default landing path for /accept-terms with a query string', () => {
+    expect(sanitizeAuthRedirectTarget('/accept-terms?x=1')).toBe('/profile')
+  })
+
+  it('falls back to a custom default when provided', () => {
+    expect(sanitizeAuthRedirectTarget('/onboarding', '/clubs')).toBe('/clubs')
+  })
+
+  it('keeps a valid, unrelated target as-is', () => {
+    expect(sanitizeAuthRedirectTarget('/clubs/42')).toBe('/clubs/42')
+  })
+
+  it('falls back to the default landing path for a trailing-slash variant of /onboarding', () => {
+    expect(sanitizeAuthRedirectTarget('/onboarding/')).toBe('/profile')
+  })
+
+  it('falls back to the default landing path for a case variant of /onboarding', () => {
+    expect(sanitizeAuthRedirectTarget('/Onboarding')).toBe('/profile')
+  })
+
+  it('falls back to the default landing path for a case variant of /accept-terms', () => {
+    expect(sanitizeAuthRedirectTarget('/ACCEPT-TERMS')).toBe('/profile')
+  })
+
+  it('falls back to the default landing path for a self-referential trailing-slash redirect query', () => {
+    expect(sanitizeAuthRedirectTarget('/onboarding/?redirect=/onboarding/')).toBe('/profile')
+  })
+
+  it('does not clobber a legitimate target that merely shares a prefix with /onboarding', () => {
+    expect(sanitizeAuthRedirectTarget('/onboarding-guide')).toBe('/onboarding-guide')
+  })
+})
+
+describe('resolvePostAuthRoute', () => {
+  it('returns null for an unauthenticated user', () => {
+    expect(resolvePostAuthRoute(null, '/clubs')).toBeNull()
+  })
+
+  it('sends a brand-new user (terms not accepted, no graduation year) to accept-terms', () => {
+    expect(resolvePostAuthRoute({ acceptedTerms: false, graduationYear: null }, '/clubs')).toEqual({
+      path: '/accept-terms',
+      query: { redirect: '/clubs' },
+    })
+  })
+
+  it('sends a user who accepted terms but has no graduation year to onboarding', () => {
+    expect(resolvePostAuthRoute({ acceptedTerms: true, graduationYear: null }, '/clubs')).toEqual({
+      path: '/onboarding',
+      query: { redirect: '/clubs' },
+    })
+  })
+
+  it('sends a fully-onboarded user straight to their target', () => {
+    expect(resolvePostAuthRoute({ acceptedTerms: true, graduationYear: 2027 }, '/clubs')).toBe(
+      '/clubs',
+    )
+  })
+
+  it('regression: after accepting terms, a user with no graduation year still goes to onboarding, not the final target', () => {
+    // Simulates AcceptTermsView calling the resolver right after refreshUser(),
+    // where acceptedTerms is now true but graduationYear has never been set.
+    const userAfterAcceptingTerms = { acceptedTerms: true, graduationYear: null }
+    expect(resolvePostAuthRoute(userAfterAcceptingTerms, '/profile')).toEqual({
+      path: '/onboarding',
+      query: { redirect: '/profile' },
+    })
+  })
+
+  it('does not loop back to a redirect step used as the target', () => {
+    expect(
+      resolvePostAuthRoute({ acceptedTerms: false, graduationYear: null }, '/onboarding'),
+    ).toEqual({ path: '/accept-terms', query: { redirect: '/profile' } })
+  })
+})
+
+describe('pending auth redirect round-trip', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('saves and consumes a valid redirect', () => {
+    savePendingAuthRedirect('/clubs/7')
+    expect(consumePendingAuthRedirect()).toBe('/clubs/7')
+  })
+
+  it('only consumes a redirect once', () => {
+    savePendingAuthRedirect('/clubs/7')
+    consumePendingAuthRedirect()
+    expect(consumePendingAuthRedirect()).toBeNull()
+  })
+})

--- a/frontend/src/utils/authRedirect.spec.ts
+++ b/frontend/src/utils/authRedirect.spec.ts
@@ -115,6 +115,12 @@ describe('resolvePostAuthRoute', () => {
       resolvePostAuthRoute({ acceptedTerms: false, graduationYear: null }, '/onboarding'),
     ).toEqual({ path: '/accept-terms', query: { redirect: '/profile' } })
   })
+
+  it('sends a fully-onboarded user to the default landing path when there is no target', () => {
+    expect(resolvePostAuthRoute({ acceptedTerms: true, graduationYear: 2027 }, null)).toBe(
+      '/profile',
+    )
+  })
 })
 
 describe('pending auth redirect round-trip', () => {

--- a/frontend/src/utils/authRedirect.ts
+++ b/frontend/src/utils/authRedirect.ts
@@ -1,4 +1,13 @@
+import type { AuthUser } from '../types/auth'
+
 const PENDING_AUTH_REDIRECT_KEY = 'hsclubs.pendingAuthRedirect'
+
+// Where a fully-onboarded user lands after auth if no other target applies.
+export const DEFAULT_POST_AUTH_PATH = '/profile'
+
+// Steps in the post-auth flow that must never be used as a "redirect back to"
+// target, since landing back on them would create a redirect loop.
+const NON_TARGETABLE_AUTH_STEPS = new Set(['/accept-terms', '/onboarding'])
 
 export const normalizeAuthRedirect = (value: unknown) => {
   if (typeof value !== 'string') {
@@ -9,6 +18,26 @@ export const normalizeAuthRedirect = (value: unknown) => {
     return null
   }
   return trimmed
+}
+
+/**
+ * Normalizes a candidate redirect target and falls back to `fallback` when the
+ * target is missing or points at one of the post-auth flow's own steps
+ * (e.g. `/onboarding` or `/accept-terms?foo=1`), which would otherwise send
+ * the user right back into the step they just left.
+ */
+export const sanitizeAuthRedirectTarget = (
+  value: unknown,
+  fallback: string = DEFAULT_POST_AUTH_PATH,
+) => {
+  const normalized = normalizeAuthRedirect(value)
+  if (!normalized) {
+    return fallback
+  }
+  const path = normalized.split(/[?#]/, 1)[0] ?? normalized
+  const comparablePath =
+    path === '/' ? path : path.toLowerCase().replace(/\/$/, '')
+  return NON_TARGETABLE_AUTH_STEPS.has(comparablePath) ? fallback : normalized
 }
 
 export const savePendingAuthRedirect = (value: unknown) => {
@@ -32,4 +61,40 @@ export const consumePendingAuthRedirect = () => {
   } catch {
     return null
   }
+}
+
+export type PostAuthUser = Pick<AuthUser, 'acceptedTerms' | 'graduationYear'>
+
+export type PostAuthRoute =
+  | { path: '/accept-terms' | '/onboarding'; query: { redirect: string } }
+  | string
+
+/**
+ * The single source of truth for "where does this user go after auth?".
+ *
+ * Ordering:
+ *   1. no user               -> null (caller handles the unauthenticated case)
+ *   2. terms not accepted    -> /accept-terms, carrying the sanitized target
+ *   3. no graduation year    -> /onboarding, carrying the sanitized target
+ *   4. otherwise             -> the sanitized target itself
+ */
+export const resolvePostAuthRoute = (
+  user: PostAuthUser | null | undefined,
+  rawTarget: unknown,
+): PostAuthRoute | null => {
+  if (!user) {
+    return null
+  }
+
+  const target = sanitizeAuthRedirectTarget(rawTarget)
+
+  if (user.acceptedTerms === false) {
+    return { path: '/accept-terms', query: { redirect: target } }
+  }
+
+  if (user.graduationYear == null) {
+    return { path: '/onboarding', query: { redirect: target } }
+  }
+
+  return target
 }

--- a/frontend/src/views/AcceptInvitationView.vue
+++ b/frontend/src/views/AcceptInvitationView.vue
@@ -55,7 +55,11 @@ onMounted(() => {
       <div v-if="!isAuthenticated" class="auth-gate">
         <h1>Accept school invitation</h1>
         <p>Sign in first to accept your invitation as a school administrator.</p>
-        <RouterLink to="/auth?intent=login" class="btn primary">Sign in</RouterLink>
+        <RouterLink
+          :to="{ name: 'auth-choice', query: { intent: 'login', redirect: route.fullPath } }"
+          class="btn primary"
+          >Sign in</RouterLink
+        >
       </div>
 
       <div v-else-if="status === 'loading'" class="status">

--- a/frontend/src/views/AcceptTermsView.vue
+++ b/frontend/src/views/AcceptTermsView.vue
@@ -3,7 +3,7 @@ import { ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 import { buildApiUrl } from '../services/httpClient'
-import { normalizeAuthRedirect } from '../utils/authRedirect'
+import { DEFAULT_POST_AUTH_PATH, resolvePostAuthRoute } from '../utils/authRedirect'
 
 const route = useRoute()
 const router = useRouter()
@@ -11,8 +11,6 @@ const authStore = useAuthStore()
 const agreed = ref(false)
 const loading = ref(false)
 const error = ref('')
-
-const resolveRedirectTarget = () => normalizeAuthRedirect(route.query.redirect) ?? '/'
 
 const handleAccept = async () => {
   if (!agreed.value) return
@@ -27,7 +25,8 @@ const handleAccept = async () => {
       throw new Error('Failed to record acceptance')
     }
     await authStore.refreshUser()
-    router.replace(resolveRedirectTarget())
+    const destination = resolvePostAuthRoute(authStore.currentUser, route.query.redirect)
+    router.replace(destination ?? DEFAULT_POST_AUTH_PATH)
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'Something went wrong'
   } finally {

--- a/frontend/src/views/AuthCallbackView.vue
+++ b/frontend/src/views/AuthCallbackView.vue
@@ -15,11 +15,7 @@ const router = useRouter()
 const authStore = useAuthStore()
 
 const resolveRedirectTarget = () => {
-  return (
-    normalizeAuthRedirect(route.query.redirect) ??
-    consumePendingAuthRedirect() ??
-    DEFAULT_POST_AUTH_PATH
-  )
+  return normalizeAuthRedirect(route.query.redirect) ?? consumePendingAuthRedirect()
 }
 
 onMounted(async () => {
@@ -28,7 +24,7 @@ onMounted(async () => {
   if (authStore.isAuthenticated) {
     const redirectTarget = resolveRedirectTarget()
     const destination = resolvePostAuthRoute(authStore.currentUser, redirectTarget)
-    router.replace(destination ?? redirectTarget)
+    router.replace(destination ?? DEFAULT_POST_AUTH_PATH)
   } else {
     router.replace({ path: '/auth', query: { error: 'login_failed' } })
   }

--- a/frontend/src/views/AuthCallbackView.vue
+++ b/frontend/src/views/AuthCallbackView.vue
@@ -3,30 +3,32 @@ import { onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import { useAuthStore } from '../stores/auth'
-import { consumePendingAuthRedirect, normalizeAuthRedirect } from '../utils/authRedirect'
+import {
+  consumePendingAuthRedirect,
+  DEFAULT_POST_AUTH_PATH,
+  normalizeAuthRedirect,
+  resolvePostAuthRoute,
+} from '../utils/authRedirect'
 
 const route = useRoute()
 const router = useRouter()
 const authStore = useAuthStore()
 
 const resolveRedirectTarget = () => {
-  return normalizeAuthRedirect(route.query.redirect) ?? consumePendingAuthRedirect() ?? '/profile'
+  return (
+    normalizeAuthRedirect(route.query.redirect) ??
+    consumePendingAuthRedirect() ??
+    DEFAULT_POST_AUTH_PATH
+  )
 }
 
 onMounted(async () => {
   await authStore.refreshUser()
 
   if (authStore.isAuthenticated) {
-    const user = authStore.currentUser
     const redirectTarget = resolveRedirectTarget()
-    if (user?.acceptedTerms === false) {
-      router.replace({ path: '/accept-terms', query: { redirect: redirectTarget } })
-    } else if (user && user.graduationYear == null) {
-      // New users without a graduation year set go to onboarding first
-      router.replace({ path: '/onboarding', query: { redirect: redirectTarget } })
-    } else {
-      router.replace(redirectTarget)
-    }
+    const destination = resolvePostAuthRoute(authStore.currentUser, redirectTarget)
+    router.replace(destination ?? redirectTarget)
   } else {
     router.replace({ path: '/auth', query: { error: 'login_failed' } })
   }

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -3,7 +3,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 import { updateGraduationYear } from '../services/userService'
-import { normalizeAuthRedirect } from '../utils/authRedirect'
+import { sanitizeAuthRedirectTarget } from '../utils/authRedirect'
 
 const route = useRoute()
 const router = useRouter()
@@ -24,11 +24,7 @@ const yearOptions = computed(() => {
 
 const canSave = computed(() => graduationYear.value !== null && graduationYear.value > 0)
 
-const resolveRedirectTarget = () => {
-  const redirect = normalizeAuthRedirect(route.query.redirect)
-  const redirectPath = redirect?.split(/[?#]/, 1)[0]
-  return redirect && redirectPath !== '/onboarding' ? redirect : '/profile'
-}
+const resolveRedirectTarget = () => sanitizeAuthRedirectTarget(route.query.redirect)
 
 const handleSave = async () => {
   if (!canSave.value) return


### PR DESCRIPTION
## Problem

Two defects in the post-login/registration redirect chain.

**1. Brand-new users never saw onboarding.** A first-time user has `acceptedTerms === false` and `graduationYear == null`. `AuthCallbackView` sent them to `/accept-terms`, and `AcceptTermsView` then jumped straight to the final redirect target — `/onboarding` was skipped entirely, so the graduation year that feeds the club recommendation engine was never collected for most first-time users.

Root cause: the "where does this user go after auth?" decision was duplicated across four places (`AuthCallbackView.vue`, `AcceptTermsView.vue`, `OnboardingView.vue`, and the global guard in `router/index.ts`), and only one of them knew about the full sequence.

**2. Invitation deep-links lost their token across login.** `AcceptInvitationView`'s sign-in link was a bare `/auth?intent=login` with no `redirect`, and `/accept-invitation` is not `requiresAuth`, so the guard never injected one either. After the OAuth round trip the user landed on `/profile` with `?token=...` gone — the invitation could never be accepted.

## Change

- Prefactor: `resolvePostAuthRoute(user, target)` in `frontend/src/utils/authRedirect.ts` is now the single source of truth for the sequence (no user -> null, terms not accepted -> `/accept-terms`, no graduation year -> `/onboarding`, else the target). `AuthCallbackView`, `AcceptTermsView` and the router guard all route through it. `OnboardingView` deliberately calls only `sanitizeAuthRedirectTarget` instead, because its Skip button leaves `graduationYear == null` and the full resolver would bounce the user straight back into `/onboarding` -- this is not a missed migration.
- `sanitizeAuthRedirectTarget()` centralizes the loop guard that `OnboardingView` used to hand-roll: a `?redirect=` pointing at `/accept-terms` or `/onboarding` falls back to the default landing path instead of bouncing the user into the step they just left. Comparison is case- and trailing-slash-insensitive, since the router is not `strict`/`sensitive` (`/Onboarding`, `/onboarding/` resolve to the same route).
- Router guard's accept-terms branch previously returned `normalizeAuthRedirect(...) ?? { name: 'home' }`, which skipped onboarding for a user who had accepted terms but had no graduation year. It now defers to the shared resolver. (Commit c910b16's message claims this could also self-redirect forever -- that is overstated: the bare string dropped the query, so the next guard pass fell through to home, costing one wasted bounce rather than looping.)
- Standardized the post-auth landing path on `/profile` (`AcceptTermsView` previously defaulted to `/`, the guard to home).
- `AcceptInvitationView`'s sign-in link now carries `redirect: route.fullPath`, matching the `{ intent: 'login', redirect: <fullPath> }` convention used by the guard and `App.vue`.
- CI: the frontend job ran only `npm ci && npm run build`, so vitest never executed and these regression tests would not have gated anything. Added `npm run test:unit -- --run` (separate commit, easy to drop).

## Tests

`frontend/src/utils/authRedirect.spec.ts` is new — this chain previously had **zero** coverage. 24 cases covering the resolver ordering, the regression itself (after accepting terms, `graduationYear == null` must resolve to `/onboarding`, not the final target), open-redirect rejection (`https://`, `//evil.com`, non-strings, whitespace), loop-guard variants (`/onboarding/`, `/Onboarding`, `/ACCEPT-TERMS`, self-referential targets), a false-positive guard (`/onboarding-guide` survives), and the sessionStorage round-trip.

Verified locally: `npm run test:unit -- --run` (32 passed), `npm run build` (includes `vue-tsc` type-check) clean, eslint clean on all changed files.

## Known gaps, deliberately not in this PR

- The frontend redirect target survives the OAuth round trip only via `sessionStorage`; the backend does not echo it back, so a cross-tab return or blocked storage silently falls back to `/profile`.
- A failed OAuth attempt leaves the pending redirect in `sessionStorage`, which can hijack the next unrelated login; `AuthCallbackView` also ignores the `error=oauth2_login_failed` param the backend sends.
- Terms are consented twice (the pre-login checkbox in `AuthChoiceView` is never posted, so `/accept-terms` asks again).
- No guard for an already-authenticated user hitting `/auth`; `ProfileView`'s unauthenticated branch is dead code behind `requiresAuth`.
- Startup fires `/api/auth/me` twice (`main.ts` bootstrap + router guard, no in-flight dedupe).
- `AcceptInvitationView` auto-accepts from `onMounted` only; that works today solely because the global guard awaits the session check before the view mounts, which is fragile implicit coupling.
- Tests cover the pure resolver only — there is no component- or guard-level test.
