### PR TITLE
Post-auth hygiene: failed-login cleanup, single terms consent, and test coverage for the login contract

### DIFF
--- a/frontend/src/router/index.spec.ts
+++ b/frontend/src/router/index.spec.ts
@@ -133,6 +133,47 @@ describe('already-authenticated user landing on the sign-in page', () => {
     expect(router.currentRoute.value.path).toBe('/profile')
   })
 
+  it('regression: preserves the invitation token when forwarding a fully-onboarded user to a query-bearing redirect target', async () => {
+    await primeSession(onboardedUser)
+
+    // Mirrors how AcceptInvitationView and the unauthenticated guard branch
+    // build this query value: `redirect` is set from a full path that itself
+    // carries a query string, e.g. `to.fullPath` for
+    // `/accept-invitation?token=abc`.
+    await router.push({ name: 'auth-choice', query: { redirect: '/accept-invitation?token=abc' } })
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('accept-invitation')
+    expect(router.currentRoute.value.fullPath).toBe('/accept-invitation?token=abc')
+    expect(router.currentRoute.value.query.token).toBe('abc')
+  })
+
+  it('preserves multiple query params and a hash when forwarding a fully-onboarded user to the redirect target', async () => {
+    await primeSession(onboardedUser)
+
+    await router.push({
+      name: 'auth-choice',
+      query: { redirect: '/search?q=chess&sort=name#results' },
+    })
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('club-search')
+    expect(router.currentRoute.value.fullPath).toBe('/search?q=chess&sort=name#results')
+    expect(router.currentRoute.value.query.q).toBe('chess')
+    expect(router.currentRoute.value.query.sort).toBe('name')
+    expect(router.currentRoute.value.hash).toBe('#results')
+  })
+
+  it('preserves the nested redirect query when forwarding a not-yet-onboarded user to onboarding', async () => {
+    await primeSession({ ...onboardedUser, graduationYear: null })
+
+    await router.push('/auth?redirect=/clubs/3')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('onboarding')
+    expect(router.currentRoute.value.query.redirect).toBe('/clubs/3')
+  })
+
   it('replaces the /auth history entry instead of pushing a new one, so Back does not bounce between /auth and the destination', async () => {
     await primeSession(onboardedUser)
     await router.push('/search')

--- a/frontend/src/router/index.spec.ts
+++ b/frontend/src/router/index.spec.ts
@@ -1,0 +1,198 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../services/authService', () => ({
+  fetchAuthProviders: vi.fn(),
+  fetchAuthenticatedUser: vi.fn(),
+  logout: vi.fn(),
+}))
+
+import type { AuthUser } from '../types/auth'
+import { fetchAuthenticatedUser } from '../services/authService'
+import router from './index'
+
+const fetchAuthenticatedUserMock = vi.mocked(fetchAuthenticatedUser)
+
+// A fully-onboarded user: accepted the terms and has a graduation year on
+// file, so none of the post-auth steps (accept-terms, onboarding) apply.
+const onboardedUser: AuthUser = {
+  id: 'user-1',
+  email: 'ada@example.com',
+  displayName: 'Ada Lovelace',
+  avatarUrl: '',
+  provider: 'google',
+  isOwner: false,
+  graduationYear: 2026,
+  acceptedTerms: true,
+}
+
+// The catch-all 404 route: it has no `requiresAuth` meta and is in the
+// guard's `termsBypassRouteNames` allowlist, so navigating here never
+// triggers a redirect for ANY auth/terms/onboarding combination. That makes
+// it a safe "neutral" waypoint to move the router away from wherever the
+// previous test left `currentRoute`, without that move itself being
+// redirected (which would make its `refreshUser()` call reflect the wrong
+// session for the test that follows).
+const NEUTRAL_RESET_PATH = '/__router-spec-reset__'
+
+/**
+ * Establishes a fresh Pinia store, wires the mocked `fetchAuthenticatedUser`
+ * to resolve as `user`, and performs the one navigation that actually
+ * triggers the guard's `refreshUser()` call (since `hasCheckedSession` stays
+ * true forever after). Every subsequent `router.push` in the test reuses
+ * that already-resolved session.
+ */
+const primeSession = async (user: AuthUser | null) => {
+  setActivePinia(createPinia())
+  fetchAuthenticatedUserMock.mockReset()
+  fetchAuthenticatedUserMock.mockResolvedValue(user)
+  await router.push(NEUTRAL_RESET_PATH)
+  await router.isReady()
+}
+
+beforeEach(() => {
+  fetchAuthenticatedUserMock.mockReset()
+})
+
+describe('authentication gate', () => {
+  it('redirects an unauthenticated user requesting a protected route to auth-choice, preserving the original path', async () => {
+    await primeSession(null)
+
+    await router.push('/profile')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('auth-choice')
+    expect(router.currentRoute.value.query.intent).toBe('login')
+    expect(router.currentRoute.value.query.redirect).toBe('/profile')
+  })
+
+  it('still renders the sign-in page for an unauthenticated visitor (no redirect)', async () => {
+    await primeSession(null)
+
+    await router.push('/auth')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('auth-choice')
+    expect(router.currentRoute.value.fullPath).toBe('/auth')
+  })
+
+  it('leaves a public route untouched for an unauthenticated visitor', async () => {
+    await primeSession(null)
+
+    await router.push('/search')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('club-search')
+  })
+})
+
+describe('already-authenticated user landing on the sign-in page', () => {
+  it('sends a fully-onboarded user to the default landing path', async () => {
+    await primeSession(onboardedUser)
+
+    await router.push('/auth')
+    await router.isReady()
+
+    expect(router.currentRoute.value.path).toBe('/profile')
+  })
+
+  it('forwards a fully-onboarded user to the requested redirect target', async () => {
+    await primeSession(onboardedUser)
+
+    await router.push('/auth?intent=login&redirect=/clubs/3')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('club-detail')
+    expect(router.currentRoute.value.path).toBe('/clubs/3')
+  })
+
+  it('does not follow an off-site redirect target, falling back to the default landing path', async () => {
+    await primeSession(onboardedUser)
+
+    await router.push('/auth?redirect=https://evil.com')
+    await router.isReady()
+
+    expect(router.currentRoute.value.path).toBe('/profile')
+  })
+
+  it('sends a user who has not accepted the terms to accept-terms instead', async () => {
+    await primeSession({ ...onboardedUser, acceptedTerms: false })
+
+    await router.push('/auth')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('accept-terms')
+  })
+
+  it('sends a user with no graduation year to onboarding instead', async () => {
+    await primeSession({ ...onboardedUser, graduationYear: null })
+
+    await router.push('/auth')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('onboarding')
+  })
+
+  it('does not hijack the OAuth callback route (only auth-choice is redirected onward)', async () => {
+    await primeSession(onboardedUser)
+
+    await router.push('/auth/callback')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('auth-callback')
+  })
+})
+
+describe('terms enforcement', () => {
+  it('redirects a user who has not accepted the terms to accept-terms, preserving the requested route', async () => {
+    await primeSession({ ...onboardedUser, acceptedTerms: false })
+
+    await router.push('/profile')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('accept-terms')
+    expect(router.currentRoute.value.query.redirect).toBe('/profile')
+  })
+
+  it('still allows a user who has not accepted the terms to reach the terms and privacy pages', async () => {
+    await primeSession({ ...onboardedUser, acceptedTerms: false })
+
+    await router.push('/terms')
+    await router.isReady()
+    expect(router.currentRoute.value.name).toBe('terms')
+
+    await router.push('/privacy')
+    await router.isReady()
+    expect(router.currentRoute.value.name).toBe('privacy')
+  })
+
+  it('regression: after accepting the terms, a user with no graduation year is forwarded to onboarding, not the original redirect target', async () => {
+    await primeSession({ ...onboardedUser, acceptedTerms: true, graduationYear: null })
+
+    await router.push('/accept-terms?redirect=/clubs/3')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('onboarding')
+    expect(router.currentRoute.value.query.redirect).toBe('/clubs/3')
+  })
+
+  it('does not loop when the redirect target is accept-terms itself, terminating on the default landing path', async () => {
+    await primeSession(onboardedUser)
+
+    await router.push('/accept-terms?redirect=/accept-terms')
+    await router.isReady()
+
+    expect(router.currentRoute.value.path).toBe('/profile')
+  })
+})
+
+describe('owner gate', () => {
+  it('redirects an authenticated non-owner away from an owner-only route, back to home', async () => {
+    await primeSession({ ...onboardedUser, isOwner: false })
+
+    await router.push('/admin')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('home')
+  })
+})

--- a/frontend/src/router/index.spec.ts
+++ b/frontend/src/router/index.spec.ts
@@ -115,6 +115,40 @@ describe('already-authenticated user landing on the sign-in page', () => {
     expect(router.currentRoute.value.path).toBe('/profile')
   })
 
+  it('does not follow a backslash redirect target that would resolve cross-origin, falling back to the default landing path', async () => {
+    await primeSession(onboardedUser)
+
+    await router.push('/auth?redirect=/\\evil.com')
+    await router.isReady()
+
+    expect(router.currentRoute.value.path).toBe('/profile')
+  })
+
+  it('does not follow a percent-encoded backslash redirect target, falling back to the default landing path', async () => {
+    await primeSession(onboardedUser)
+
+    await router.push('/auth?redirect=%2F%5Cevil.com')
+    await router.isReady()
+
+    expect(router.currentRoute.value.path).toBe('/profile')
+  })
+
+  it('replaces the /auth history entry instead of pushing a new one, so Back does not bounce between /auth and the destination', async () => {
+    await primeSession(onboardedUser)
+    await router.push('/search')
+    await router.isReady()
+    const historyLengthBeforeAuth = window.history.length
+
+    await router.push('/auth')
+    await router.isReady()
+    expect(router.currentRoute.value.path).toBe('/profile')
+
+    // A `replace` navigation overwrites the current history entry rather
+    // than appending one, so the entry count must not have grown across the
+    // /auth -> /profile guard redirect.
+    expect(window.history.length).toBe(historyLengthBeforeAuth)
+  })
+
   it('sends a user who has not accepted the terms to accept-terms instead', async () => {
     await primeSession({ ...onboardedUser, acceptedTerms: false })
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -150,6 +150,15 @@ router.beforeEach(async (to) => {
     }
   }
 
+  // An already-authenticated user landing on the sign-in page (stale link,
+  // browser Back, bookmarked /auth?redirect=...) has nothing to choose from
+  // here. Route them onward through the same post-auth resolver used after a
+  // real login, so a not-yet-onboarded user still lands on /accept-terms or
+  // /onboarding instead of skipping those steps.
+  if (authStore.isAuthenticated && to.name === 'auth-choice') {
+    return resolvePostAuthRoute(authStore.currentUser, to.query.redirect) ?? DEFAULT_POST_AUTH_PATH
+  }
+
   if (
     authStore.isAuthenticated &&
     authStore.currentUser?.acceptedTerms === false &&

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -134,7 +134,7 @@ const termsBypassRouteNames = new Set([
 router.beforeEach(async (to) => {
   const authStore = useAuthStore()
   if (!authStore.hasCheckedSession) {
-    await authStore.refreshUser()
+    await authStore.ensureSessionChecked()
   }
 
   const requiresAuth = to.matched.some((record) => record.meta.requiresAuth)
@@ -156,7 +156,14 @@ router.beforeEach(async (to) => {
   // real login, so a not-yet-onboarded user still lands on /accept-terms or
   // /onboarding instead of skipping those steps.
   if (authStore.isAuthenticated && to.name === 'auth-choice') {
-    return resolvePostAuthRoute(authStore.currentUser, to.query.redirect) ?? DEFAULT_POST_AUTH_PATH
+    // An authenticated visit to /auth must not leave /auth sitting in
+    // history: forward with `replace: true` so the (now-pointless) /auth
+    // entry doesn't trap the Back button behind the real destination.
+    const destination = resolvePostAuthRoute(authStore.currentUser, to.query.redirect) ?? DEFAULT_POST_AUTH_PATH
+    return {
+      ...(typeof destination === 'string' ? { path: destination } : destination),
+      replace: true,
+    }
   }
 
   if (

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -159,9 +159,21 @@ router.beforeEach(async (to) => {
     // An authenticated visit to /auth must not leave /auth sitting in
     // history: forward with `replace: true` so the (now-pointless) /auth
     // entry doesn't trap the Back button behind the real destination.
+    //
+    // The destination is resolved (via `router.resolve`) before being
+    // returned rather than being returned as-is: `resolvePostAuthRoute` can
+    // return a bare string carrying its own query string and/or hash (e.g.
+    // `/accept-invitation?token=abc`), and wrapping that string directly in
+    // `{ path: destination }` would make vue-router silently drop everything
+    // after the path. Resolving first and re-expressing the result as
+    // `{ path, query, hash }` keeps the query and hash intact for both the
+    // bare-string and object-shaped (`{ path, query }`) cases.
     const destination = resolvePostAuthRoute(authStore.currentUser, to.query.redirect) ?? DEFAULT_POST_AUTH_PATH
+    const resolved = router.resolve(destination)
     return {
-      ...(typeof destination === 'string' ? { path: destination } : destination),
+      path: resolved.path,
+      query: resolved.query,
+      hash: resolved.hash,
       replace: true,
     }
   }

--- a/frontend/src/stores/auth.spec.ts
+++ b/frontend/src/stores/auth.spec.ts
@@ -1,0 +1,93 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { AuthUser } from '../types/auth'
+
+vi.mock('../services/authService', () => ({
+  fetchAuthProviders: vi.fn(),
+  fetchAuthenticatedUser: vi.fn(),
+  logout: vi.fn(),
+}))
+
+import { fetchAuthenticatedUser } from '../services/authService'
+import { useAuthStore } from './auth'
+
+const fetchAuthenticatedUserMock = vi.mocked(fetchAuthenticatedUser)
+
+const knownUser: AuthUser = {
+  id: 'user-1',
+  email: 'ada@example.com',
+  displayName: 'Ada Lovelace',
+  avatarUrl: '',
+  provider: 'google',
+  isOwner: false,
+  graduationYear: 2026,
+  acceptedTerms: true,
+}
+
+// A deferred promise gives the test control over exactly when the mocked
+// fetch resolves, so concurrent refreshUser() calls can be started before
+// either one has settled.
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  fetchAuthenticatedUserMock.mockReset()
+})
+
+describe('refreshUser', () => {
+  it('populates currentUser and marks the session as checked on success', async () => {
+    fetchAuthenticatedUserMock.mockResolvedValue(knownUser)
+    const store = useAuthStore()
+
+    await store.refreshUser()
+
+    expect(store.currentUser?.id).toBe('user-1')
+    expect(store.userLoading).toBe(false)
+    expect(store.userError).toBeNull()
+    expect(store.hasCheckedSession).toBe(true)
+  })
+
+  it('dedupes concurrent calls into a single underlying request', async () => {
+    const deferred = createDeferred<AuthUser>()
+    fetchAuthenticatedUserMock.mockReturnValue(deferred.promise)
+    const store = useAuthStore()
+
+    const first = store.refreshUser()
+    const second = store.refreshUser()
+
+    deferred.resolve(knownUser)
+    await Promise.all([first, second])
+
+    expect(fetchAuthenticatedUserMock).toHaveBeenCalledTimes(1)
+    expect(store.currentUser?.id).toBe('user-1')
+    expect(store.userLoading).toBe(false)
+    expect(store.hasCheckedSession).toBe(true)
+  })
+
+  it('does not cache a poisoned promise after a rejected request', async () => {
+    fetchAuthenticatedUserMock.mockRejectedValueOnce(new Error('network down'))
+    const store = useAuthStore()
+
+    await store.refreshUser()
+
+    expect(store.currentUser).toBeNull()
+    expect(store.userError).toBe('network down')
+    expect(store.hasCheckedSession).toBe(true)
+
+    fetchAuthenticatedUserMock.mockResolvedValueOnce(knownUser)
+    await store.refreshUser()
+
+    expect(fetchAuthenticatedUserMock).toHaveBeenCalledTimes(2)
+    expect(store.currentUser?.id).toBe('user-1')
+    expect(store.userError).toBeNull()
+  })
+})

--- a/frontend/src/stores/auth.spec.ts
+++ b/frontend/src/stores/auth.spec.ts
@@ -56,18 +56,15 @@ describe('refreshUser', () => {
     expect(store.hasCheckedSession).toBe(true)
   })
 
-  it('dedupes concurrent calls into a single underlying request', async () => {
-    const deferred = createDeferred<AuthUser>()
-    fetchAuthenticatedUserMock.mockReturnValue(deferred.promise)
+  it('always issues a fresh request, even for back-to-back calls (no dedupe: post-mutation callers must see current server state)', async () => {
+    fetchAuthenticatedUserMock.mockResolvedValue(knownUser)
     const store = useAuthStore()
 
     const first = store.refreshUser()
     const second = store.refreshUser()
-
-    deferred.resolve(knownUser)
     await Promise.all([first, second])
 
-    expect(fetchAuthenticatedUserMock).toHaveBeenCalledTimes(1)
+    expect(fetchAuthenticatedUserMock).toHaveBeenCalledTimes(2)
     expect(store.currentUser?.id).toBe('user-1')
     expect(store.userLoading).toBe(false)
     expect(store.hasCheckedSession).toBe(true)
@@ -89,5 +86,90 @@ describe('refreshUser', () => {
     expect(fetchAuthenticatedUserMock).toHaveBeenCalledTimes(2)
     expect(store.currentUser?.id).toBe('user-1')
     expect(store.userError).toBeNull()
+  })
+})
+
+describe('ensureSessionChecked', () => {
+  it('dedupes two concurrent session-style checks into a single underlying request, both observing the same result', async () => {
+    const deferred = createDeferred<AuthUser>()
+    fetchAuthenticatedUserMock.mockReturnValue(deferred.promise)
+    const store = useAuthStore()
+
+    const first = store.ensureSessionChecked()
+    const second = store.ensureSessionChecked()
+
+    deferred.resolve(knownUser)
+    await Promise.all([first, second])
+
+    expect(fetchAuthenticatedUserMock).toHaveBeenCalledTimes(1)
+    expect(store.currentUser?.id).toBe('user-1')
+    expect(store.userLoading).toBe(false)
+    expect(store.hasCheckedSession).toBe(true)
+  })
+
+  it('does not cache a poisoned promise after a rejected request: the next session check genuinely refetches', async () => {
+    fetchAuthenticatedUserMock.mockRejectedValueOnce(new Error('network down'))
+    const store = useAuthStore()
+
+    await store.ensureSessionChecked()
+
+    expect(store.currentUser).toBeNull()
+    expect(store.userError).toBe('network down')
+    expect(store.hasCheckedSession).toBe(true)
+
+    fetchAuthenticatedUserMock.mockResolvedValueOnce(knownUser)
+    await store.ensureSessionChecked()
+
+    expect(fetchAuthenticatedUserMock).toHaveBeenCalledTimes(2)
+    expect(store.currentUser?.id).toBe('user-1')
+    expect(store.userError).toBeNull()
+  })
+
+  it('a cold load issues exactly ONE /api/auth/me request even though bootstrap() and a guard-style session check both run concurrently', async () => {
+    fetchAuthenticatedUserMock.mockResolvedValue(knownUser)
+    const store = useAuthStore()
+
+    // Mirrors main.ts calling bootstrap() and the router guard's
+    // `if (!hasCheckedSession) await authStore.ensureSessionChecked()`
+    // firing before either has resolved on a cold load.
+    await Promise.all([store.bootstrap(), store.ensureSessionChecked()])
+
+    expect(fetchAuthenticatedUserMock).toHaveBeenCalledTimes(1)
+    expect(store.currentUser?.id).toBe('user-1')
+    expect(store.hasCheckedSession).toBe(true)
+  })
+})
+
+describe('refreshUser vs. ensureSessionChecked concurrency (Finding-1 regression)', () => {
+  it('regression: a post-mutation refreshUser() (e.g. right after the accept-terms POST) is not handed a stale response from a concurrently in-flight session check', async () => {
+    const staleUser = { ...knownUser, acceptedTerms: false }
+    const freshUser = { ...knownUser, acceptedTerms: true }
+    const sessionCheckDeferred = createDeferred<AuthUser>()
+    const postMutationDeferred = createDeferred<AuthUser>()
+
+    fetchAuthenticatedUserMock
+      .mockReturnValueOnce(sessionCheckDeferred.promise)
+      .mockReturnValueOnce(postMutationDeferred.promise)
+
+    const store = useAuthStore()
+
+    // A router-guard-style session check is already in flight when
+    // AcceptTermsView's POST finishes and it calls refreshUser() to see
+    // whether the user is now allowed past the accept-terms guard.
+    const sessionCheck = store.ensureSessionChecked()
+    const postMutationRefresh = store.refreshUser()
+
+    // Both underlying requests are in flight: refreshUser() must have
+    // issued its OWN request rather than being handed the session check's.
+    expect(fetchAuthenticatedUserMock).toHaveBeenCalledTimes(2)
+
+    sessionCheckDeferred.resolve(staleUser)
+    postMutationDeferred.resolve(freshUser)
+    await Promise.all([sessionCheck, postMutationRefresh])
+
+    // The post-mutation caller's own fresh response (acceptedTerms: true)
+    // must be what the store ends up reflecting, not the pre-mutation
+    // response the session check happened to have in flight.
+    expect(store.currentUser?.acceptedTerms).toBe(true)
   })
 })

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -55,20 +55,37 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
-  const refreshUser = async () => {
-    userLoading.value = true
-    try {
-      const fetched = await fetchAuthenticatedUser()
-      currentUser.value = normalizeUser(fetched)
-      userError.value = null
-    } catch (error) {
-      userError.value =
-        error instanceof Error ? error.message : 'Unable to verify session'
-      currentUser.value = null
-    } finally {
-      userLoading.value = false
-      hasCheckedSession.value = true
+  // Concurrent callers (e.g. main.ts's bootstrap() and the router guard both
+  // firing on cold load, before either has resolved) must share a single
+  // /api/auth/me request instead of each issuing their own. The in-flight
+  // promise is cached here and cleared once the request settles, so a later
+  // explicit refreshUser() call still triggers a fresh request.
+  let inFlightRefresh: Promise<void> | null = null
+
+  const refreshUser = (): Promise<void> => {
+    if (inFlightRefresh) {
+      return inFlightRefresh
     }
+
+    const request = (async () => {
+      userLoading.value = true
+      try {
+        const fetched = await fetchAuthenticatedUser()
+        currentUser.value = normalizeUser(fetched)
+        userError.value = null
+      } catch (error) {
+        userError.value =
+          error instanceof Error ? error.message : 'Unable to verify session'
+        currentUser.value = null
+      } finally {
+        userLoading.value = false
+        hasCheckedSession.value = true
+        inFlightRefresh = null
+      }
+    })()
+
+    inFlightRefresh = request
+    return request
   }
 
   const bootstrap = async () => {
@@ -82,11 +99,14 @@ export const useAuthStore = defineStore('auth', () => {
         'No OAuth provider was selected. Please refresh and try again.'
       return
     }
-    savePendingAuthRedirect(redirectTarget)
     const provider = providers.value.find((item) => item.id === sanitizedId)
-    const authorizationPath =
-      provider?.authorizationUrl ?? `/oauth2/authorization/${sanitizedId}`
-    window.location.href = buildApiUrl(authorizationPath)
+    if (!provider?.authorizationUrl) {
+      providersError.value =
+        'This sign-in provider is not configured correctly. Please refresh and try again.'
+      return
+    }
+    savePendingAuthRedirect(redirectTarget)
+    window.location.href = buildApiUrl(provider.authorizationUrl)
   }
 
   const logout = async () => {

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -55,41 +55,56 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
-  // Concurrent callers (e.g. main.ts's bootstrap() and the router guard both
-  // firing on cold load, before either has resolved) must share a single
-  // /api/auth/me request instead of each issuing their own. The in-flight
-  // promise is cached here and cleared once the request settles, so a later
-  // explicit refreshUser() call still triggers a fresh request.
-  let inFlightRefresh: Promise<void> | null = null
-
-  const refreshUser = (): Promise<void> => {
-    if (inFlightRefresh) {
-      return inFlightRefresh
+  // The actual /api/auth/me round trip. Every call issues a brand-new
+  // request; callers that need de-duplication (see `ensureSessionChecked`
+  // below) are responsible for sharing the returned promise themselves.
+  const fetchAndApplyUser = async (): Promise<void> => {
+    userLoading.value = true
+    try {
+      const fetched = await fetchAuthenticatedUser()
+      currentUser.value = normalizeUser(fetched)
+      userError.value = null
+    } catch (error) {
+      userError.value =
+        error instanceof Error ? error.message : 'Unable to verify session'
+      currentUser.value = null
+    } finally {
+      userLoading.value = false
+      hasCheckedSession.value = true
     }
+  }
 
-    const request = (async () => {
-      userLoading.value = true
-      try {
-        const fetched = await fetchAuthenticatedUser()
-        currentUser.value = normalizeUser(fetched)
-        userError.value = null
-      } catch (error) {
-        userError.value =
-          error instanceof Error ? error.message : 'Unable to verify session'
-        currentUser.value = null
-      } finally {
-        userLoading.value = false
-        hasCheckedSession.value = true
-        inFlightRefresh = null
-      }
-    })()
+  // Post-mutation callers (AcceptTermsView after POSTing accept-terms,
+  // OnboardingView/ProfileView after saving a graduation year,
+  // AcceptInvitationView after accepting an invitation, App.vue when auth
+  // flips true) MUST see the server's current state, not a response some
+  // other in-flight caller happened to have kicked off before the mutation
+  // landed. So `refreshUser()` always issues a fresh request and never reuses
+  // a cached in-flight promise.
+  const refreshUser = (): Promise<void> => fetchAndApplyUser()
 
-    inFlightRefresh = request
+  // Session checks (main.ts's bootstrap() and the router guard's
+  // `if (!hasCheckedSession)` branch) only need "has this browser got a
+  // session?" and both fire on cold load before either has resolved. These
+  // share a single in-flight /api/auth/me request instead of each issuing
+  // their own. The in-flight promise is cleared once the request settles
+  // (success or failure), so the next call always genuinely refetches
+  // instead of replaying a poisoned/stale result.
+  let inFlightSessionCheck: Promise<void> | null = null
+
+  const ensureSessionChecked = (): Promise<void> => {
+    if (inFlightSessionCheck) {
+      return inFlightSessionCheck
+    }
+    const request = fetchAndApplyUser().finally(() => {
+      inFlightSessionCheck = null
+    })
+    inFlightSessionCheck = request
     return request
   }
 
   const bootstrap = async () => {
-    await Promise.allSettled([ensureProvidersLoaded(), refreshUser()])
+    await Promise.allSettled([ensureProvidersLoaded(), ensureSessionChecked()])
   }
 
   const beginLogin = (providerId: string, redirectTarget?: string | null) => {
@@ -125,6 +140,7 @@ export const useAuthStore = defineStore('auth', () => {
     isAuthenticated,
     ensureProvidersLoaded,
     refreshUser,
+    ensureSessionChecked,
     bootstrap,
     beginLogin,
     logout,

--- a/frontend/src/utils/authRedirect.spec.ts
+++ b/frontend/src/utils/authRedirect.spec.ts
@@ -32,6 +32,50 @@ describe('normalizeAuthRedirect', () => {
     expect(normalizeAuthRedirect('')).toBeNull()
     expect(normalizeAuthRedirect('   ')).toBeNull()
   })
+
+  // A backslash is a path separator to a browser's URL parser, not a literal
+  // character: `new URL('/\\evil.com', 'http://localhost/')` resolves to
+  // `http://evil.com/`, the same cross-origin escape the backend's
+  // PostLoginRedirectResolver.isSafeInAppTarget already rejects.
+  it('rejects a leading-slash-then-backslash target that resolves cross-origin', () => {
+    expect(normalizeAuthRedirect('/\\evil.com')).toBeNull()
+  })
+
+  it('rejects a slash-backslash-slash target that resolves cross-origin', () => {
+    expect(normalizeAuthRedirect('/\\/evil.com')).toBeNull()
+  })
+
+  it('rejects a backslash appearing mid-path, not just at the start', () => {
+    expect(normalizeAuthRedirect('/clubs/3\\evil.com')).toBeNull()
+  })
+
+  it('still rejects a protocol-relative URL', () => {
+    expect(normalizeAuthRedirect('//evil.com')).toBeNull()
+  })
+
+  it('still rejects an absolute cross-origin URL', () => {
+    expect(normalizeAuthRedirect('https://evil.com')).toBeNull()
+  })
+
+  it('rejects a raw newline smuggled into an otherwise valid-looking target', () => {
+    expect(normalizeAuthRedirect('/clubs/3\nevil')).toBeNull()
+  })
+
+  it('still accepts a legitimate target carrying a query string', () => {
+    expect(normalizeAuthRedirect('/clubs/3?tab=members')).toBe('/clubs/3?tab=members')
+  })
+
+  it('still accepts a legitimate target carrying a fragment', () => {
+    expect(normalizeAuthRedirect('/clubs/3#officers')).toBe('/clubs/3#officers')
+  })
+
+  it('still accepts a legitimate target with encoded characters', () => {
+    expect(normalizeAuthRedirect('/search?q=chess%20club')).toBe('/search?q=chess%20club')
+  })
+
+  it('still accepts a legitimate target with a unicode club name', () => {
+    expect(normalizeAuthRedirect('/clubs/日本語クラブ')).toBe('/clubs/日本語クラブ')
+  })
 })
 
 describe('sanitizeAuthRedirectTarget', () => {

--- a/frontend/src/utils/authRedirect.spec.ts
+++ b/frontend/src/utils/authRedirect.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
+  clearPendingAuthRedirect,
   consumePendingAuthRedirect,
   normalizeAuthRedirect,
   resolvePostAuthRoute,
@@ -137,5 +138,45 @@ describe('pending auth redirect round-trip', () => {
     savePendingAuthRedirect('/clubs/7')
     consumePendingAuthRedirect()
     expect(consumePendingAuthRedirect()).toBeNull()
+  })
+
+  it('clears a saved redirect so it is no longer consumable', () => {
+    savePendingAuthRedirect('/clubs/7')
+    clearPendingAuthRedirect()
+    expect(consumePendingAuthRedirect()).toBeNull()
+  })
+
+  it('clearing when nothing is stored is a no-op and does not throw', () => {
+    expect(() => clearPendingAuthRedirect()).not.toThrow()
+    expect(consumePendingAuthRedirect()).toBeNull()
+  })
+
+  it('survives a throwing sessionStorage when saving, consuming, and clearing', () => {
+    const originalSessionStorage = window.sessionStorage
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      value: {
+        getItem: () => {
+          throw new Error('storage disabled')
+        },
+        setItem: () => {
+          throw new Error('storage disabled')
+        },
+        removeItem: () => {
+          throw new Error('storage disabled')
+        },
+      },
+    })
+
+    try {
+      expect(() => savePendingAuthRedirect('/clubs/7')).not.toThrow()
+      expect(consumePendingAuthRedirect()).toBeNull()
+      expect(() => clearPendingAuthRedirect()).not.toThrow()
+    } finally {
+      Object.defineProperty(window, 'sessionStorage', {
+        configurable: true,
+        value: originalSessionStorage,
+      })
+    }
   })
 })

--- a/frontend/src/utils/authRedirect.ts
+++ b/frontend/src/utils/authRedirect.ts
@@ -9,12 +9,24 @@ export const DEFAULT_POST_AUTH_PATH = '/profile'
 // target, since landing back on them would create a redirect loop.
 const NON_TARGETABLE_AUTH_STEPS = new Set(['/accept-terms', '/onboarding'])
 
+// A raw backslash or a raw control character (including newlines) anywhere in
+// the target is rejected. Per the WHATWG URL spec a browser treats `\` as a
+// path separator just like `/`, so `/\evil.com` and `/\/evil.com` both
+// resolve to `http://evil.com/` instead of staying in-app -- the same shape
+// the backend's `PostLoginRedirectResolver.isSafeInAppTarget` already
+// rejects. No legitimate in-app route needs a raw backslash or control
+// character, so rejecting them outright is not a functional regression.
+const UNSAFE_REDIRECT_CHARS = /[\\\u0000-\u001f]/
+
 export const normalizeAuthRedirect = (value: unknown) => {
   if (typeof value !== 'string') {
     return null
   }
   const trimmed = value.trim()
   if (!trimmed.startsWith('/') || trimmed.startsWith('//')) {
+    return null
+  }
+  if (UNSAFE_REDIRECT_CHARS.test(trimmed)) {
     return null
   }
   return trimmed

--- a/frontend/src/utils/authRedirect.ts
+++ b/frontend/src/utils/authRedirect.ts
@@ -63,6 +63,20 @@ export const consumePendingAuthRedirect = () => {
   }
 }
 
+/**
+ * Drops any pending redirect target without reading it. Callers use this when
+ * a login attempt has concluded unsuccessfully (backend-reported error, or an
+ * unauthenticated refreshUser() result): a stale target must not survive to
+ * hijack the user's next, unrelated login attempt.
+ */
+export const clearPendingAuthRedirect = () => {
+  try {
+    sessionStorage.removeItem(PENDING_AUTH_REDIRECT_KEY)
+  } catch {
+    // Ignore storage failures; there is nothing to clean up if storage never worked.
+  }
+}
+
 export type PostAuthUser = Pick<AuthUser, 'acceptedTerms' | 'graduationYear'>
 
 export type PostAuthRoute =

--- a/frontend/src/views/AcceptTermsView.spec.ts
+++ b/frontend/src/views/AcceptTermsView.spec.ts
@@ -1,0 +1,152 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('vue-router', () => ({
+  useRoute: vi.fn(),
+  useRouter: vi.fn(),
+}))
+
+vi.mock('../services/authService', () => ({
+  fetchAuthProviders: vi.fn(),
+  fetchAuthenticatedUser: vi.fn(),
+  logout: vi.fn(),
+}))
+
+import { useRoute, useRouter } from 'vue-router'
+
+import { fetchAuthenticatedUser } from '../services/authService'
+import type { AuthUser } from '../types/auth'
+import AcceptTermsView from './AcceptTermsView.vue'
+
+const useRouteMock = vi.mocked(useRoute)
+const useRouterMock = vi.mocked(useRouter)
+const fetchAuthenticatedUserMock = vi.mocked(fetchAuthenticatedUser)
+
+// The user record `refreshUser()` returns *after* the accept-terms POST has
+// succeeded server-side; acceptedTerms is already true at that point since
+// the backend just recorded it.
+const buildUser = (overrides: Partial<AuthUser> = {}): AuthUser => ({
+  id: 'user-1',
+  email: 'ada@example.com',
+  displayName: 'Ada Lovelace',
+  avatarUrl: '',
+  provider: 'google',
+  isOwner: false,
+  graduationYear: 2027,
+  acceptedTerms: true,
+  ...overrides,
+})
+
+let replaceMock: ReturnType<typeof vi.fn>
+let fetchMock: ReturnType<typeof vi.fn>
+
+const setRouteQuery = (query: Record<string, string>) => {
+  useRouteMock.mockReturnValue({ query } as ReturnType<typeof useRoute>)
+}
+
+const mountView = () => mount(AcceptTermsView, { global: { stubs: { RouterLink: true } } })
+
+// Checks the consent checkbox and submits the form, mirroring what a real
+// user has to do before the accept button does anything.
+const agreeAndSubmit = async (wrapper: ReturnType<typeof mountView>) => {
+  await wrapper.find('input[type="checkbox"]').setValue(true)
+  await wrapper.find('form').trigger('submit')
+  await flushPromises()
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  fetchAuthenticatedUserMock.mockReset()
+  replaceMock = vi.fn()
+  useRouterMock.mockReturnValue({ replace: replaceMock } as unknown as ReturnType<typeof useRouter>)
+  setRouteQuery({})
+  fetchMock = vi.fn()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('AcceptTermsView', () => {
+  it('sends a user with no graduation year to onboarding (not the final destination) after accepting terms', async () => {
+    fetchMock.mockResolvedValue({ ok: true })
+    fetchAuthenticatedUserMock.mockResolvedValue(buildUser({ graduationYear: null }))
+    setRouteQuery({ redirect: '/clubs/5' })
+    const wrapper = mountView()
+
+    await agreeAndSubmit(wrapper)
+
+    expect(replaceMock).toHaveBeenCalledWith({
+      path: '/onboarding',
+      query: { redirect: '/clubs/5' },
+    })
+  })
+
+  it('sends a user who already has a graduation year on to the sanitized target', async () => {
+    fetchMock.mockResolvedValue({ ok: true })
+    fetchAuthenticatedUserMock.mockResolvedValue(buildUser({ graduationYear: 2027 }))
+    setRouteQuery({ redirect: '/clubs/5' })
+    const wrapper = mountView()
+
+    await agreeAndSubmit(wrapper)
+
+    expect(replaceMock).toHaveBeenCalledWith('/clubs/5')
+  })
+
+  it('lands a user with no redirect target at all on the default profile page', async () => {
+    fetchMock.mockResolvedValue({ ok: true })
+    fetchAuthenticatedUserMock.mockResolvedValue(buildUser())
+    const wrapper = mountView()
+
+    await agreeAndSubmit(wrapper)
+
+    expect(replaceMock).toHaveBeenCalledWith('/profile')
+  })
+
+  it('does nothing until the agreement checkbox is checked: the submit button is disabled, and even a forced submit is a no-op', async () => {
+    const wrapper = mountView()
+
+    expect(wrapper.find('button[type="submit"]').attributes('disabled')).toBeDefined()
+
+    // Guards against a forced/programmatic submit too, not just the disabled
+    // button: the checkbox is the real gate, not just a UI affordance.
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(replaceMock).not.toHaveBeenCalled()
+  })
+
+  it('enables the submit button and lets it submit once the agreement checkbox is checked', async () => {
+    fetchMock.mockResolvedValue({ ok: true })
+    fetchAuthenticatedUserMock.mockResolvedValue(buildUser())
+    const wrapper = mountView()
+
+    await agreeAndSubmit(wrapper)
+
+    expect(wrapper.find('button[type="submit"]').attributes('disabled')).toBeUndefined()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces an error and does not navigate when the accept-terms request comes back non-ok', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 })
+    const wrapper = mountView()
+
+    await agreeAndSubmit(wrapper)
+
+    expect(wrapper.text()).toContain('Failed to record acceptance')
+    expect(replaceMock).not.toHaveBeenCalled()
+  })
+
+  it('surfaces an error and does not navigate when the accept-terms request itself rejects', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'))
+    const wrapper = mountView()
+
+    await agreeAndSubmit(wrapper)
+
+    expect(wrapper.text()).toContain('network down')
+    expect(replaceMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/views/AuthCallbackView.spec.ts
+++ b/frontend/src/views/AuthCallbackView.spec.ts
@@ -1,0 +1,153 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('vue-router', () => ({
+  useRoute: vi.fn(),
+  useRouter: vi.fn(),
+}))
+
+vi.mock('../services/authService', () => ({
+  fetchAuthProviders: vi.fn(),
+  fetchAuthenticatedUser: vi.fn(),
+  logout: vi.fn(),
+}))
+
+import { useRoute, useRouter } from 'vue-router'
+
+import { fetchAuthenticatedUser } from '../services/authService'
+import type { AuthUser } from '../types/auth'
+import { consumePendingAuthRedirect, savePendingAuthRedirect } from '../utils/authRedirect'
+import AuthCallbackView from './AuthCallbackView.vue'
+
+const useRouteMock = vi.mocked(useRoute)
+const useRouterMock = vi.mocked(useRouter)
+const fetchAuthenticatedUserMock = vi.mocked(fetchAuthenticatedUser)
+
+// A fully-onboarded user by default; individual tests override the fields
+// that make a real difference to the post-auth routing decision.
+const buildUser = (overrides: Partial<AuthUser> = {}): AuthUser => ({
+  id: 'user-1',
+  email: 'ada@example.com',
+  displayName: 'Ada Lovelace',
+  avatarUrl: '',
+  provider: 'google',
+  isOwner: false,
+  graduationYear: 2026,
+  acceptedTerms: true,
+  ...overrides,
+})
+
+let replaceMock: ReturnType<typeof vi.fn>
+
+// Mounts the view with a given `route.query`, waiting for the async
+// onMounted handler (and the store call it awaits) to settle.
+const mountWithQuery = async (query: Record<string, string>) => {
+  useRouteMock.mockReturnValue({ query } as ReturnType<typeof useRoute>)
+  const wrapper = mount(AuthCallbackView)
+  await flushPromises()
+  return wrapper
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  sessionStorage.clear()
+  fetchAuthenticatedUserMock.mockReset()
+  replaceMock = vi.fn()
+  useRouterMock.mockReturnValue({ replace: replaceMock } as unknown as ReturnType<typeof useRouter>)
+  useRouteMock.mockReturnValue({ query: {} } as ReturnType<typeof useRoute>)
+})
+
+describe('AuthCallbackView', () => {
+  it('sends a fully-onboarded user straight to the requested redirect target', async () => {
+    fetchAuthenticatedUserMock.mockResolvedValue(buildUser())
+
+    await mountWithQuery({ redirect: '/clubs/3' })
+
+    expect(replaceMock).toHaveBeenCalledWith('/clubs/3')
+  })
+
+  it('sends a brand-new user (terms not yet accepted) to accept-terms, carrying the target along', async () => {
+    fetchAuthenticatedUserMock.mockResolvedValue(
+      buildUser({ acceptedTerms: false, graduationYear: null }),
+    )
+
+    await mountWithQuery({ redirect: '/clubs/3' })
+
+    expect(replaceMock).toHaveBeenCalledWith({
+      path: '/accept-terms',
+      query: { redirect: '/clubs/3' },
+    })
+  })
+
+  it('sends a user who accepted terms but has no graduation year to onboarding, carrying the target along', async () => {
+    fetchAuthenticatedUserMock.mockResolvedValue(
+      buildUser({ acceptedTerms: true, graduationYear: null }),
+    )
+
+    await mountWithQuery({ redirect: '/clubs/3' })
+
+    expect(replaceMock).toHaveBeenCalledWith({
+      path: '/onboarding',
+      query: { redirect: '/clubs/3' },
+    })
+  })
+
+  it('falls back to a pending redirect saved in sessionStorage when the URL carries none, and consumes it', async () => {
+    savePendingAuthRedirect('/clubs/9')
+    fetchAuthenticatedUserMock.mockResolvedValue(buildUser())
+
+    await mountWithQuery({})
+
+    expect(replaceMock).toHaveBeenCalledWith('/clubs/9')
+    // The pending redirect must not be left behind for a later, unrelated login.
+    expect(consumePendingAuthRedirect()).toBeNull()
+  })
+
+  it('lands a fully-onboarded user with no redirect target at all on the default profile page', async () => {
+    fetchAuthenticatedUserMock.mockResolvedValue(buildUser())
+
+    await mountWithQuery({})
+
+    expect(replaceMock).toHaveBeenCalledWith('/profile')
+  })
+
+  it.each(['https://evil.com', '//evil.com'])(
+    'never lets an attacker-controlled redirect target (%s) reach router.replace, and falls back to the default',
+    async (maliciousTarget) => {
+      fetchAuthenticatedUserMock.mockResolvedValue(buildUser())
+
+      await mountWithQuery({ redirect: maliciousTarget })
+
+      expect(replaceMock).not.toHaveBeenCalledWith(maliciousTarget)
+      expect(replaceMock).toHaveBeenCalledWith('/profile')
+    },
+  )
+
+  it('skips fetching the user entirely when the backend already reports an oauth2 failure, and goes to /auth', async () => {
+    await mountWithQuery({ error: 'oauth2_login_failed' })
+
+    expect(fetchAuthenticatedUserMock).not.toHaveBeenCalled()
+    expect(replaceMock).toHaveBeenCalledWith({
+      path: '/auth',
+      query: { error: 'oauth2_login_failed' },
+    })
+  })
+
+  it('clears a pending redirect on a backend-reported failure so it cannot hijack the next login attempt', async () => {
+    savePendingAuthRedirect('/clubs/9')
+
+    await mountWithQuery({ error: 'oauth2_login_failed' })
+
+    expect(consumePendingAuthRedirect()).toBeNull()
+  })
+
+  it('clears a pending redirect when refreshUser() comes back with no user, so it cannot hijack the next login attempt', async () => {
+    savePendingAuthRedirect('/clubs/9')
+    fetchAuthenticatedUserMock.mockResolvedValue(null)
+
+    await mountWithQuery({})
+
+    expect(consumePendingAuthRedirect()).toBeNull()
+  })
+})

--- a/frontend/src/views/AuthCallbackView.vue
+++ b/frontend/src/views/AuthCallbackView.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from 'vue-router'
 
 import { useAuthStore } from '../stores/auth'
 import {
+  clearPendingAuthRedirect,
   consumePendingAuthRedirect,
   DEFAULT_POST_AUTH_PATH,
   normalizeAuthRedirect,
@@ -19,6 +20,17 @@ const resolveRedirectTarget = () => {
 }
 
 onMounted(async () => {
+  // The backend's OAuth2 failure handler redirects here with `?error=...`
+  // when it already knows the login failed, so there is no session to
+  // fetch. Skip the pointless refreshUser() round trip in that case.
+  if (typeof route.query.error === 'string') {
+    // A stale pending redirect must not survive a failed login and hijack
+    // the user's next, unrelated login attempt.
+    clearPendingAuthRedirect()
+    router.replace({ path: '/auth', query: { error: route.query.error } })
+    return
+  }
+
   await authStore.refreshUser()
 
   if (authStore.isAuthenticated) {
@@ -26,6 +38,7 @@ onMounted(async () => {
     const destination = resolvePostAuthRoute(authStore.currentUser, redirectTarget)
     router.replace(destination ?? DEFAULT_POST_AUTH_PATH)
   } else {
+    clearPendingAuthRedirect()
     router.replace({ path: '/auth', query: { error: 'login_failed' } })
   }
 })

--- a/frontend/src/views/AuthChoiceView.spec.ts
+++ b/frontend/src/views/AuthChoiceView.spec.ts
@@ -1,0 +1,187 @@
+import { h } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// AuthChoiceView imports RouterLink directly from 'vue-router' (rather than
+// relying on the router's auto-registered global component), so the mocked
+// module needs to provide a working stand-in: a plain anchor rendering its
+// `to` prop as `href`, which is enough to assert on the legal links below.
+const { RouterLinkStub } = vi.hoisted(() => {
+  return {
+    RouterLinkStub: {
+      name: 'RouterLink',
+      props: ['to'],
+      render(this: { to: unknown; $slots: { default?: () => unknown } }) {
+        const href = typeof this.to === 'string' ? this.to : JSON.stringify(this.to)
+        const children = this.$slots.default?.()
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return h('a', { href }, children as any)
+      },
+    },
+  }
+})
+
+vi.mock('vue-router', () => ({
+  RouterLink: RouterLinkStub,
+  useRoute: vi.fn(),
+  useRouter: vi.fn(() => ({ push: vi.fn(), back: vi.fn(), replace: vi.fn() })),
+}))
+
+vi.mock('../services/authService', () => ({
+  fetchAuthProviders: vi.fn(),
+  fetchAuthenticatedUser: vi.fn(),
+  logout: vi.fn(),
+}))
+
+import { useRoute } from 'vue-router'
+
+import { fetchAuthProviders } from '../services/authService'
+import type { AuthProvider } from '../types/auth'
+import { useAuthStore } from '../stores/auth'
+import AuthChoiceView from './AuthChoiceView.vue'
+
+const useRouteMock = vi.mocked(useRoute)
+const fetchAuthProvidersMock = vi.mocked(fetchAuthProviders)
+
+const googleProvider: AuthProvider = {
+  id: 'google',
+  name: 'Google',
+  authorizationUrl: '/oauth2/authorization/google',
+}
+const microsoftProvider: AuthProvider = {
+  id: 'microsoft',
+  name: 'Microsoft',
+  authorizationUrl: '/oauth2/authorization/microsoft',
+}
+
+const setRouteQuery = (query: Record<string, string>) => {
+  useRouteMock.mockReturnValue({ query } as ReturnType<typeof useRoute>)
+}
+
+// A deferred promise gives a test control over exactly when the providers
+// fetch resolves, so the loading state can be observed before it settles.
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  fetchAuthProvidersMock.mockReset()
+  setRouteQuery({})
+})
+
+describe('AuthChoiceView', () => {
+  it('renders one enabled provider button per configured provider, with no checkbox gating them', async () => {
+    fetchAuthProvidersMock.mockResolvedValue([googleProvider, microsoftProvider])
+    const wrapper = mount(AuthChoiceView)
+    await flushPromises()
+
+    expect(wrapper.find('input[type="checkbox"]').exists()).toBe(false)
+
+    const buttons = wrapper.findAll('button.provider-btn')
+    expect(buttons).toHaveLength(2)
+    expect(wrapper.text()).toContain('Sign in with Google')
+    expect(wrapper.text()).toContain('Sign in with Microsoft')
+    buttons.forEach((button) => {
+      expect(button.attributes('disabled')).toBeUndefined()
+    })
+  })
+
+  it('renders inline legal copy linking to both the Terms of Use and the Privacy Policy', async () => {
+    fetchAuthProvidersMock.mockResolvedValue([googleProvider])
+    const wrapper = mount(AuthChoiceView)
+    await flushPromises()
+
+    const links = wrapper.findAll('a')
+    const termsLink = links.find((link) => link.text() === 'Terms of Use')
+    const privacyLink = links.find((link) => link.text() === 'Privacy Policy')
+
+    expect(termsLink?.attributes('href')).toBe('/terms')
+    expect(privacyLink?.attributes('href')).toBe('/privacy')
+  })
+
+  it('starts login with the clicked provider and the redirect target carried in the route query', async () => {
+    fetchAuthProvidersMock.mockResolvedValue([googleProvider])
+    setRouteQuery({ redirect: '/clubs/9' })
+    const store = useAuthStore()
+    const beginLoginSpy = vi.spyOn(store, 'beginLogin').mockImplementation(() => {})
+    const wrapper = mount(AuthChoiceView)
+    await flushPromises()
+
+    await wrapper.find('button.provider-btn').trigger('click')
+
+    expect(beginLoginSpy).toHaveBeenCalledWith('google', '/clubs/9')
+  })
+
+  it('starts login with no redirect target when the route query carries none', async () => {
+    fetchAuthProvidersMock.mockResolvedValue([googleProvider])
+    const store = useAuthStore()
+    const beginLoginSpy = vi.spyOn(store, 'beginLogin').mockImplementation(() => {})
+    const wrapper = mount(AuthChoiceView)
+    await flushPromises()
+
+    await wrapper.find('button.provider-btn').trigger('click')
+
+    expect(beginLoginSpy).toHaveBeenCalledWith('google', null)
+  })
+
+  it('shows the route-level error banner when the URL carries an error param', async () => {
+    fetchAuthProvidersMock.mockResolvedValue([googleProvider])
+    setRouteQuery({ error: 'oauth2_login_failed' })
+    const wrapper = mount(AuthChoiceView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('We could not complete your sign in. Please try again.')
+  })
+
+  it('shows a providers-error banner when loading the provider list fails', async () => {
+    fetchAuthProvidersMock.mockRejectedValue(new Error('Providers unavailable'))
+    const wrapper = mount(AuthChoiceView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Providers unavailable')
+    expect(wrapper.find('button.provider-btn').exists()).toBe(false)
+  })
+
+  it('shows the route error and the providers error banners together, since they are independent conditions', async () => {
+    fetchAuthProvidersMock.mockRejectedValue(new Error('Providers unavailable'))
+    setRouteQuery({ error: 'oauth2_login_failed' })
+    const wrapper = mount(AuthChoiceView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('We could not complete your sign in. Please try again.')
+    expect(wrapper.text()).toContain('Providers unavailable')
+  })
+
+  it('shows a loading message while providers are being fetched, and hides it once they arrive', async () => {
+    const deferred = createDeferred<AuthProvider[]>()
+    fetchAuthProvidersMock.mockReturnValue(deferred.promise)
+    const wrapper = mount(AuthChoiceView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Loading sign-in options…')
+    expect(wrapper.find('button.provider-btn').exists()).toBe(false)
+
+    deferred.resolve([googleProvider])
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('Loading sign-in options…')
+    expect(wrapper.text()).toContain('Sign in with Google')
+  })
+
+  it('shows a "no providers configured" message when the provider list loads but is empty', async () => {
+    fetchAuthProvidersMock.mockResolvedValue([])
+    const wrapper = mount(AuthChoiceView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('No OAuth providers are configured yet.')
+    expect(wrapper.find('button.provider-btn').exists()).toBe(false)
+  })
+})

--- a/frontend/src/views/AuthChoiceView.vue
+++ b/frontend/src/views/AuthChoiceView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
 import { storeToRefs } from 'pinia'
 
@@ -9,8 +9,6 @@ import BackButton from '../components/BackButton.vue'
 const route = useRoute()
 const authStore = useAuthStore()
 const { providers, providersLoading, providersError } = storeToRefs(authStore)
-const acceptedTerms = ref(false)
-const termsError = ref('')
 
 onMounted(() => {
   authStore.ensureProvidersLoaded()
@@ -28,11 +26,6 @@ const redirectTarget = computed(() => {
 })
 
 const handleProviderLogin = (providerId: string) => {
-  if (!acceptedTerms.value) {
-    termsError.value = 'Please accept the Terms of Use before continuing.'
-    return
-  }
-  termsError.value = ''
   authStore.beginLogin(providerId, redirectTarget.value)
 }
 </script>
@@ -49,25 +42,20 @@ const handleProviderLogin = (providerId: string) => {
       <div class="alerts">
         <p v-if="routeError" class="alert error">{{ routeError }}</p>
         <p v-if="providersError" class="alert error">{{ providersError }}</p>
-        <p v-if="termsError" class="alert error">{{ termsError }}</p>
         <p v-else-if="providersLoading" class="alert muted">Loading sign-in options…</p>
       </div>
-      <label class="terms-check">
-        <input v-model="acceptedTerms" type="checkbox" @change="termsError = ''" />
-        <span>
-          I agree to the
-          <RouterLink to="/terms" target="_blank">Terms of Use</RouterLink>
-          and
-          <RouterLink to="/privacy" target="_blank">Privacy Policy</RouterLink>.
-        </span>
-      </label>
+      <p class="terms-notice">
+        By continuing you agree to our
+        <RouterLink to="/terms" target="_blank">Terms of Use</RouterLink>
+        and
+        <RouterLink to="/privacy" target="_blank">Privacy Policy</RouterLink>.
+      </p>
       <div v-if="!providersLoading && !providersError" class="provider-list">
         <button
           v-for="provider in providers"
           :key="provider.id"
           class="provider-btn"
           type="button"
-          :disabled="!acceptedTerms"
           @click="handleProviderLogin(provider.id)"
         >
           <span class="provider-icon" aria-hidden="true">{{ provider.name.charAt(0) }}</span>
@@ -157,29 +145,15 @@ const handleProviderLogin = (providerId: string) => {
   box-shadow: var(--mv-shadow-elevated);
 }
 
-.provider-btn:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
-}
-
-.terms-check {
+.terms-notice {
   width: 100%;
-  display: flex;
-  align-items: flex-start;
-  gap: 0.65rem;
+  margin: 0;
   color: var(--mv-text-soft);
   font-size: 0.95rem;
   line-height: 1.5;
 }
 
-.terms-check input {
-  margin-top: 0.25rem;
-  flex: 0 0 auto;
-}
-
-.terms-check a {
+.terms-notice a {
   color: var(--mv-gold);
   font-weight: 600;
 }

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -24,6 +24,8 @@ const yearOptions = computed(() => {
 
 const canSave = computed(() => graduationYear.value !== null && graduationYear.value > 0)
 
+// Deliberately bypasses resolvePostAuthRoute: at this point graduationYear is
+// still null, so the full resolver would just send us back to /onboarding.
 const resolveRedirectTarget = () => sanitizeAuthRedirectTarget(route.query.redirect)
 
 const handleSave = async () => {


### PR DESCRIPTION
Stacked on #68 -- **review that one first**; the base here is `agent/fix-post-auth-redirect`, so this PR's diff shows only the new work. If #68 merges first I will rebase this onto `main`.

Follow-up to the deferred items listed in #68.

## 1. Failed OAuth logins left debris (`ec0fbda`)

The backend's failure handler redirects to `/auth/callback?error=oauth2_login_failed`, but the view never read that param -- it fired a pointless `/api/auth/me`, found no session, and inferred failure. It now reads the param and skips the round trip.

The real bug underneath: `savePendingAuthRedirect()` stashes the intended destination in `sessionStorage` before leaving for the provider, and **nothing cleared it when the login failed**. The stale target then hijacked the user's *next* login -- clicking "Log in" from the navbar deliberately saves no target, so they would be silently dumped at whatever destination a previous failed attempt had wanted. Both failure exits now clear it.

## 2. Terms consent was requested twice (`615f110`)

The sign-in page gated its provider buttons behind a required "I agree" checkbox whose value was **never sent anywhere** and was discarded on navigation to the provider. Because the backend-tracked `acceptedTerms` flag was still false afterwards, the guard sent the user to `/accept-terms` to consent again -- and only that POST is actually recorded. Replaced the blocking checkbox with inline legal copy ("By continuing you agree to...", both links kept); `/accept-terms` remains the single authoritative record, so consent happens explicitly exactly once.

## 3. Three rough edges (`6da6f8f`)

- **Already-authenticated users hitting `/auth`** saw a provider list that made no sense (stale link, browser Back, bookmarked `/auth?redirect=...`). The new guard branch defers to the shared post-auth resolver, so a not-yet-onboarded user still lands on `/accept-terms` or `/onboarding` instead of skipping those steps, and a carried `?redirect=` is honored and sanitized. Only the `auth-choice` route is caught -- `/auth/callback` must stay reachable while authenticated or login itself breaks (pinned by a test).
- **Duplicate `/api/auth/me` on cold load**: `main.ts`'s `bootstrap()` and the router guard both called `refreshUser()` before either resolved, so `hasCheckedSession` was still false and two requests went out. Concurrent callers now share one in-flight promise, cleared on settle so later refreshes still work and a rejection leaves no poisoned promise cached.
- **Dead OAuth fallback**: `beginLogin`'s `/oauth2/authorization/{id}` fallback could not trigger (the backend serves `/api/auth/authorize` and always populates `authorizationUrl`) and would have 404'd if it had. A missing URL now surfaces through `providersError` instead of navigating somewhere that cannot work.

## 4. Test coverage for the login contract (`4bccd8b`)

This flow previously had **zero** tests beyond the pure helpers. Adds 14 guard-level integration tests driving the real router and 26 component tests across the three views -- 78 tests total in the suite now.

**These tests were mutation-verified**, not just observed green. Reintroducing each original bug fails exactly the matching test:

| Mutation | Result |
| --- | --- |
| `AcceptTermsView` jumps straight to the target again | 1 failure -- the headline onboarding regression test |
| Remove the authenticated-`/auth` guard branch | 5 failures across the guard spec |
| Stop clearing the pending redirect on failure | 1 failure -- the hijack test |

## Not done, and why

**`ProfileView`'s unauthenticated branch is NOT dead code** -- I claimed it was when triaging, and that was wrong. The view calls `refreshUser()` itself in `handleGraduationYearSave` (`frontend/src/views/ProfileView.vue:139`); if that call comes back unauthenticated, `isAuthenticated` flips false while the view is still mounted, and `App.vue`'s watcher navigates away asynchronously. The `v-else` branch can render in that window, so deleting it risked a blank-screen flash. Left untouched deliberately.

Still deferred: the backend does not round-trip the redirect target (it survives only via `sessionStorage`, so a cross-tab return or blocked storage falls back to `/profile`) -- that is the next PR, and it is the last item from #68's list.

## Verification

`npm run test:unit -- --run` -> 78 passed; `npm run build` (includes `vue-tsc`) clean; eslint clean on all changed files. Note `AboutView.vue`, `HomeView.vue` and `OwnerAdminView.vue` carry 3 pre-existing unrelated eslint errors, untouched here.
