### PR TITLE
Fix: reject unsupported avatar formats instead of caching them as PNG

### DIFF
--- a/backend/src/main/java/com/example/demo/club/service/InstagramAvatarCacheService.java
+++ b/backend/src/main/java/com/example/demo/club/service/InstagramAvatarCacheService.java
@@ -499,15 +499,22 @@ public class InstagramAvatarCacheService {
         if (bytes.length == 0 || bytes.length > MAX_AVATAR_BYTES) {
             throw new IOException("Avatar response size is invalid");
         }
-        MediaType mediaType = mediaTypeFromResponse(response, bytes);
+        MediaType mediaType = mediaTypeFromResponse(response, bytes)
+            .orElseThrow(() -> new IOException("Unsupported or unrecognized avatar image format"));
         return new CachedAvatar(bytes, mediaType);
     }
 
-    private MediaType mediaTypeFromResponse(HttpResponse<byte[]> response, byte[] bytes) {
+    // PNG, JPEG, GIF, and WebP are the single supported image format set shared by the
+    // download Accept header, response media-type validation below, and the on-disk
+    // extension mapping (extensionForMediaType/mediaTypeForExtension). Any format outside
+    // this set must be rejected here rather than silently mislabeled/cached, otherwise it
+    // can be written to disk under the wrong extension and served with the wrong
+    // Content-Type for the lifetime of the cache TTL.
+    private Optional<MediaType> mediaTypeFromResponse(HttpResponse<byte[]> response, byte[] bytes) {
         Optional<MediaType> headerMediaType = response.headers()
             .firstValue("content-type")
             .flatMap(this::safeImageMediaType);
-        return headerMediaType.or(() -> mediaTypeFromMagicBytes(bytes)).orElse(MediaType.IMAGE_JPEG);
+        return headerMediaType.or(() -> mediaTypeFromMagicBytes(bytes));
     }
 
     private Optional<MediaType> safeImageMediaType(String value) {
@@ -519,7 +526,14 @@ public class InstagramAvatarCacheService {
             if (Set.of("jpg", "jpeg", "pjpeg").contains(mediaType.getSubtype())) {
                 return Optional.of(MediaType.IMAGE_JPEG);
             }
-            return Optional.of(mediaType);
+            if (MediaType.IMAGE_PNG.equalsTypeAndSubtype(mediaType)
+                || MediaType.IMAGE_GIF.equalsTypeAndSubtype(mediaType)
+                || WEBP_MEDIA_TYPE.equalsTypeAndSubtype(mediaType)) {
+                return Optional.of(mediaType);
+            }
+            // Unsupported image subtype (avif, svg+xml, heic, bmp, tiff, ...): reject rather
+            // than caching it under a mismatched extension.
+            return Optional.empty();
         } catch (IllegalArgumentException ignored) {
             return Optional.empty();
         }
@@ -630,6 +644,9 @@ public class InstagramAvatarCacheService {
         if (WEBP_MEDIA_TYPE.includes(mediaType)) {
             return "webp";
         }
+        // Unreachable given upstream validation in mediaTypeFromResponse/safeImageMediaType,
+        // which only ever produce the four supported formats handled above. Not a
+        // format-mapping table entry for arbitrary media types.
         return "png";
     }
 

--- a/backend/src/test/java/com/example/demo/club/service/InstagramAvatarCacheServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/InstagramAvatarCacheServiceTest.java
@@ -241,6 +241,159 @@ class InstagramAvatarCacheServiceTest {
         );
     }
 
+    @Test
+    void resolveAvatarRejectsUnsupportedContentTypeAndDoesNotCacheIt() throws Exception {
+        // Regression test for: unsupported avatar formats (e.g. AVIF) were previously
+        // cached to disk as PNG because extensionForMediaType() silently defaulted to
+        // "png" for any unrecognized media type. The fix rejects unsupported formats
+        // before they reach the cache, so resolveAvatar must fall back to the generated
+        // SVG placeholder and no file should be written for the handle.
+        byte[] bytes = { 0, 1, 2, 3, 4, 5, 6, 7 };
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/avatar.avif", exchange -> {
+            exchange.getResponseHeaders().add("Content-Type", "image/avif");
+            exchange.sendResponseHeaders(200, bytes.length);
+            exchange.getResponseBody().write(bytes);
+            exchange.close();
+        });
+        server.start();
+        int port = server.getAddress().getPort();
+        Path script = tempDir.resolve("avif-instaloader.sh");
+        Files.writeString(
+            script,
+            "#!/bin/sh\necho \"http://127.0.0.1:%d/avatar.avif\"\n".formatted(port),
+            StandardCharsets.UTF_8
+        );
+        assertThat(script.toFile().setExecutable(true)).isTrue();
+        InstagramAvatarCacheService service = service(true, script.toString(), 4000);
+
+        try {
+            InstagramAvatarCacheService.ResolvedAvatar avatar = service.resolveAvatar("mvhsclubs");
+
+            assertThat(avatar.mediaType()).isEqualTo(MediaType.valueOf("image/svg+xml"));
+            assertThat(cachedAvatarFiles("mvhsclubs")).isEmpty();
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void resolveAvatarSniffsMagicBytesWhenContentTypeIsMisleading() throws Exception {
+        // A CDN mislabeling a real PNG as application/octet-stream should still be
+        // rescued by magic-byte sniffing, cached, and served as image/png thereafter.
+        byte[] bytes = { (byte) 0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a };
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/avatar.bin", exchange -> {
+            exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
+            exchange.sendResponseHeaders(200, bytes.length);
+            exchange.getResponseBody().write(bytes);
+            exchange.close();
+        });
+        server.start();
+        int port = server.getAddress().getPort();
+        Path script = tempDir.resolve("mislabeled-png-instaloader.sh");
+        Files.writeString(
+            script,
+            "#!/bin/sh\necho \"http://127.0.0.1:%d/avatar.bin\"\n".formatted(port),
+            StandardCharsets.UTF_8
+        );
+        assertThat(script.toFile().setExecutable(true)).isTrue();
+        InstagramAvatarCacheService service = service(true, script.toString(), 4000);
+
+        try {
+            InstagramAvatarCacheService.ResolvedAvatar first = service.resolveAvatar("mvhsclubs");
+            assertThat(first.mediaType()).isEqualTo(MediaType.IMAGE_PNG);
+            assertThat(first.bytes()).isEqualTo(bytes);
+
+            InstagramAvatarCacheService.ResolvedAvatar second = service.resolveAvatar("mvhsclubs");
+            assertThat(second.mediaType()).isEqualTo(MediaType.IMAGE_PNG);
+            assertThat(second.bytes()).isEqualTo(bytes);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void resolveAvatarRejectsSvgContentTypeAndDoesNotCacheIt() throws Exception {
+        // The reviewer's other flagged example (image/svg+xml pretending to be a
+        // cacheable avatar) must also be rejected rather than cached.
+        byte[] bytes = { 0, 1, 2, 3, 4, 5, 6, 7 };
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/avatar.svg", exchange -> {
+            exchange.getResponseHeaders().add("Content-Type", "image/svg+xml");
+            exchange.sendResponseHeaders(200, bytes.length);
+            exchange.getResponseBody().write(bytes);
+            exchange.close();
+        });
+        server.start();
+        int port = server.getAddress().getPort();
+        Path script = tempDir.resolve("svg-instaloader.sh");
+        Files.writeString(
+            script,
+            "#!/bin/sh\necho \"http://127.0.0.1:%d/avatar.svg\"\n".formatted(port),
+            StandardCharsets.UTF_8
+        );
+        assertThat(script.toFile().setExecutable(true)).isTrue();
+        InstagramAvatarCacheService service = service(true, script.toString(), 4000);
+
+        try {
+            InstagramAvatarCacheService.ResolvedAvatar avatar = service.resolveAvatar("mvhsclubs");
+
+            assertThat(avatar.mediaType()).isEqualTo(MediaType.valueOf("image/svg+xml"));
+            assertThat(cachedAvatarFiles("mvhsclubs")).isEmpty();
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void resolveAvatarCachesAndServesSupportedWebpFormat() throws Exception {
+        // Happy-path confirmation that the four supported formats still work end to
+        // end after tightening the unsupported-format rejection.
+        byte[] bytes = { 'R', 'I', 'F', 'F', 0, 0, 0, 0, 'W', 'E', 'B', 'P', 1, 2, 3, 4 };
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/avatar.webp", exchange -> {
+            exchange.getResponseHeaders().add("Content-Type", "image/webp");
+            exchange.sendResponseHeaders(200, bytes.length);
+            exchange.getResponseBody().write(bytes);
+            exchange.close();
+        });
+        server.start();
+        int port = server.getAddress().getPort();
+        Path script = tempDir.resolve("webp-instaloader.sh");
+        Files.writeString(
+            script,
+            "#!/bin/sh\necho \"http://127.0.0.1:%d/avatar.webp\"\n".formatted(port),
+            StandardCharsets.UTF_8
+        );
+        assertThat(script.toFile().setExecutable(true)).isTrue();
+        InstagramAvatarCacheService service = service(true, script.toString(), 4000);
+
+        try {
+            InstagramAvatarCacheService.ResolvedAvatar first = service.resolveAvatar("mvhsclubs");
+            assertThat(first.mediaType()).isEqualTo(MediaType.valueOf("image/webp"));
+            assertThat(first.bytes()).isEqualTo(bytes);
+
+            InstagramAvatarCacheService.ResolvedAvatar second = service.resolveAvatar("mvhsclubs");
+            assertThat(second.mediaType()).isEqualTo(MediaType.valueOf("image/webp"));
+            assertThat(second.bytes()).isEqualTo(bytes);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    private List<Path> cachedAvatarFiles(String handle) throws IOException {
+        Path cacheDir = tempDir.resolve("avatar-cache").resolve("instagram");
+        if (!Files.isDirectory(cacheDir)) {
+            return List.of();
+        }
+        try (var stream = Files.list(cacheDir)) {
+            return stream
+                .filter(path -> path.getFileName().toString().startsWith(handle + "."))
+                .toList();
+        }
+    }
+
     private InstagramAvatarCacheService service(boolean enabled) {
         return service(enabled, "python3", "http://127.0.0.1/unused?username=%s", 1000);
     }


### PR DESCRIPTION
## Problem (Codex P1: "Unsupported formats are cached as PNG")

`InstagramAvatarCacheService.downloadAvatar` sends `Accept: image/webp,image/png,image/jpeg,image/gif`, but `Accept` is only a hint -- a CDN can return any `Content-Type`. `safeImageMediaType` accepted **any** `image/*` subtype, so a response labelled `image/avif` (or `image/svg+xml`, `image/heic`, ...) passed through verbatim as the media type. `cacheAvatar` then called `extensionForMediaType`, which has no case for those formats and silently returned `"png"`, so the bytes were written to `<handle>.png`.

On every subsequent read within the cache TTL (**up to 30 days**), `readCachedAvatar` mapped `.png` back to `image/png`, so e.g. AVIF bytes were served as `Content-Type: image/png` and the avatar was broken until the cache expired. `mediaTypeFromResponse`'s blind `.orElse(MediaType.IMAGE_JPEG)` was a milder version of the same fault (unrecognized bytes mislabelled as JPEG, cached as `.jpg`).

## Fix

PNG, JPEG, GIF and WebP are now the single supported format set shared by the `Accept` header, response validation, and the on-disk extension mapping, so they cannot drift apart again:

- `safeImageMediaType` returns a value only for those four (normalizing `jpg`/`jpeg`/`pjpeg` to JPEG); any other `image/*` subtype or non-image type returns empty.
- `mediaTypeFromResponse` returns `Optional<MediaType>` (supported header type, else magic-byte sniff, else empty) -- the fabricated `IMAGE_JPEG` default is gone.
- `downloadAvatar` throws `IOException` when the format can't be resolved to a supported one.

This is safe degradation, not a new failure mode: `resolveAvatar` already catches any exception from the refresh path and serves the generated SVG placeholder, and the scheduled refresh retries later -- strictly better than caching mislabelled bytes for weeks. Magic-byte sniffing still rescues a *supported* image that a CDN mislabels (e.g. a real PNG served as `application/octet-stream`).

The `Accept` header is unchanged (it already matched the supported set; I did not re-add avif/apng/svg). `extensionForMediaType`'s `"png"` default is kept but now unreachable, with a comment saying so.

## Tests

Appended 4 tests to `InstagramAvatarCacheServiceTest` using the existing `HttpServer` + shell-script harness:

- `image/avif` + unrecognized bytes -> SVG fallback, **no cache file written** (the "not cached as PNG" guarantee).
- `application/octet-stream` + real PNG magic bytes -> cached and served as `image/png` on the next read (sniffing rescue).
- `image/svg+xml` + unrecognized bytes -> SVG fallback, no cache file (the reviewer's other example).
- WebP happy path -> cached and served back as `image/webp`, confirming supported formats still work end to end.

**Mutation-verified:** reverting the fix (restoring `.orElse(IMAGE_JPEG)` and dropping the throw) makes the avif and svg regression tests fail (bytes served as `image/jpeg` instead of rejected); restoring it goes green again.

## Verification

`./mvnw test` -> **50 tests, 0 failures** (46 baseline + 4 new). CI runs `./mvnw test`, so it will exercise these.

## Note

This addresses a review comment on already-merged code (originally raised on PR #60); it is unrelated to the recent auth-redirect PR stack and is based directly on `main`.
