### PR TITLE
Make the supported avatar format set a real single source of truth (review follow-up to #71)

### DIFF
--- a/backend/src/main/java/com/example/demo/club/service/InstagramAvatarCacheService.java
+++ b/backend/src/main/java/com/example/demo/club/service/InstagramAvatarCacheService.java
@@ -25,9 +25,12 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -36,6 +39,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Service
 public class InstagramAvatarCacheService {
@@ -46,6 +50,19 @@ public class InstagramAvatarCacheService {
     private static final List<String> IMAGE_EXTENSIONS = List.of("png", "jpg", "jpeg", "webp", "gif");
     private static final MediaType SVG_MEDIA_TYPE = MediaType.valueOf("image/svg+xml");
     private static final MediaType WEBP_MEDIA_TYPE = MediaType.valueOf("image/webp");
+    // The single canonical source of truth for which image formats the on-disk avatar
+    // cache can WRITE and for what extension it writes them under. downloadAvatar's
+    // Accept header, safeImageMediaType's supported-format check, and
+    // extensionForMediaType's extension lookup are all derived from this map, so the
+    // four supported formats can never drift out of sync between those three call sites
+    // again. This is a WRITE-side mapping only: it intentionally does not cover legacy
+    // on-disk extensions such as ".jpeg" (see IMAGE_EXTENSIONS/mediaTypeForExtension,
+    // which remain the READ-side mapping and must keep recognizing those legacy files).
+    private static final Map<MediaType, String> SUPPORTED_MEDIA_TYPE_EXTENSIONS = supportedMediaTypeExtensions();
+    private static final String SUPPORTED_AVATAR_ACCEPT_HEADER = SUPPORTED_MEDIA_TYPE_EXTENSIONS.keySet()
+        .stream()
+        .map(MediaType::toString)
+        .collect(Collectors.joining(","));
     private static final String INSTAGRAM_WEB_PROFILE_API =
         "https://www.instagram.com/api/v1/users/web_profile_info/?username=%s";
     private static final String BROWSER_USER_AGENT =
@@ -488,7 +505,7 @@ public class InstagramAvatarCacheService {
             .uri(uri)
             .timeout(Duration.ofMillis(fetchTimeoutMillis))
             .header("User-Agent", BROWSER_USER_AGENT)
-            .header("Accept", "image/webp,image/png,image/jpeg,image/gif")
+            .header("Accept", SUPPORTED_AVATAR_ACCEPT_HEADER)
             .GET()
             .build();
         HttpResponse<byte[]> response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
@@ -504,12 +521,14 @@ public class InstagramAvatarCacheService {
         return new CachedAvatar(bytes, mediaType);
     }
 
-    // PNG, JPEG, GIF, and WebP are the single supported image format set shared by the
-    // download Accept header, response media-type validation below, and the on-disk
-    // extension mapping (extensionForMediaType/mediaTypeForExtension). Any format outside
-    // this set must be rejected here rather than silently mislabeled/cached, otherwise it
-    // can be written to disk under the wrong extension and served with the wrong
-    // Content-Type for the lifetime of the cache TTL.
+    // PNG, JPEG, GIF and WebP (SUPPORTED_MEDIA_TYPE_EXTENSIONS) are the single supported
+    // image format set, and that map is what the download Accept header, the
+    // response media-type validation below (via safeImageMediaType), and the on-disk
+    // extension mapping (extensionForMediaType) all derive from, so the set cannot drift
+    // out of sync between those call sites again. Any format outside this set must be
+    // rejected here rather than silently mislabeled/cached, otherwise it can be written
+    // to disk under the wrong extension and served with the wrong Content-Type for the
+    // lifetime of the cache TTL.
     private Optional<MediaType> mediaTypeFromResponse(HttpResponse<byte[]> response, byte[] bytes) {
         Optional<MediaType> headerMediaType = response.headers()
             .firstValue("content-type")
@@ -526,9 +545,7 @@ public class InstagramAvatarCacheService {
             if (Set.of("jpg", "jpeg", "pjpeg").contains(mediaType.getSubtype())) {
                 return Optional.of(MediaType.IMAGE_JPEG);
             }
-            if (MediaType.IMAGE_PNG.equalsTypeAndSubtype(mediaType)
-                || MediaType.IMAGE_GIF.equalsTypeAndSubtype(mediaType)
-                || WEBP_MEDIA_TYPE.equalsTypeAndSubtype(mediaType)) {
+            if (isSupportedMediaType(mediaType)) {
                 return Optional.of(mediaType);
             }
             // Unsupported image subtype (avif, svg+xml, heic, bmp, tiff, ...): reject rather
@@ -632,22 +649,37 @@ public class InstagramAvatarCacheService {
     }
 
     private String extensionForMediaType(MediaType mediaType) {
-        if (MediaType.IMAGE_JPEG.includes(mediaType)) {
-            return "jpg";
-        }
         if (Set.of("jpg", "jpeg", "pjpeg").contains(mediaType.getSubtype())) {
-            return "jpg";
+            return SUPPORTED_MEDIA_TYPE_EXTENSIONS.get(MediaType.IMAGE_JPEG);
         }
-        if (MediaType.IMAGE_GIF.includes(mediaType)) {
-            return "gif";
+        for (Map.Entry<MediaType, String> entry : SUPPORTED_MEDIA_TYPE_EXTENSIONS.entrySet()) {
+            if (entry.getKey().includes(mediaType)) {
+                return entry.getValue();
+            }
         }
-        if (WEBP_MEDIA_TYPE.includes(mediaType)) {
-            return "webp";
+        // A genuine programming error, not a reachable format-mapping case: every
+        // MediaType that reaches this method was already produced by
+        // mediaTypeFromResponse/safeImageMediaType, which only ever return one of the
+        // formats in SUPPORTED_MEDIA_TYPE_EXTENSIONS.
+        throw new IllegalStateException("No cache extension is mapped for media type " + mediaType);
+    }
+
+    private static Map<MediaType, String> supportedMediaTypeExtensions() {
+        Map<MediaType, String> extensions = new LinkedHashMap<>();
+        extensions.put(WEBP_MEDIA_TYPE, "webp");
+        extensions.put(MediaType.IMAGE_PNG, "png");
+        extensions.put(MediaType.IMAGE_JPEG, "jpg");
+        extensions.put(MediaType.IMAGE_GIF, "gif");
+        return Collections.unmodifiableMap(extensions);
+    }
+
+    private static boolean isSupportedMediaType(MediaType mediaType) {
+        for (MediaType supported : SUPPORTED_MEDIA_TYPE_EXTENSIONS.keySet()) {
+            if (supported.equalsTypeAndSubtype(mediaType)) {
+                return true;
+            }
         }
-        // Unreachable given upstream validation in mediaTypeFromResponse/safeImageMediaType,
-        // which only ever produce the four supported formats handled above. Not a
-        // format-mapping table entry for arbitrary media types.
-        return "png";
+        return false;
     }
 
     public record CachedAvatar(byte[] bytes, MediaType mediaType) {}

--- a/backend/src/test/java/com/example/demo/club/service/InstagramAvatarCacheServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/InstagramAvatarCacheServiceTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 class InstagramAvatarCacheServiceTest {
 
@@ -55,6 +56,25 @@ class InstagramAvatarCacheServiceTest {
 
         assertThat(avatar.bytes()).isEqualTo(bytes);
         assertThat(avatar.mediaType()).isEqualTo(MediaType.IMAGE_PNG);
+        assertThat(avatar.maxAge()).isEqualTo(60);
+        assertThat(avatar.maxAgeUnit()).isEqualTo(TimeUnit.DAYS);
+    }
+
+    @Test
+    void resolveAvatarReadsLegacyJpegExtensionFromCache() throws Exception {
+        // extensionForMediaType only ever WRITES the "jpg" extension, but older cache
+        // files were written as ".jpeg" before that convention existed. The read path
+        // (IMAGE_EXTENSIONS/mediaTypeForExtension) must keep recognizing them.
+        Path cacheDir = tempDir.resolve("avatar-cache").resolve("instagram");
+        Files.createDirectories(cacheDir);
+        byte[] bytes = new byte[] { 4, 5, 6 };
+        Files.write(cacheDir.resolve("mvhsclubs.jpeg"), bytes);
+        InstagramAvatarCacheService service = service(true);
+
+        InstagramAvatarCacheService.ResolvedAvatar avatar = service.resolveAvatar("mvhsclubs");
+
+        assertThat(avatar.bytes()).isEqualTo(bytes);
+        assertThat(avatar.mediaType()).isEqualTo(MediaType.IMAGE_JPEG);
         assertThat(avatar.maxAge()).isEqualTo(60);
         assertThat(avatar.maxAgeUnit()).isEqualTo(TimeUnit.DAYS);
     }
@@ -249,8 +269,10 @@ class InstagramAvatarCacheServiceTest {
         // before they reach the cache, so resolveAvatar must fall back to the generated
         // SVG placeholder and no file should be written for the handle.
         byte[] bytes = { 0, 1, 2, 3, 4, 5, 6, 7 };
+        AtomicInteger hits = new AtomicInteger();
         HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
         server.createContext("/avatar.avif", exchange -> {
+            hits.incrementAndGet();
             exchange.getResponseHeaders().add("Content-Type", "image/avif");
             exchange.sendResponseHeaders(200, bytes.length);
             exchange.getResponseBody().write(bytes);
@@ -270,7 +292,15 @@ class InstagramAvatarCacheServiceTest {
         try {
             InstagramAvatarCacheService.ResolvedAvatar avatar = service.resolveAvatar("mvhsclubs");
 
+            // The download must actually have happened; otherwise this test would pass
+            // just as well for a broken harness (unreachable server, bad script path...).
+            assertThat(hits.get()).isGreaterThanOrEqualTo(1);
+            // Assert the payload is the GENERATED placeholder (not merely that the media
+            // type matches, which the served response also happens to report as SVG).
             assertThat(avatar.mediaType()).isEqualTo(MediaType.valueOf("image/svg+xml"));
+            assertThat(new String(avatar.bytes(), StandardCharsets.UTF_8)).contains("<svg").contains("MV");
+            assertThat(avatar.maxAge()).isEqualTo(15);
+            assertThat(avatar.maxAgeUnit()).isEqualTo(TimeUnit.SECONDS);
             assertThat(cachedAvatarFiles("mvhsclubs")).isEmpty();
         } finally {
             server.stop(0);
@@ -316,10 +346,16 @@ class InstagramAvatarCacheServiceTest {
     @Test
     void resolveAvatarRejectsSvgContentTypeAndDoesNotCacheIt() throws Exception {
         // The reviewer's other flagged example (image/svg+xml pretending to be a
-        // cacheable avatar) must also be rejected rather than cached.
+        // cacheable avatar) must also be rejected rather than cached. The served
+        // Content-Type here is ALSO image/svg+xml, so the returned media type alone
+        // cannot distinguish "rejected, replaced by the generated placeholder" from
+        // "passed straight through" -- assert on the placeholder's actual payload/TTL
+        // and on the download having happened instead.
         byte[] bytes = { 0, 1, 2, 3, 4, 5, 6, 7 };
+        AtomicInteger hits = new AtomicInteger();
         HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
         server.createContext("/avatar.svg", exchange -> {
+            hits.incrementAndGet();
             exchange.getResponseHeaders().add("Content-Type", "image/svg+xml");
             exchange.sendResponseHeaders(200, bytes.length);
             exchange.getResponseBody().write(bytes);
@@ -339,7 +375,16 @@ class InstagramAvatarCacheServiceTest {
         try {
             InstagramAvatarCacheService.ResolvedAvatar avatar = service.resolveAvatar("mvhsclubs");
 
+            // The download must actually have happened; otherwise this test would pass
+            // just as well for a broken harness (unreachable server, bad script path...).
+            assertThat(hits.get()).isGreaterThanOrEqualTo(1);
+            // Assert the payload is the GENERATED placeholder, not the served bytes,
+            // and that it carries the placeholder's short TTL rather than the cached
+            // 60-day TTL.
             assertThat(avatar.mediaType()).isEqualTo(MediaType.valueOf("image/svg+xml"));
+            assertThat(new String(avatar.bytes(), StandardCharsets.UTF_8)).contains("<svg").contains("MV");
+            assertThat(avatar.maxAge()).isEqualTo(15);
+            assertThat(avatar.maxAgeUnit()).isEqualTo(TimeUnit.SECONDS);
             assertThat(cachedAvatarFiles("mvhsclubs")).isEmpty();
         } finally {
             server.stop(0);


### PR DESCRIPTION
Follow-up to the review of #71 (already merged). Closes both P3 findings from that review; the reviewer's verdict on #71 itself was "patch is correct".

## 1. The "single supported set" comment was not actually enforced

#71 added a comment claiming PNG/JPEG/GIF/WebP was "the single supported image format set shared by the download Accept header, response media-type validation, and the on-disk extension mapping". In reality the set was still spelled out independently in **four** places -- the `Accept` header literal, `safeImageMediaType`'s checks, `extensionForMediaType`, and `mediaTypeForExtension` -- with nothing linking them at compile time. That is precisely the drift that caused the original mislabeling bug, so the comment described an invariant the code did not have.

The set now lives in one map (media type -> the extension the cache writes it under), and the `Accept` header, the supported-format check, and the extension lookup all derive from it. The header still emits the identical `image/webp,image/png,image/jpeg,image/gif`.

`extensionForMediaType` no longer needs its "unreachable" `png` default -- an unmapped media type is now a loud `IllegalStateException` instead of a silent wrong extension. It stays unreachable because upstream validation only ever yields the four supported formats, and both callers already degrade to the SVG placeholder on exception, so this cannot surface as a user-facing failure.

### Deliberately write-side only

`IMAGE_EXTENSIONS` and `mediaTypeForExtension` are **unchanged** and remain the read side: the cache must keep finding, serving and cleaning up legacy `.jpeg` files written by older code, even though it now only ever writes `.jpg`. A new regression test (`resolveAvatarReadsLegacyJpegExtensionFromCache`) writes a `.jpeg` file directly into the cache dir and asserts it is served as `image/jpeg` with the 60-day cached TTL, so a future refactor cannot quietly orphan those files.

## 2. Two rejection tests could pass for the wrong reason

`resolveAvatarRejectsSvgContentTypeAndDoesNotCacheIt` asserted the returned media type was `image/svg+xml` -- but that was *also* the `Content-Type` being served, so the assertion could not distinguish "rejected, replaced by the generated placeholder" from "passed straight through". And both rejection tests would have passed even if the download never happened at all (a typo'd script path, an unreachable server), since any failure yields the same placeholder.

Both now assert the body really is the **generated** placeholder (contains `<svg` and the handle's initials) with the fallback's short 15s TTL rather than the cached 60-day one, and count HTTP hits to prove the request actually happened.

## Verification

`./mvnw test` -> **51 tests, 0 failures** (50 + 1 new legacy-jpeg regression test).

Both changes mutation-verified:
- Reverting the format rejection (blind `orElse(IMAGE_JPEG)`, no throw) fails **both** hardened rejection tests.
- Removing the WebP entry from the new map fails the WebP happy-path test -- confirming the map genuinely drives all three call sites rather than being decorative.

## Two follow-ups NOT in this PR (raised by the same review, flagged for a decision)

1. **No negative cache for permanently-unsupported handles.** A rejected format is never written, so `hasFreshCachedAvatar` stays false forever for that handle: every page view re-triggers an instaloader subprocess + HTTP fetch, and the scheduled prewarm keeps spending its `maxRefreshPerRun` budget on handles that can never succeed, starving other clubs. The old code at least cached (badly). A short negative-cache/backoff marker would fix it.
2. **Pre-existing poisoned cache entries survive this fix.** Files mislabelled by the old code (e.g. AVIF bytes sitting in `<handle>.png`) are still read and served as `image/png` until their TTL expires -- so broken avatars can persist for up to 30 days after deploy unless the cache directory is cleared. Options: clear the avatar cache dir on deploy, or validate magic bytes on cache read and treat a mismatch as a miss (self-healing).
