### PR TITLE
Carry the post-login destination through the OAuth round trip (server-side)

### DIFF
--- a/backend/src/main/java/com/example/demo/auth/config/PostLoginRedirectResolver.java
+++ b/backend/src/main/java/com/example/demo/auth/config/PostLoginRedirectResolver.java
@@ -1,0 +1,121 @@
+package com.example.demo.auth.config;
+
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
+
+/**
+ * Builds the final URL the OAuth2 success/failure handlers redirect the
+ * browser to: the configured post-login redirect URI, plus an optional
+ * {@code redirect} query parameter carrying the frontend's intended in-app
+ * destination, plus an optional {@code error} query parameter.
+ *
+ * <p><strong>Security:</strong> {@code candidateTarget} is fully
+ * attacker-controlled (anyone can link a victim to the authorize endpoint
+ * with any {@code redirect=} value, which the {@link
+ * RedirectCapturingAuthorizationRequestResolver} stashes verbatim without
+ * validation). This class is the single place that value is validated
+ * before being echoed back into a redirect {@code Location} header. A
+ * rejected value is dropped silently — the bare redirect URI (plus any
+ * error param) is returned instead. Login itself never fails because of an
+ * invalid redirect target.
+ */
+public final class PostLoginRedirectResolver {
+
+    /**
+     * Defense-in-depth cap on the length of an in-app redirect target we
+     * will accept and echo back through the OAuth2 callback. Well beyond
+     * anything a legitimate in-app route needs, but short enough to keep
+     * the resulting redirect header small.
+     */
+    static final int MAX_REDIRECT_LENGTH = 2048;
+
+    private static final String REDIRECT_PARAM = "redirect";
+    private static final String ERROR_PARAM = "error";
+
+    private PostLoginRedirectResolver() {
+    }
+
+    /**
+     * Builds the redirect URI with a validated {@code redirect} param, if
+     * {@code candidateTarget} is safe, and no {@code error} param.
+     */
+    public static String buildRedirectUri(String baseRedirectUri, String candidateTarget) {
+        return buildRedirectUri(baseRedirectUri, candidateTarget, null);
+    }
+
+    /**
+     * Builds the redirect URI with a validated {@code redirect} param, if
+     * {@code candidateTarget} is safe, and an {@code error} param, if
+     * {@code errorCode} is present.
+     *
+     * <p>Both parameters are percent-encoded exactly once: the raw values
+     * are handed to {@link UriComponentsBuilder} and the resulting
+     * {@link org.springframework.web.util.UriComponents} is built with
+     * {@code build(true)} (components already encoded) so that {@code
+     * toUriString()} does not re-encode them.
+     */
+    public static String buildRedirectUri(String baseRedirectUri, String candidateTarget, String errorCode) {
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(baseRedirectUri);
+
+        if (isSafeInAppTarget(candidateTarget)) {
+            builder.queryParam(REDIRECT_PARAM, UriUtils.encodeQueryParam(candidateTarget, StandardCharsets.UTF_8));
+        }
+
+        if (StringUtils.hasText(errorCode)) {
+            builder.queryParam(ERROR_PARAM, UriUtils.encodeQueryParam(errorCode, StandardCharsets.UTF_8));
+        }
+
+        return builder.build(true).toUriString();
+    }
+
+    /**
+     * Returns {@code true} only when {@code candidate} is safe to treat as
+     * an in-app relative path (optionally carrying its own query string
+     * and/or fragment). Rejects (non-exhaustive rationale in parentheses):
+     * <ul>
+     *   <li>{@code null}/blank values</li>
+     *   <li>anything not starting with {@code /} (absolute URLs, scheme-bearing
+     *       values such as {@code javascript:...} or {@code mailto:...})</li>
+     *   <li>{@code //evil.com} and {@code /\evil.com} (protocol-relative:
+     *       browsers treat a leading {@code //} or {@code /\} as "same
+     *       scheme, different host")</li>
+     *   <li>any value containing {@code ://} (an embedded absolute URL)</li>
+     *   <li>values containing CR, LF, TAB, or any other control character
+     *       (HTTP header / redirect response splitting)</li>
+     *   <li>values longer than {@link #MAX_REDIRECT_LENGTH}</li>
+     * </ul>
+     */
+    static boolean isSafeInAppTarget(String candidate) {
+        if (!StringUtils.hasText(candidate)) {
+            return false;
+        }
+        if (candidate.length() > MAX_REDIRECT_LENGTH) {
+            return false;
+        }
+        if (!candidate.startsWith("/")) {
+            return false;
+        }
+        if (candidate.length() > 1) {
+            char second = candidate.charAt(1);
+            if (second == '/' || second == '\\') {
+                return false;
+            }
+        }
+        if (candidate.contains("://")) {
+            return false;
+        }
+        return !containsControlCharacter(candidate);
+    }
+
+    private static boolean containsControlCharacter(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            if (Character.isISOControl(value.charAt(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/backend/src/main/java/com/example/demo/auth/config/PostLoginRedirectResolver.java
+++ b/backend/src/main/java/com/example/demo/auth/config/PostLoginRedirectResolver.java
@@ -61,14 +61,41 @@ public final class PostLoginRedirectResolver {
         UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(baseRedirectUri);
 
         if (isSafeInAppTarget(candidateTarget)) {
-            builder.queryParam(REDIRECT_PARAM, UriUtils.encodeQueryParam(candidateTarget, StandardCharsets.UTF_8));
+            builder.queryParam(REDIRECT_PARAM, encodeQueryParamForFrontendRouter(candidateTarget));
         }
 
         if (StringUtils.hasText(errorCode)) {
+            // errorCode is always one of our own fixed literal error codes
+            // (e.g. "oauth2_login_failed"), never attacker- or user-supplied
+            // text, so it can never contain a literal '+'. No need for the
+            // same escaping as the redirect target below.
             builder.queryParam(ERROR_PARAM, UriUtils.encodeQueryParam(errorCode, StandardCharsets.UTF_8));
         }
 
         return builder.build(true).toUriString();
+    }
+
+    /**
+     * Percent-encodes a value for use as a single query parameter, with one
+     * extra pass beyond {@link UriUtils#encodeQueryParam}: a literal
+     * {@code +} in the input is additionally escaped to {@code %2B}.
+     *
+     * <p>{@code +} is a legal, unreserved-by-RFC-3986 character inside a
+     * URI query component, so {@code encodeQueryParam} deliberately leaves
+     * it untouched. That is correct for RFC 3986 consumers, but vue-router
+     * (like most {@code application/x-www-form-urlencoded} query parsers)
+     * decodes an unescaped {@code +} in a query string as a space. Left
+     * alone, a target such as {@code /search?q=C++} would arrive at the
+     * frontend as {@code /search?q=C  }. Escaping it to {@code %2B} here
+     * keeps the value byte-for-byte round-trippable by any correct decoder
+     * without double-encoding anything else: {@code encodeQueryParam} never
+     * itself emits a literal {@code +} (it turns a literal space into
+     * {@code %20}), so every {@code +} seen after encoding came from a
+     * {@code +} in the original input.
+     */
+    private static String encodeQueryParamForFrontendRouter(String value) {
+        String encoded = UriUtils.encodeQueryParam(value, StandardCharsets.UTF_8);
+        return encoded.replace("+", "%2B");
     }
 
     /**

--- a/backend/src/main/java/com/example/demo/auth/config/RedirectCapturingAuthorizationRequestResolver.java
+++ b/backend/src/main/java/com/example/demo/auth/config/RedirectCapturingAuthorizationRequestResolver.java
@@ -1,0 +1,126 @@
+package com.example.demo.auth.config;
+
+import java.util.function.Supplier;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.util.StringUtils;
+
+/**
+ * Wraps the {@link DefaultOAuth2AuthorizationRequestResolver} to also
+ * capture the frontend's intended post-login destination — the {@code
+ * redirect} query parameter on the authorize request — and stash it in the
+ * {@link HttpSession} for the duration of the OAuth2 round trip, so the
+ * success/failure handlers can echo it back into the callback redirect
+ * (see {@link PostLoginRedirectResolver}).
+ *
+ * <p><strong>Only capture on genuine authorize requests.</strong>
+ * {@code OAuth2AuthorizationRequestRedirectFilter} (the framework class that
+ * drives this resolver) calls {@code resolve(request)} unconditionally on
+ * <em>every</em> request that reaches it, not just ones aimed at the
+ * authorization endpoint, and only null-checks the result afterwards. The
+ * delegate only returns a non-null {@link OAuth2AuthorizationRequest} (or
+ * throws, e.g. {@code InvalidClientRegistrationIdException}) once it has
+ * already decided — from the request path for {@link #resolve(HttpServletRequest)},
+ * or from a non-null {@code clientRegistrationId} for
+ * {@link #resolve(HttpServletRequest, String)} — that this genuinely is an
+ * attempt to build an authorization request. A clean {@code null} return
+ * means the opposite: the request doesn't match the authorize shape at all
+ * (e.g. the provider's callback request, an unrelated API call, a static
+ * asset). We treat "the delegate produced a result, successfully or not" as
+ * that signal, so the session is touched only for real authorize attempts —
+ * never for the callback request or any other unrelated request in the same
+ * session, which would otherwise wipe the just-captured target before the
+ * success/failure handler ever reads it back.
+ *
+ * <p><strong>No session is created just to clear a value.</strong> A
+ * request that turns out not to carry a {@code redirect} param, but that IS
+ * a genuine authorize attempt, still clears any previously-stashed value
+ * (an anti-hijack measure: a login attempt with no explicit target must not
+ * inherit a stale one from an earlier, abandoned attempt in the same
+ * browser session). That clearing only touches a session that already
+ * exists ({@code getSession(false)}); it never eagerly allocates one. A
+ * session is created ({@code getSession(true)}) only when there is an
+ * actual value to store.
+ *
+ * <p>The captured value is NOT semantically validated here: it is fully
+ * attacker-controlled (anyone can send a victim a link to the authorize
+ * endpoint with any {@code redirect=} value) and is deliberately kept out
+ * of the OAuth {@code state} parameter or any other value that round-trips
+ * through the identity provider, since that would make it attacker-visible
+ * and attacker-modifiable in transit. Stashing the raw value in the
+ * server-side session is safe because it is only ever read back by this
+ * same server, for this same browser session, and is semantically
+ * validated exactly once — in {@link PostLoginRedirectResolver} — before it
+ * is ever echoed back into a redirect {@code Location} header. The one
+ * exception is the length cap below, applied here too, before storing, so
+ * an unbounded attacker-controlled string can't sit in server-side session
+ * storage for the lifetime of the OAuth2 round trip; see the field javadoc
+ * for why that specific, narrow check is duplicated rather than shared.
+ */
+public class RedirectCapturingAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+    /** Package-visible so {@link SecurityConfig} can read it back after login. */
+    static final String SESSION_ATTRIBUTE =
+        RedirectCapturingAuthorizationRequestResolver.class.getName() + ".REDIRECT_TARGET";
+
+    private static final String REDIRECT_PARAM = "redirect";
+
+    private final DefaultOAuth2AuthorizationRequestResolver delegate;
+
+    public RedirectCapturingAuthorizationRequestResolver(
+            ClientRegistrationRepository clientRegistrationRepository, String authorizationRequestBaseUri) {
+        this.delegate =
+            new DefaultOAuth2AuthorizationRequestResolver(clientRegistrationRepository, authorizationRequestBaseUri);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        return resolveAndCaptureIfGenuineAttempt(request, () -> delegate.resolve(request));
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+        return resolveAndCaptureIfGenuineAttempt(request, () -> delegate.resolve(request, clientRegistrationId));
+    }
+
+    /**
+     * Invokes {@code delegateCall} and captures the redirect target only
+     * when the delegate's own outcome shows this was a genuine authorize
+     * attempt: it produced an {@link OAuth2AuthorizationRequest}, or it
+     * threw trying to (e.g. an authorize-shaped path with an unknown
+     * registration id). A clean {@code null} return — the delegate's own
+     * signal that this request doesn't match the authorize shape at all —
+     * skips capture entirely.
+     */
+    private OAuth2AuthorizationRequest resolveAndCaptureIfGenuineAttempt(
+            HttpServletRequest request, Supplier<OAuth2AuthorizationRequest> delegateCall) {
+        OAuth2AuthorizationRequest authorizationRequest;
+        try {
+            authorizationRequest = delegateCall.get();
+        } catch (RuntimeException ex) {
+            captureRedirectTarget(request);
+            throw ex;
+        }
+        if (authorizationRequest != null) {
+            captureRedirectTarget(request);
+        }
+        return authorizationRequest;
+    }
+
+    private void captureRedirectTarget(HttpServletRequest request) {
+        String redirectTarget = request.getParameter(REDIRECT_PARAM);
+        if (StringUtils.hasText(redirectTarget) && redirectTarget.length() <= PostLoginRedirectResolver.MAX_REDIRECT_LENGTH) {
+            request.getSession(true).setAttribute(SESSION_ATTRIBUTE, redirectTarget);
+            return;
+        }
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.removeAttribute(SESSION_ATTRIBUTE);
+        }
+    }
+}

--- a/backend/src/main/java/com/example/demo/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/demo/auth/config/SecurityConfig.java
@@ -3,7 +3,9 @@ package com.example.demo.auth.config;
 import java.util.List;
 
 import com.example.demo.security.CustomOAuth2UserService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
@@ -19,7 +22,6 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Configuration
 @EnableWebSecurity
@@ -28,11 +30,14 @@ public class SecurityConfig {
 
     private final SecurityProperties securityProperties;
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final ClientRegistrationRepository clientRegistrationRepository;
 
     public SecurityConfig(SecurityProperties securityProperties,
-                          CustomOAuth2UserService customOAuth2UserService) {
+                          CustomOAuth2UserService customOAuth2UserService,
+                          ClientRegistrationRepository clientRegistrationRepository) {
         this.securityProperties = securityProperties;
         this.customOAuth2UserService = customOAuth2UserService;
+        this.clientRegistrationRepository = clientRegistrationRepository;
     }
 
     @Bean
@@ -60,19 +65,17 @@ public class SecurityConfig {
                 .anyRequest().permitAll())
             .oauth2Login(oauth2 -> oauth2
                 .authorizationEndpoint(authorization -> authorization
-                    .baseUri(resolveAuthorizationRequestBaseUri()))
+                    .baseUri(resolveAuthorizationRequestBaseUri())
+                    .authorizationRequestResolver(new RedirectCapturingAuthorizationRequestResolver(
+                        clientRegistrationRepository, resolveAuthorizationRequestBaseUri())))
                 .redirectionEndpoint(redirection -> redirection.baseUri("/api/auth/*/callback"))
                 .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                 .successHandler((request, response, authentication) ->
-                    response.sendRedirect(resolveLoginRedirectUri()))
-                .failureHandler((request, response, exception) -> {
-                    String targetUrl = UriComponentsBuilder
-                        .fromUriString(resolveLoginRedirectUri())
-                        .queryParam("error", "oauth2_login_failed")
-                        .build()
-                        .toUriString();
-                    response.sendRedirect(targetUrl);
-                }))
+                    response.sendRedirect(PostLoginRedirectResolver.buildRedirectUri(
+                        resolveLoginRedirectUri(), consumeSessionRedirectTarget(request))))
+                .failureHandler((request, response, exception) ->
+                    response.sendRedirect(PostLoginRedirectResolver.buildRedirectUri(
+                        resolveLoginRedirectUri(), consumeSessionRedirectTarget(request), "oauth2_login_failed"))))
             .logout(logout -> logout
                 .logoutUrl("/api/auth/logout")
                 .logoutSuccessHandler((request, response, authentication) ->
@@ -108,6 +111,22 @@ public class SecurityConfig {
             return configured;
         }
         return OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI;
+    }
+
+    /**
+     * Reads back the redirect target that {@link RedirectCapturingAuthorizationRequestResolver}
+     * stashed in the session when the authorize request was first made, and
+     * removes it so it cannot leak into a later, unrelated login attempt in
+     * the same browser session.
+     */
+    private String consumeSessionRedirectTarget(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            return null;
+        }
+        Object redirectTarget = session.getAttribute(RedirectCapturingAuthorizationRequestResolver.SESSION_ATTRIBUTE);
+        session.removeAttribute(RedirectCapturingAuthorizationRequestResolver.SESSION_ATTRIBUTE);
+        return redirectTarget instanceof String ? (String) redirectTarget : null;
     }
 }
 /**

--- a/backend/src/test/java/com/example/demo/auth/config/PostLoginRedirectResolverTest.java
+++ b/backend/src/test/java/com/example/demo/auth/config/PostLoginRedirectResolverTest.java
@@ -1,0 +1,145 @@
+package com.example.demo.auth.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
+
+/**
+ * Plain unit tests for {@link PostLoginRedirectResolver} — no Spring context
+ * needed, since the class under test has no framework dependencies beyond a
+ * couple of stateless Spring Web helper classes.
+ *
+ * <p>Note: {@code UriUtils.encodeQueryParam} leaves {@code /} and {@code ?}
+ * un-encoded (they carry no special meaning once already inside a URI's
+ * query component) but does encode {@code = & # %} and whitespace (which
+ * would otherwise be parsed as delimiters, or corrupt a later decode pass).
+ * The literal expected strings below were captured from the real output of
+ * {@link PostLoginRedirectResolver#buildRedirectUri}, not hand-derived.
+ */
+class PostLoginRedirectResolverTest {
+
+    private static final String CALLBACK = "https://frontend.example.com/auth/callback";
+
+    @Test
+    void appendsAValidInAppTargetEncodedExactlyOnce() {
+        String result = PostLoginRedirectResolver.buildRedirectUri(CALLBACK, "/clubs/9?tab=events");
+
+        assertThat(result).isEqualTo(
+            "https://frontend.example.com/auth/callback?redirect=/clubs/9?tab%3Devents");
+        assertThat(decodeRedirectParam(result)).isEqualTo("/clubs/9?tab=events");
+    }
+
+    @Test
+    void queryStringAndFragmentSurviveTheRoundTripIntact() {
+        String target = "/search?q=chess&sort=name#results";
+
+        String result = PostLoginRedirectResolver.buildRedirectUri(CALLBACK, target);
+
+        assertThat(decodeRedirectParam(result)).isEqualTo(target);
+    }
+
+    @Test
+    void aLiteralPercentSignInTheTargetIsNotDoubleEncodedOrDoubleDecoded() {
+        // If encoding ran twice, "%" (encoded once to "%25") would become
+        // "%2525"; if decoding happened anywhere it shouldn't, "%25" would
+        // decode back to "%" before the browser/frontend ever sees it. The
+        // round trip must land on exactly the original string.
+        String target = "/search?q=50%off";
+
+        String result = PostLoginRedirectResolver.buildRedirectUri(CALLBACK, target);
+
+        assertThat(result).contains("q%3D50%25off");
+        assertThat(decodeRedirectParam(result)).isEqualTo(target);
+    }
+
+    @Test
+    void noTargetYieldsTheBareCallbackUrl() {
+        assertThat(PostLoginRedirectResolver.buildRedirectUri(CALLBACK, null)).isEqualTo(CALLBACK);
+        assertThat(PostLoginRedirectResolver.buildRedirectUri(CALLBACK, "")).isEqualTo(CALLBACK);
+        assertThat(PostLoginRedirectResolver.buildRedirectUri(CALLBACK, "   ")).isEqualTo(CALLBACK);
+    }
+
+    @Test
+    void rejectsProtocolRelativeDoubleSlash() {
+        assertThat(PostLoginRedirectResolver.buildRedirectUri(CALLBACK, "//evil.com")).isEqualTo(CALLBACK);
+    }
+
+    @Test
+    void rejectsBackslashProtocolRelativeVariant() {
+        assertThat(PostLoginRedirectResolver.buildRedirectUri(CALLBACK, "/\\evil.com")).isEqualTo(CALLBACK);
+    }
+
+    @Test
+    void rejectsAbsoluteUrl() {
+        assertThat(PostLoginRedirectResolver.buildRedirectUri(CALLBACK, "https://evil.com")).isEqualTo(CALLBACK);
+    }
+
+    @Test
+    void rejectsSchemeBearingValueWithoutLeadingSlash() {
+        assertThat(PostLoginRedirectResolver.buildRedirectUri(CALLBACK, "javascript:alert(1)")).isEqualTo(CALLBACK);
+    }
+
+    @Test
+    void rejectsEmbeddedSchemeEvenWithLeadingSlash() {
+        assertThat(PostLoginRedirectResolver.buildRedirectUri(CALLBACK, "/redirect?to=https://evil.com"))
+            .isEqualTo(CALLBACK);
+    }
+
+    @Test
+    void rejectsCarriageReturnLineFeedInjection() {
+        assertThat(PostLoginRedirectResolver.buildRedirectUri(CALLBACK, "/profile\r\nSet-Cookie:evil=1"))
+            .isEqualTo(CALLBACK);
+    }
+
+    @Test
+    void rejectsTabCharacter() {
+        assertThat(PostLoginRedirectResolver.buildRedirectUri(CALLBACK, "/pro\tfile")).isEqualTo(CALLBACK);
+    }
+
+    @Test
+    void rejectsOverLengthValues() {
+        String tooLong = "/" + "a".repeat(PostLoginRedirectResolver.MAX_REDIRECT_LENGTH);
+        assertThat(PostLoginRedirectResolver.buildRedirectUri(CALLBACK, tooLong)).isEqualTo(CALLBACK);
+    }
+
+    @Test
+    void rejectsNonSlashPrefixedValue() {
+        assertThat(PostLoginRedirectResolver.buildRedirectUri(CALLBACK, "profile")).isEqualTo(CALLBACK);
+    }
+
+    @Test
+    void appendsErrorParamWithoutARedirectTarget() {
+        String result = PostLoginRedirectResolver.buildRedirectUri(CALLBACK, null, "oauth2_login_failed");
+
+        assertThat(result).isEqualTo(
+            "https://frontend.example.com/auth/callback?error=oauth2_login_failed");
+    }
+
+    @Test
+    void appendsBothRedirectAndErrorParamsOnFailureWithARememberedTarget() {
+        String result = PostLoginRedirectResolver.buildRedirectUri(CALLBACK, "/clubs/9", "oauth2_login_failed");
+
+        assertThat(result).isEqualTo(
+            "https://frontend.example.com/auth/callback?redirect=/clubs/9&error=oauth2_login_failed");
+    }
+
+    @Test
+    void dropsAnInvalidTargetButStillAppendsTheErrorParam() {
+        String result = PostLoginRedirectResolver.buildRedirectUri(CALLBACK, "//evil.com", "oauth2_login_failed");
+
+        assertThat(result).isEqualTo(
+            "https://frontend.example.com/auth/callback?error=oauth2_login_failed");
+    }
+
+    private static String decodeRedirectParam(String builtUri) {
+        String encoded = UriComponentsBuilder.fromUriString(builtUri)
+            .build()
+            .getQueryParams()
+            .getFirst("redirect");
+        return UriUtils.decode(encoded, StandardCharsets.UTF_8);
+    }
+}

--- a/backend/src/test/java/com/example/demo/auth/config/PostLoginRedirectResolverTest.java
+++ b/backend/src/test/java/com/example/demo/auth/config/PostLoginRedirectResolverTest.java
@@ -57,6 +57,44 @@ class PostLoginRedirectResolverTest {
     }
 
     @Test
+    void aLiteralPlusInAQueryStringSurvivesTheRoundTripInsteadOfBecomingASpace() {
+        // vue-router (like most application/x-www-form-urlencoded query
+        // parsers) decodes an unescaped '+' in a query string as a space.
+        // UriUtils.encodeQueryParam leaves '+' alone since it is a legal
+        // RFC 3986 query character, so it must be escaped to "%2B" here or
+        // a search for "C++" would arrive at the frontend as "C  ".
+        String target = "/search?q=C++";
+
+        String result = PostLoginRedirectResolver.buildRedirectUri(CALLBACK, target);
+
+        assertThat(result).contains("q%3DC%2B%2B");
+        assertThat(result).doesNotContain("q%3DC++");
+        assertThat(decodeRedirectParam(result)).isEqualTo(target);
+    }
+
+    @Test
+    void aLiteralPlusInABarePathSurvivesTheRoundTrip() {
+        String target = "/clubs/a+b";
+
+        String result = PostLoginRedirectResolver.buildRedirectUri(CALLBACK, target);
+
+        assertThat(result).contains("/clubs/a%2Bb");
+        assertThat(decodeRedirectParam(result)).isEqualTo(target);
+    }
+
+    @Test
+    void ampersandEqualsHashAndPercentStillRoundTripAfterThePlusFix() {
+        // Re-asserts an existing payload shape covered above, guarding
+        // against a regression in the encoder introduced while fixing the
+        // '+' handling.
+        String target = "/search?q=50%off&sort=name#results";
+
+        String result = PostLoginRedirectResolver.buildRedirectUri(CALLBACK, target);
+
+        assertThat(decodeRedirectParam(result)).isEqualTo(target);
+    }
+
+    @Test
     void noTargetYieldsTheBareCallbackUrl() {
         assertThat(PostLoginRedirectResolver.buildRedirectUri(CALLBACK, null)).isEqualTo(CALLBACK);
         assertThat(PostLoginRedirectResolver.buildRedirectUri(CALLBACK, "")).isEqualTo(CALLBACK);
@@ -133,6 +171,40 @@ class PostLoginRedirectResolverTest {
 
         assertThat(result).isEqualTo(
             "https://frontend.example.com/auth/callback?error=oauth2_login_failed");
+    }
+
+    @Test
+    void aLiteralSpacePremiseForThePlusEscapeHoldsSpaceStaysPercentTwentyNotPlus() {
+        // Pins the unstated premise behind encodeQueryParamForFrontendRouter's
+        // ".replace("+", "%2B")" pass: UriUtils.encodeQueryParam must encode
+        // a literal space as "%20", never emit a bare '+' on its own. If that
+        // ever stopped being true, the replace() above would rewrite an
+        // encoder-emitted '+' into "%2B", silently turning every space in a
+        // redirect target into a literal '+'. Asserting "%20" (not "+") is
+        // present, and that the round trip preserves the space intact, is
+        // what would catch that regression.
+        String target = "/search?q=chess club";
+
+        String result = PostLoginRedirectResolver.buildRedirectUri(CALLBACK, target);
+
+        assertThat(result).contains("%20");
+        assertThat(result).doesNotContain("+");
+        assertThat(decodeRedirectParam(result)).isEqualTo(target);
+    }
+
+    @Test
+    void aLiteralSpaceAndPlusTogetherDoNotGetConflatedByThePlusEscape() {
+        // Same premise as above, but with a space and a literal '+' in the
+        // same value: this is the case that would actually break if
+        // encodeQueryParam's space and '+' encodings were ever conflated
+        // (e.g. a switch to form-style encoding where a space also becomes
+        // '+'). Both characters must survive the round trip distinctly.
+        String target = "/search?q=C++ tutorial";
+
+        String result = PostLoginRedirectResolver.buildRedirectUri(CALLBACK, target);
+
+        assertThat(result).contains("q%3DC%2B%2B%20tutorial");
+        assertThat(decodeRedirectParam(result)).isEqualTo(target);
     }
 
     private static String decodeRedirectParam(String builtUri) {

--- a/backend/src/test/java/com/example/demo/auth/config/RedirectCapturingAuthorizationRequestResolverTest.java
+++ b/backend/src/test/java/com/example/demo/auth/config/RedirectCapturingAuthorizationRequestResolverTest.java
@@ -1,0 +1,249 @@
+package com.example.demo.auth.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
+/**
+ * Plain unit tests for {@link RedirectCapturingAuthorizationRequestResolver}
+ * — no Spring context needed. The delegate ({@code
+ * DefaultOAuth2AuthorizationRequestResolver}) is constructed with a real
+ * {@link InMemoryClientRegistrationRepository} holding one dummy Google-like
+ * {@link ClientRegistration}, registered under {@link #BASE_URI}, so that a
+ * {@code GET {BASE_URI}/google} request is a <em>genuine</em> authorize
+ * request as far as the delegate is concerned — it actually returns a
+ * non-null {@code OAuth2AuthorizationRequest} — rather than a request the
+ * wrapper merely hopes looks like one. That distinction matters because the
+ * wrapper only captures the redirect target when the delegate's own outcome
+ * says this is a real authorize attempt (see the production class javadoc):
+ * a request whose path doesn't match {@link #BASE_URI}{@code /{registrationId}}
+ * at all (e.g. {@link #NON_MATCHING_PATH}, or the provider's callback
+ * request) makes the delegate return a clean {@code null}, and the wrapper
+ * must not touch the session for those.
+ *
+ * <p>The {@code resolve(request, clientRegistrationId)} overload never
+ * consults the request path at all — only the explicit {@code
+ * clientRegistrationId} argument matters. Supplying an id that isn't
+ * registered (see {@link #UNKNOWN_REGISTRATION_ID}) still counts as a
+ * genuine authorize *attempt* (the caller unambiguously asked to build an
+ * authorization request for a specific client), so the delegate throws
+ * {@code InvalidClientRegistrationIdException} (a package-private subclass
+ * of {@link IllegalArgumentException}) rather than returning {@code null}
+ * — and the wrapper still captures before letting that exception propagate.
+ */
+class RedirectCapturingAuthorizationRequestResolverTest {
+
+    /** Same shape as {@code app.security.authorization-request-base-uri}'s default (see {@code application.yaml}). */
+    private static final String BASE_URI = "/api/auth/authorize";
+    private static final String REGISTERED_ID = "google";
+    private static final String MATCHING_PATH = BASE_URI + "/" + REGISTERED_ID;
+    private static final String NON_MATCHING_PATH = "/not/an/authorization/request";
+    private static final String UNKNOWN_REGISTRATION_ID = "not-registered";
+
+    private final RedirectCapturingAuthorizationRequestResolver resolver =
+        new RedirectCapturingAuthorizationRequestResolver(googleClientRegistrationRepository(), BASE_URI);
+
+    @Test
+    void storesTheRedirectParamValueInTheSession() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", MATCHING_PATH);
+        request.setParameter("redirect", "/clubs/9");
+
+        resolver.resolve(request);
+
+        assertThat(sessionAttribute(request)).isEqualTo("/clubs/9");
+    }
+
+    @Test
+    void anAuthorizeRequestWithNoRedirectParamClearsAStaleTargetSoItCannotHijackTheNextLogin() {
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(RedirectCapturingAuthorizationRequestResolver.SESSION_ATTRIBUTE, "/clubs/9");
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", MATCHING_PATH);
+        request.setSession(session);
+        // No "redirect" parameter set: this is an unrelated/abandoned login
+        // attempt arriving on a browser session that still remembers a
+        // target from an earlier, different login flow.
+
+        resolver.resolve(request);
+
+        assertThat(session.getAttribute(RedirectCapturingAuthorizationRequestResolver.SESSION_ATTRIBUTE)).isNull();
+    }
+
+    @Test
+    void emptyOrBlankRedirectParamClearsRatherThanStoresAStaleTarget() {
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(RedirectCapturingAuthorizationRequestResolver.SESSION_ATTRIBUTE, "/clubs/9");
+        MockHttpServletRequest emptyRequest = new MockHttpServletRequest("GET", MATCHING_PATH);
+        emptyRequest.setSession(session);
+        emptyRequest.setParameter("redirect", "");
+
+        resolver.resolve(emptyRequest);
+
+        assertThat(session.getAttribute(RedirectCapturingAuthorizationRequestResolver.SESSION_ATTRIBUTE)).isNull();
+
+        session.setAttribute(RedirectCapturingAuthorizationRequestResolver.SESSION_ATTRIBUTE, "/clubs/9");
+        MockHttpServletRequest blankRequest = new MockHttpServletRequest("GET", MATCHING_PATH);
+        blankRequest.setSession(session);
+        blankRequest.setParameter("redirect", "   ");
+
+        resolver.resolve(blankRequest);
+
+        assertThat(session.getAttribute(RedirectCapturingAuthorizationRequestResolver.SESSION_ATTRIBUTE)).isNull();
+    }
+
+    @Test
+    void storesAHostilePayloadVerbatimBecauseValidationHappensOnceInPostLoginRedirectResolver() {
+        // This class deliberately does NOT semantically validate the
+        // redirect target — see PostLoginRedirectResolver, which is the
+        // single place that validation happens, right before the value is
+        // ever echoed back into a redirect Location header. A
+        // protocol-relative value like "//evil.com" is exactly the kind of
+        // payload PostLoginRedirectResolver rejects; it is asserted here
+        // purely to document (and pin) that this class stores it unexamined
+        // (it is well within the length cap, so that narrower check does
+        // not interfere either).
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", MATCHING_PATH);
+        request.setParameter("redirect", "//evil.com");
+
+        resolver.resolve(request);
+
+        assertThat(sessionAttribute(request)).isEqualTo("//evil.com");
+    }
+
+    @Test
+    void bothResolveOverloadsCaptureTheRedirectTarget() {
+        MockHttpServletRequest oneArgRequest = new MockHttpServletRequest("GET", MATCHING_PATH);
+        oneArgRequest.setParameter("redirect", "/clubs/1");
+
+        resolver.resolve(oneArgRequest);
+
+        assertThat(sessionAttribute(oneArgRequest)).isEqualTo("/clubs/1");
+
+        MockHttpServletRequest twoArgRequest = new MockHttpServletRequest("GET", NON_MATCHING_PATH);
+        twoArgRequest.setParameter("redirect", "/clubs/2");
+
+        // The two-arg overload never looks at the request path — only the
+        // explicit registration id matters. UNKNOWN_REGISTRATION_ID isn't in
+        // the repository, so the delegate throws rather than returning
+        // null; the capture happens before that call fails, so the session
+        // assertion still holds.
+        assertThatThrownBy(() -> resolver.resolve(twoArgRequest, UNKNOWN_REGISTRATION_ID))
+            .isInstanceOf(IllegalArgumentException.class);
+
+        assertThat(sessionAttribute(twoArgRequest)).isEqualTo("/clubs/2");
+    }
+
+    @Test
+    void aRequestWithNoPreExistingSessionCreatesOneAndStoresAValidTarget() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", MATCHING_PATH);
+        request.setParameter("redirect", "/clubs/9");
+
+        assertThat(request.getSession(false)).isNull();
+
+        assertThatCode(() -> resolver.resolve(request)).doesNotThrowAnyException();
+
+        assertThat(request.getSession(false)).isNotNull();
+        assertThat(sessionAttribute(request)).isEqualTo("/clubs/9");
+    }
+
+    @Test
+    void aStoredRedirectTargetSurvivesTheProviderCallbackRequest() {
+        // This is the Bug 1 regression: OAuth2AuthorizationRequestRedirectFilter
+        // calls resolve(request) on every request that reaches it, including
+        // the provider's own callback request once the user has authenticated.
+        // That request carries no "redirect" param, so if the wrapper is not
+        // gated on the delegate's own decision, it wipes the just-captured
+        // target before the success handler ever reads it back — silently
+        // breaking the whole feature. The callback path below does not match
+        // BASE_URI + "/{registrationId}", so the delegate returns a clean
+        // null and this resolver must leave the session alone.
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(RedirectCapturingAuthorizationRequestResolver.SESSION_ATTRIBUTE, "/clubs/9");
+        MockHttpServletRequest callbackRequest = new MockHttpServletRequest("GET", "/api/auth/google/callback");
+        callbackRequest.setSession(session);
+        callbackRequest.setParameter("code", "authorization-code-from-provider");
+        callbackRequest.setParameter("state", "state-value-from-provider");
+
+        resolver.resolve(callbackRequest);
+
+        assertThat(session.getAttribute(RedirectCapturingAuthorizationRequestResolver.SESSION_ATTRIBUTE))
+            .isEqualTo("/clubs/9");
+    }
+
+    @Test
+    void aNonAuthorizeRequestWithNoRedirectParamDoesNotCreateASession() {
+        // This is the Bug 2 regression: since resolve(request) runs on every
+        // request (see the test above), eagerly calling getSession(true)
+        // for a request that isn't even an authorize attempt would allocate
+        // an HttpSession (and emit a Set-Cookie: JSESSIONID) for every
+        // anonymous hit to a public endpoint.
+        MockHttpServletRequest callbackRequest = new MockHttpServletRequest("GET", "/api/auth/google/callback");
+        callbackRequest.setParameter("code", "authorization-code-from-provider");
+        callbackRequest.setParameter("state", "state-value-from-provider");
+
+        assertThat(callbackRequest.getSession(false)).isNull();
+
+        resolver.resolve(callbackRequest);
+
+        assertThat(callbackRequest.getSession(false)).isNull();
+    }
+
+    @Test
+    void aGenuineAuthorizeRequestWithNoRedirectParamStillClearsAStaleTarget() {
+        // The anti-hijack clearing behavior (see
+        // anAuthorizeRequestWithNoRedirectParamClearsAStaleTargetSoItCannotHijackTheNextLogin
+        // above) must survive the Bug 1 fix for genuine authorize requests,
+        // not just disappear along with the over-eager capture-on-every-request
+        // behavior that caused Bug 1.
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(RedirectCapturingAuthorizationRequestResolver.SESSION_ATTRIBUTE, "/clubs/9");
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", MATCHING_PATH);
+        request.setSession(session);
+
+        resolver.resolve(request);
+
+        assertThat(session.getAttribute(RedirectCapturingAuthorizationRequestResolver.SESSION_ATTRIBUTE)).isNull();
+    }
+
+    @Test
+    void anOverLengthRedirectTargetIsNotStored() {
+        // Bug 3: MAX_REDIRECT_LENGTH is enforced here too, before the value
+        // ever reaches the session, not only when PostLoginRedirectResolver
+        // later reads it back — otherwise an unbounded attacker-controlled
+        // string sits in server-side session storage for the lifetime of
+        // the OAuth2 round trip for nothing.
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(RedirectCapturingAuthorizationRequestResolver.SESSION_ATTRIBUTE, "/clubs/9");
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", MATCHING_PATH);
+        request.setSession(session);
+        String tooLong = "/" + "a".repeat(PostLoginRedirectResolver.MAX_REDIRECT_LENGTH);
+        request.setParameter("redirect", tooLong);
+
+        resolver.resolve(request);
+
+        assertThat(session.getAttribute(RedirectCapturingAuthorizationRequestResolver.SESSION_ATTRIBUTE)).isNull();
+    }
+
+    private static Object sessionAttribute(MockHttpServletRequest request) {
+        return request.getSession(false).getAttribute(RedirectCapturingAuthorizationRequestResolver.SESSION_ATTRIBUTE);
+    }
+
+    private static ClientRegistrationRepository googleClientRegistrationRepository() {
+        ClientRegistration google = ClientRegistration.withRegistrationId(REGISTERED_ID)
+            .clientId("dummy-client-id")
+            .clientSecret("dummy-client-secret")
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+            .authorizationUri("https://accounts.google.com/o/oauth2/v2/auth")
+            .tokenUri("https://oauth2.googleapis.com/token")
+            .build();
+        return new InMemoryClientRegistrationRepository(google);
+    }
+}

--- a/frontend/src/stores/auth.spec.ts
+++ b/frontend/src/stores/auth.spec.ts
@@ -1,7 +1,7 @@
 import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { AuthUser } from '../types/auth'
+import type { AuthProvider, AuthUser } from '../types/auth'
 
 vi.mock('../services/authService', () => ({
   fetchAuthProviders: vi.fn(),
@@ -9,10 +9,21 @@ vi.mock('../services/authService', () => ({
   logout: vi.fn(),
 }))
 
-import { fetchAuthenticatedUser } from '../services/authService'
+vi.mock('../utils/authRedirect', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/authRedirect')>()
+  return {
+    ...actual,
+    savePendingAuthRedirect: vi.fn(),
+  }
+})
+
+import { fetchAuthenticatedUser, fetchAuthProviders } from '../services/authService'
+import { savePendingAuthRedirect } from '../utils/authRedirect'
 import { useAuthStore } from './auth'
 
 const fetchAuthenticatedUserMock = vi.mocked(fetchAuthenticatedUser)
+const fetchAuthProvidersMock = vi.mocked(fetchAuthProviders)
+const savePendingAuthRedirectMock = vi.mocked(savePendingAuthRedirect)
 
 const knownUser: AuthUser = {
   id: 'user-1',
@@ -171,5 +182,57 @@ describe('refreshUser vs. ensureSessionChecked concurrency (Finding-1 regression
     // must be what the store ends up reflecting, not the pre-mutation
     // response the session check happened to have in flight.
     expect(store.currentUser?.acceptedTerms).toBe(true)
+  })
+})
+
+describe('beginLogin', () => {
+  const googleProvider: AuthProvider = {
+    id: 'google',
+    name: 'Google',
+    authorizationUrl: '/api/auth/authorize/google',
+  }
+
+  let originalLocation: Location
+
+  beforeEach(() => {
+    originalLocation = window.location
+    // jsdom's real navigation throws "Not implemented"; replace `location`
+    // with a plain writable stub so `beginLogin` can assign `href` and the
+    // test can read back exactly what it navigated to.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { href: '' },
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    })
+  })
+
+  it('navigates to the authorization URL with an encoded redirect param, and still saves the pending redirect', async () => {
+    fetchAuthProvidersMock.mockResolvedValue([googleProvider])
+    const store = useAuthStore()
+    await store.ensureProvidersLoaded()
+
+    store.beginLogin('google', '/clubs/9?tab=events')
+
+    expect(window.location.href).toBe(
+      'http://localhost:8080/api/auth/authorize/google?redirect=%2Fclubs%2F9%3Ftab%3Devents',
+    )
+    expect(savePendingAuthRedirectMock).toHaveBeenCalledWith('/clubs/9?tab=events')
+  })
+
+  it('navigates to the bare authorization URL when no redirect target is supplied', async () => {
+    fetchAuthProvidersMock.mockResolvedValue([googleProvider])
+    const store = useAuthStore()
+    await store.ensureProvidersLoaded()
+
+    store.beginLogin('google', null)
+
+    expect(window.location.href).toBe('http://localhost:8080/api/auth/authorize/google')
+    expect(savePendingAuthRedirectMock).toHaveBeenCalledWith(null)
   })
 })

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -9,7 +9,7 @@ import {
 } from '../services/authService'
 import { buildApiUrl } from '../services/httpClient'
 import { localAvatar, userAvatar } from '../utils/avatarImages'
-import { savePendingAuthRedirect } from '../utils/authRedirect'
+import { normalizeAuthRedirect, savePendingAuthRedirect } from '../utils/authRedirect'
 
 export const useAuthStore = defineStore('auth', () => {
   const currentUser = ref<AuthUser | null>(null)
@@ -121,7 +121,12 @@ export const useAuthStore = defineStore('auth', () => {
       return
     }
     savePendingAuthRedirect(redirectTarget)
-    window.location.href = buildApiUrl(provider.authorizationUrl)
+
+    const authorizationUrl = buildApiUrl(provider.authorizationUrl)
+    const normalizedTarget = normalizeAuthRedirect(redirectTarget)
+    window.location.href = normalizedTarget
+      ? `${authorizationUrl}${authorizationUrl.includes('?') ? '&' : '?'}redirect=${encodeURIComponent(normalizedTarget)}`
+      : authorizationUrl
   }
 
   const logout = async () => {

--- a/frontend/src/views/AuthCallbackView.spec.ts
+++ b/frontend/src/views/AuthCallbackView.spec.ts
@@ -104,6 +104,22 @@ describe('AuthCallbackView', () => {
     expect(consumePendingAuthRedirect()).toBeNull()
   })
 
+  it('prevents a stale pending redirect from hijacking a later, unrelated login when the server-provided redirect wins', async () => {
+    // The server-provided `?redirect=` takes precedence over the stored
+    // fallback (regression check for that precedence), but the stored
+    // value must still be cleared as a side effect -- otherwise it would
+    // survive to hijack a later login attempt that has no server-side
+    // target of its own (e.g. a bookmarked/direct authorization URL that
+    // never went through beginLogin()).
+    savePendingAuthRedirect('/clubs/9')
+    fetchAuthenticatedUserMock.mockResolvedValue(buildUser())
+
+    await mountWithQuery({ redirect: '/clubs/3' })
+
+    expect(replaceMock).toHaveBeenCalledWith('/clubs/3')
+    expect(consumePendingAuthRedirect()).toBeNull()
+  })
+
   it('lands a fully-onboarded user with no redirect target at all on the default profile page', async () => {
     fetchAuthenticatedUserMock.mockResolvedValue(buildUser())
 

--- a/frontend/src/views/AuthCallbackView.spec.ts
+++ b/frontend/src/views/AuthCallbackView.spec.ts
@@ -166,4 +166,36 @@ describe('AuthCallbackView', () => {
 
     expect(consumePendingAuthRedirect()).toBeNull()
   })
+
+  it('forwards a valid remembered target alongside the error on a backend-reported failure, so a retry can resume', async () => {
+    await mountWithQuery({ error: 'oauth2_login_failed', redirect: '/clubs/9' })
+
+    expect(replaceMock).toHaveBeenCalledWith({
+      path: '/auth',
+      query: { error: 'oauth2_login_failed', redirect: '/clubs/9' },
+    })
+  })
+
+  it.each(['https://evil.com', '//evil.com', '/\\evil.com'])(
+    'drops a hostile remembered target (%s) on a backend-reported failure but still forwards the error',
+    async (maliciousTarget) => {
+      await mountWithQuery({ error: 'oauth2_login_failed', redirect: maliciousTarget })
+
+      expect(replaceMock).toHaveBeenCalledWith({
+        path: '/auth',
+        query: { error: 'oauth2_login_failed' },
+      })
+    },
+  )
+
+  it('forwards only the error, with no redirect key at all, when a backend-reported failure carries no remembered target', async () => {
+    await mountWithQuery({ error: 'oauth2_login_failed' })
+
+    expect(replaceMock).toHaveBeenCalledWith({
+      path: '/auth',
+      query: { error: 'oauth2_login_failed' },
+    })
+    const call = replaceMock.mock.calls[0]?.[0] as { query: Record<string, string> }
+    expect('redirect' in call.query).toBe(false)
+  })
 })

--- a/frontend/src/views/AuthCallbackView.vue
+++ b/frontend/src/views/AuthCallbackView.vue
@@ -26,6 +26,18 @@ const resolveRedirectTarget = () => {
   return serverTarget ?? pendingTarget
 }
 
+// Builds the query for a failed-login redirect to /auth: the error always
+// passes through unchanged (AuthChoiceView's banner depends on it), and the
+// `redirect` key is only present when the URL carried a validated target --
+// never an unvalidated one, and never an empty/undefined placeholder. Used
+// by both failure paths below (the backend-reported failure and the
+// unauthenticated-refreshUser() case) so a student who retries after either
+// kind of failure still ends up where they originally wanted to go.
+const buildAuthFailureQuery = (error: string): Record<string, string> => {
+  const target = normalizeAuthRedirect(route.query.redirect)
+  return target ? { error, redirect: target } : { error }
+}
+
 onMounted(async () => {
   // The backend's OAuth2 failure handler redirects here with `?error=...`
   // when it already knows the login failed, so there is no session to
@@ -34,7 +46,7 @@ onMounted(async () => {
     // A stale pending redirect must not survive a failed login and hijack
     // the user's next, unrelated login attempt.
     clearPendingAuthRedirect()
-    router.replace({ path: '/auth', query: { error: route.query.error } })
+    router.replace({ path: '/auth', query: buildAuthFailureQuery(route.query.error) })
     return
   }
 
@@ -46,7 +58,7 @@ onMounted(async () => {
     router.replace(destination ?? DEFAULT_POST_AUTH_PATH)
   } else {
     clearPendingAuthRedirect()
-    router.replace({ path: '/auth', query: { error: 'login_failed' } })
+    router.replace({ path: '/auth', query: buildAuthFailureQuery('login_failed') })
   }
 })
 </script>

--- a/frontend/src/views/AuthCallbackView.vue
+++ b/frontend/src/views/AuthCallbackView.vue
@@ -16,7 +16,14 @@ const router = useRouter()
 const authStore = useAuthStore()
 
 const resolveRedirectTarget = () => {
-  return normalizeAuthRedirect(route.query.redirect) ?? consumePendingAuthRedirect()
+  // Always consume (read + clear) the sessionStorage fallback, even when the
+  // server-provided `?redirect=` wins and the fallback value goes unused.
+  // Otherwise a stale value survives this callback and can hijack a later,
+  // unrelated login attempt that has no server-side target of its own (the
+  // same hijack class fixed on the failure path in PR #69).
+  const serverTarget = normalizeAuthRedirect(route.query.redirect)
+  const pendingTarget = consumePendingAuthRedirect()
+  return serverTarget ?? pendingTarget
 }
 
 onMounted(async () => {


### PR DESCRIPTION
Stacked on #69 (which is stacked on #68) -- **review those first**; the base here is `agent/post-auth-hygiene`, so this diff shows only the backend round-trip work. I will rebase as the stack merges.

This is the last deferred item from #68.

## Problem

The frontend's intended post-login destination survived the OAuth round trip **only via browser `sessionStorage`**: `beginLogin()` wrote it there, the backend's success handler redirected to a fixed `/auth/callback` carrying nothing, and `AuthCallbackView` read it back. So if the round trip returned in a different tab, or `sessionStorage` was unavailable (Safari private mode, ITP, strict privacy settings), the user silently landed on `/profile` instead of the page they were trying to reach.

## Change

- `beginLogin` appends `?redirect=<encoded path>` to the authorization URL, and still writes `sessionStorage` as a fallback (belt and braces).
- New `RedirectCapturingAuthorizationRequestResolver` wraps `DefaultOAuth2AuthorizationRequestResolver` and stashes the value in the `HttpSession` for the duration of the flow.
- The success **and** failure handlers echo the validated target back on the callback URL. `AuthCallbackView` already preferred `?redirect=` over `sessionStorage`, so it needed no change.

## Security

The target is fully attacker-controlled -- anyone can hand a victim an authorize link with an arbitrary `redirect=`. Two deliberate choices:

- It is kept **out of the OAuth `state` parameter** and anything else that round-trips through the provider, since that would make it attacker-visible and attacker-modifiable in transit. It lives server-side in the session instead.
- It is validated in **exactly one place** (`PostLoginRedirectResolver`) before it can reach a `Location` header. Rejected: anything not rooted at `/`, protocol-relative `//evil.com` and `/\evil.com`, embedded schemes (`://`), control characters (CR/LF/tab -> response splitting), and over-long values. A rejected target is dropped **silently** -- never echoed, and login never fails because of it.

The callback host always comes from trusted config (`post-login-redirect-uri`), so a hostile value can only ever ride along as a query param, and the frontend consumes it through `router.replace()` (client-side routing) plus its own `normalizeAuthRedirect`. An independent security review found no realistic open-redirect or header-injection bypass, and confirmed the target is percent-encoded exactly once (verified against real output, including a target carrying its own `?`, `&`, `#` and literal `%`).

## The bug review caught, which is worth reading

The first implementation captured the redirect target on **every** call to `resolve(request)`. But `OAuth2AuthorizationRequestRedirectFilter` invokes the resolver on *every request* and only null-checks the result afterwards (confirmed in the Spring Security 7.0.2 bytecode). Consequences:

1. The provider's own callback request (`/api/auth/google/callback?code=...`) carries no `redirect` param, so it took the clearing branch and **wiped the target before the success handler could read it** -- the entire feature would have shipped as a silent no-op, falling back to `sessionStorage`, i.e. exactly the bug it was meant to fix. Any unrelated request in the same session also cleared it mid-flight.
2. `getSession(true)` ran for every request, allocating an `HttpSession` + `JSESSIONID` for **every anonymous hit** to public endpoints and static assets -- defeating the configured `SessionCreationPolicy.IF_REQUIRED` and handing an unauthenticated client a cheap memory-exhaustion vector.

Capture is now gated on the delegate's own signal that this is a genuine authorize attempt; a session is created only when there is a value to store; and the length cap is enforced *before* storing rather than only on read.

The reason this shipped invisibly in the first draft is that nothing pinned the resolve -> callback -> success-handler sequence. `aStoredRedirectTargetSurvivesTheProviderCallbackRequest` now does, and I verified it has teeth: reintroducing the unconditional capture fails exactly that test.

## Tests

- `PostLoginRedirectResolverTest` -- 16 cases: valid paths encoded exactly once, every rejected payload shape falling back to the bare callback URL, and a target carrying its own query string and fragment (`/search?q=chess&sort=name#results`) surviving intact, asserted by decoded round-trip fidelity.
- `RedirectCapturingAuthorizationRequestResolverTest` -- 10 cases: capture on genuine authorize requests, survival across the provider callback, no session created for non-authorize requests, stale-target clearing preserved (anti-hijack), over-length rejection, both `resolve` overloads, and a hostile payload stored verbatim documenting that validation happens later.
- Frontend: `beginLogin` appends an encoded `redirect`, still writes the `sessionStorage` fallback, and adds no param when there is no target.

Backend `./mvnw test` -> 41 tests green (includes the full `@SpringBootTest` context load, so the new constructor wiring is exercised). Frontend `npm run test:unit -- --run` -> 80 green; `npm run build` clean; eslint clean on changed files.

## Residual gap

No end-to-end OAuth flow test exists, because `spring-security-test` is deliberately not a dependency and I did not add one. The resolve -> callback sequence is covered by unit tests against `MockHttpServletRequest`, but nothing exercises a real provider round trip; the `SecurityConfig` wiring itself (that `.baseUri()` plus `.authorizationRequestResolver()` compose as intended) is only covered by the context load. Worth a manual smoke test against a real Google login before release.
