### PR TITLE
feat(onboarding): show the interest quiz before the graduation-year step

### DIFF
--- a/frontend/src/views/AcceptTermsView.spec.ts
+++ b/frontend/src/views/AcceptTermsView.spec.ts
@@ -70,7 +70,7 @@ afterEach(() => {
 })
 
 describe('AcceptTermsView', () => {
-  it('sends a user with no graduation year to onboarding (not the final destination) after accepting terms', async () => {
+  it('sends a first-time user to the interest quiz before onboarding after accepting terms', async () => {
     fetchMock.mockResolvedValue({ ok: true })
     fetchAuthenticatedUserMock.mockResolvedValue(buildUser({ graduationYear: null }))
     setRouteQuery({ redirect: '/clubs/5' })
@@ -79,8 +79,8 @@ describe('AcceptTermsView', () => {
     await agreeAndSubmit(wrapper)
 
     expect(replaceMock).toHaveBeenCalledWith({
-      path: '/onboarding',
-      query: { redirect: '/clubs/5' },
+      path: '/recommendations',
+      query: { onboarding: 'true', redirect: '/clubs/5' },
     })
   })
 

--- a/frontend/src/views/AcceptTermsView.spec.ts
+++ b/frontend/src/views/AcceptTermsView.spec.ts
@@ -95,6 +95,20 @@ describe('AcceptTermsView', () => {
     expect(replaceMock).toHaveBeenCalledWith('/clubs/5')
   })
 
+  it('does not push a user whose session vanished mid-accept into the interest quiz', async () => {
+    // refreshUser() swallows the failure and clears currentUser, so the
+    // interest-quiz hop must not fire for what is now an unauthenticated
+    // visitor; the default landing path lets the router guard re-prompt login.
+    fetchMock.mockResolvedValue({ ok: true })
+    fetchAuthenticatedUserMock.mockRejectedValue(new Error('session expired'))
+    setRouteQuery({ redirect: '/clubs/5' })
+    const wrapper = mountView()
+
+    await agreeAndSubmit(wrapper)
+
+    expect(replaceMock).toHaveBeenCalledWith('/profile')
+  })
+
   it('lands a user with no redirect target at all on the default profile page', async () => {
     fetchMock.mockResolvedValue({ ok: true })
     fetchAuthenticatedUserMock.mockResolvedValue(buildUser())

--- a/frontend/src/views/AcceptTermsView.vue
+++ b/frontend/src/views/AcceptTermsView.vue
@@ -4,7 +4,11 @@ import { useRoute, useRouter } from 'vue-router'
 import { schoolTemplate } from '../config/schoolTemplate'
 import { useAuthStore } from '../stores/auth'
 import { buildApiUrl } from '../services/httpClient'
-import { DEFAULT_POST_AUTH_PATH, resolvePostAuthRoute } from '../utils/authRedirect'
+import {
+  DEFAULT_POST_AUTH_PATH,
+  resolvePostAuthRoute,
+  sanitizeAuthRedirectTarget,
+} from '../utils/authRedirect'
 
 const route = useRoute()
 const router = useRouter()
@@ -27,6 +31,22 @@ const handleAccept = async () => {
       throw new Error('Failed to record acceptance')
     }
     await authStore.refreshUser()
+    // A first-time student goes through the interest quiz BEFORE the
+    // graduation-year step, so the very first thing they see after signing up
+    // is clubs they might like rather than a form. This deliberately bypasses
+    // resolvePostAuthRoute (which would jump straight to /onboarding); the quiz
+    // hands the same sanitized target on to /onboarding when it is done, so the
+    // originally requested destination still survives the detour.
+    if (authStore.currentUser && authStore.currentUser.graduationYear == null) {
+      router.replace({
+        path: '/recommendations',
+        query: {
+          onboarding: 'true',
+          redirect: sanitizeAuthRedirectTarget(route.query.redirect),
+        },
+      })
+      return
+    }
     const destination = resolvePostAuthRoute(authStore.currentUser, route.query.redirect)
     router.replace(destination ?? DEFAULT_POST_AUTH_PATH)
   } catch (err) {

--- a/frontend/src/views/RecommendationView.spec.ts
+++ b/frontend/src/views/RecommendationView.spec.ts
@@ -1,15 +1,32 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  return {
+    ...actual,
+    useRoute: vi.fn(),
+    useRouter: vi.fn(),
+  }
+})
+
 import RecommendationView from './RecommendationView.vue'
+import { useRoute, useRouter } from 'vue-router'
 
 vi.mock('../services/clubService', () => ({
   fetchAllClubs: vi.fn().mockResolvedValue([]),
 }))
 
 describe('RecommendationView', () => {
+  let replaceMock: ReturnType<typeof vi.fn>
+
   beforeEach(() => {
     vi.stubGlobal('scrollTo', vi.fn())
+    replaceMock = vi.fn()
+    vi.mocked(useRoute).mockReturnValue({ query: {} } as ReturnType<typeof useRoute>)
+    vi.mocked(useRouter).mockReturnValue({ replace: replaceMock } as unknown as ReturnType<
+      typeof useRouter
+    >)
   })
 
   afterEach(() => {
@@ -39,5 +56,62 @@ describe('RecommendationView', () => {
     }
 
     wrapper.unmount()
+  })
+
+  it('continues a first-time user to graduation-year onboarding after the quiz', async () => {
+    vi.mocked(useRoute).mockReturnValue({
+      query: { onboarding: 'true', redirect: '/clubs/5' },
+    } as unknown as ReturnType<typeof useRoute>)
+    const wrapper = mount(RecommendationView, {
+      global: { stubs: { RouterLink: true } },
+    })
+    await flushPromises()
+
+    for (let questionIndex = 0; questionIndex < 4; questionIndex++) {
+      await wrapper.find<HTMLInputElement>('.answer-input').setValue(true)
+      await wrapper.find<HTMLButtonElement>('.primary-button').trigger('click')
+      await flushPromises()
+    }
+
+    await wrapper.find<HTMLButtonElement>('.onboarding-continue .primary-button').trigger('click')
+
+    expect(replaceMock).toHaveBeenCalledWith({
+      path: '/onboarding',
+      query: { redirect: '/clubs/5' },
+    })
+  })
+
+  it('lets a first-time user skip the quiz straight to graduation-year onboarding', async () => {
+    vi.mocked(useRoute).mockReturnValue({
+      query: { onboarding: 'true', redirect: '/clubs/5' },
+    } as unknown as ReturnType<typeof useRoute>)
+    const wrapper = mount(RecommendationView, {
+      global: { stubs: { RouterLink: true } },
+    })
+    await flushPromises()
+
+    await wrapper.find<HTMLButtonElement>('.skip-quiz').trigger('click')
+
+    expect(replaceMock).toHaveBeenCalledWith({
+      path: '/onboarding',
+      query: { redirect: '/clubs/5' },
+    })
+  })
+
+  it('keeps the onboarding-only affordances out of the standalone quiz', async () => {
+    const wrapper = mount(RecommendationView, {
+      global: { stubs: { RouterLink: true } },
+    })
+    await flushPromises()
+
+    expect(wrapper.find('.skip-quiz').exists()).toBe(false)
+
+    for (let questionIndex = 0; questionIndex < 4; questionIndex++) {
+      await wrapper.find<HTMLInputElement>('.answer-input').setValue(true)
+      await wrapper.find<HTMLButtonElement>('.primary-button').trigger('click')
+      await flushPromises()
+    }
+
+    expect(wrapper.find('.onboarding-continue').exists()).toBe(false)
   })
 })

--- a/frontend/src/views/RecommendationView.vue
+++ b/frontend/src/views/RecommendationView.vue
@@ -285,7 +285,7 @@ onMounted(loadClubs)
           {{ isOnboardingFlow ? 'Choose your interests' : 'Club match quiz' }}
         </p>
         <h1>Find clubs that fit you</h1>
-        <p>
+        <p class="quiz-lede">
           Answer four quick questions and we will match your interests with clubs at your school.
         </p>
         <button
@@ -483,7 +483,10 @@ onMounted(loadClubs)
   font-size: clamp(2rem, 4vw, 3.2rem);
 }
 
-.quiz-header > p:last-child,
+/* Targeted by class, not `p:last-child`: the onboarding variant of this header
+   appends a "Skip for now" button after the copy, which would otherwise strip
+   this styling off the intro paragraph in exactly that flow. */
+.quiz-header > .quiz-lede,
 .results-header > div > p:last-child {
   max-width: 720px;
   color: var(--mv-text-muted);
@@ -796,7 +799,7 @@ onMounted(loadClubs)
     text-align: center;
   }
 
-  .quiz-header > p:last-child {
+  .quiz-header > .quiz-lede {
     margin-inline: auto;
   }
 }

--- a/frontend/src/views/RecommendationView.vue
+++ b/frontend/src/views/RecommendationView.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref } from 'vue'
-import { RouterLink } from 'vue-router'
+import { RouterLink, useRoute, useRouter } from 'vue-router'
 
 import { fetchAllClubs } from '../services/clubService'
 import type { Club } from '../types/club'
+import { sanitizeAuthRedirectTarget } from '../utils/authRedirect'
 import { clubCategoryOptions } from '../utils/clubCategories'
 import { clubImage } from '../utils/clubImages'
 import { selectWeightedClubRecommendations } from '../utils/clubRecommendations'
@@ -19,6 +20,13 @@ type QuizQuestion = {
   helper: string
   options: QuizOption[]
 }
+
+const route = useRoute()
+const router = useRouter()
+// The quiz doubles as the first step of first-time registration (linked from
+// AcceptTermsView with ?onboarding=true). In that mode it shows a way onward to
+// the graduation-year step instead of leaving the student on a dead end.
+const isOnboardingFlow = computed(() => route.query.onboarding === 'true')
 
 const questions: QuizQuestion[] = [
   {
@@ -255,6 +263,17 @@ const restartQuiz = async () => {
   await focusQuestionHeading()
 }
 
+// Hands the still-pending post-auth target on to the graduation-year step, so a
+// student who signed up from a club page still lands there once setup is done.
+// `replace` keeps the quiz out of history: Back from /onboarding must not drop
+// the student into a quiz they already finished or skipped.
+const continueOnboarding = () => {
+  void router.replace({
+    path: '/onboarding',
+    query: { redirect: sanitizeAuthRedirectTarget(route.query.redirect) },
+  })
+}
+
 onMounted(loadClubs)
 </script>
 
@@ -262,11 +281,21 @@ onMounted(loadClubs)
   <main class="quiz-page page-shell">
     <template v-if="!showResults">
       <header class="quiz-header">
-        <p class="section-label">Club match quiz</p>
+        <p class="section-label">
+          {{ isOnboardingFlow ? 'Choose your interests' : 'Club match quiz' }}
+        </p>
         <h1>Find clubs that fit you</h1>
         <p>
           Answer four quick questions and we will match your interests with clubs at your school.
         </p>
+        <button
+          v-if="isOnboardingFlow"
+          type="button"
+          class="text-link skip-quiz"
+          @click="continueOnboarding"
+        >
+          Skip for now
+        </button>
       </header>
 
       <section class="quiz-card" aria-labelledby="quiz-question">
@@ -344,6 +373,16 @@ onMounted(loadClubs)
         <button type="button" class="secondary-button" @click="restartQuiz">Retake quiz</button>
       </header>
 
+      <div v-if="isOnboardingFlow" class="onboarding-continue">
+        <div>
+          <strong>Your club matches are ready.</strong>
+          <p>Continue to finish setting up your student profile.</p>
+        </div>
+        <button type="button" class="primary-button" @click="continueOnboarding">
+          Continue profile setup
+        </button>
+      </div>
+
       <section class="match-summary" aria-label="Top category matches">
         <article
           v-for="(category, index) in topCategories"
@@ -404,6 +443,33 @@ onMounted(loadClubs)
   flex-direction: column;
   gap: 2rem;
   padding-block: clamp(2rem, 5vw, 4rem);
+}
+
+.onboarding-continue {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid var(--mv-border-strong);
+  border-radius: 22px;
+  background: var(--mv-surface-accent);
+}
+
+.onboarding-continue p {
+  margin: 0.25rem 0 0;
+  color: var(--mv-text-muted);
+}
+
+.skip-quiz {
+  margin-top: 1rem;
+}
+
+@media (max-width: 640px) {
+  .onboarding-continue {
+    align-items: stretch;
+    flex-direction: column;
+  }
 }
 
 .quiz-header,


### PR DESCRIPTION
## What changed

A first-time student used to go straight from accepting the terms to the graduation-year form, so a brand-new account's first screen was a required input rather than any clubs. Registration now routes through the existing interest quiz first:

1. Google OAuth sign-up
2. `/accept-terms`
3. `/recommendations?onboarding=true` (pick interests, see matching clubs)
4. `/onboarding` (graduation year)
5. Original destination, default `/profile`

The quiz hands the same sanitized post-auth target on to `/onboarding`, so a student who signed up from a club page still lands back there once setup finishes.

## Notes for review

- The quiz behaves exactly as before when reached normally from the category page. The onboarding-only affordances (`Skip for now`, the `Continue profile setup` banner on the results screen) render only when `?onboarding=true`, and a regression test pins that so the CTA can't leak into the standalone quiz.
- The skip button matters because the quiz is four questions long: without it the detour would trap a student who just wants to finish signing up.
- Navigation uses `replace()`, so neither the quiz nor `/accept-terms` sits in history behind `/onboarding` and traps the Back button mid-flow.
- Re-entering the app later (auth callback / router guard) still resolves via `resolvePostAuthRoute` straight to `/onboarding`; the quiz is a first-registration step, not a gate that repeats on every login.

## Verification

- `npm run test:unit -- --run`: 127 passed (3 new RecommendationView cases, 1 updated AcceptTermsView case)
- `npm run build` (type-check + vite build): pass
- `eslint` + `prettier --check` on the touched files: clean