### PR TITLE
Club media: add post schema and mapper

### DIFF
--- a/backend/src/main/java/com/example/demo/club/mapper/ClubPostMapper.java
+++ b/backend/src/main/java/com/example/demo/club/mapper/ClubPostMapper.java
@@ -1,0 +1,38 @@
+package com.example.demo.club.mapper;
+
+import com.example.demo.club.model.ClubPost;
+import com.example.demo.club.model.ClubPostComment;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface ClubPostMapper {
+
+    List<ClubPost> findFeedByClubId(@Param("clubId") Long clubId,
+                                     @Param("offset") int offset,
+                                     @Param("limit") int limit);
+
+    int countFeedByClubId(@Param("clubId") Long clubId);
+
+    int insert(ClubPost post);
+
+    int delete(@Param("id") Long id);
+
+    int pin(@Param("id") Long id, @Param("pinnedByOauthUserId") Long pinnedByOauthUserId);
+
+    int unpin(@Param("id") Long id);
+
+    int countPinnedByClubId(@Param("clubId") Long clubId);
+
+    List<ClubPostComment> findCommentsByPostId(@Param("postId") Long postId);
+
+    int insertComment(ClubPostComment comment);
+
+    int deleteComment(@Param("id") Long id);
+
+    int countCommentsByPostId(@Param("postId") Long postId);
+
+    List<String> findAllImageUrls();
+}

--- a/backend/src/main/java/com/example/demo/club/model/ClubPost.java
+++ b/backend/src/main/java/com/example/demo/club/model/ClubPost.java
@@ -1,0 +1,84 @@
+package com.example.demo.club.model;
+
+import java.time.LocalDateTime;
+
+/**
+ * A single photo post on a club's media feed. A post always has exactly one photo; pinning
+ * (setting pinnedAt/pinnedByOauthUserId) moves it to the front of the same paginated feed
+ * rather than into a separate list.
+ */
+public class ClubPost {
+
+    private Long id;
+    private Long clubId;
+    private Long authorOauthUserId;
+    private String title;
+    private String imageUrl;
+    private LocalDateTime pinnedAt;
+    private Long pinnedByOauthUserId;
+    private LocalDateTime createdAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getClubId() {
+        return clubId;
+    }
+
+    public void setClubId(Long clubId) {
+        this.clubId = clubId;
+    }
+
+    public Long getAuthorOauthUserId() {
+        return authorOauthUserId;
+    }
+
+    public void setAuthorOauthUserId(Long authorOauthUserId) {
+        this.authorOauthUserId = authorOauthUserId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public LocalDateTime getPinnedAt() {
+        return pinnedAt;
+    }
+
+    public void setPinnedAt(LocalDateTime pinnedAt) {
+        this.pinnedAt = pinnedAt;
+    }
+
+    public Long getPinnedByOauthUserId() {
+        return pinnedByOauthUserId;
+    }
+
+    public void setPinnedByOauthUserId(Long pinnedByOauthUserId) {
+        this.pinnedByOauthUserId = pinnedByOauthUserId;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/example/demo/club/model/ClubPostComment.java
+++ b/backend/src/main/java/com/example/demo/club/model/ClubPostComment.java
@@ -1,0 +1,55 @@
+package com.example.demo.club.model;
+
+import java.time.LocalDateTime;
+
+/**
+ * A flat (non-threaded) comment on a {@link ClubPost}.
+ */
+public class ClubPostComment {
+
+    private Long id;
+    private Long postId;
+    private Long authorOauthUserId;
+    private String body;
+    private LocalDateTime createdAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getPostId() {
+        return postId;
+    }
+
+    public void setPostId(Long postId) {
+        this.postId = postId;
+    }
+
+    public Long getAuthorOauthUserId() {
+        return authorOauthUserId;
+    }
+
+    public void setAuthorOauthUserId(Long authorOauthUserId) {
+        this.authorOauthUserId = authorOauthUserId;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/resources/db/h2/reset.sql
+++ b/backend/src/main/resources/db/h2/reset.sql
@@ -10,6 +10,8 @@ DROP TABLE IF EXISTS club_member;
 DROP TABLE IF EXISTS club_membership_requests;
 DROP TABLE IF EXISTS club_tag;
 DROP TABLE IF EXISTS club_social_medias;
+DROP TABLE IF EXISTS club_post_comment;
+DROP TABLE IF EXISTS club_post;
 DROP TABLE IF EXISTS clubs;
 DROP TABLE IF EXISTS user_profiles;
 DROP TABLE IF EXISTS oauth_users;

--- a/backend/src/main/resources/mapper/ClubPostMapper.xml
+++ b/backend/src/main/resources/mapper/ClubPostMapper.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.example.demo.club.mapper.ClubPostMapper">
+
+    <resultMap id="ClubPostResultMap" type="com.example.demo.club.model.ClubPost">
+        <id column="id" property="id" />
+        <result column="club_id" property="clubId" />
+        <result column="author_oauth_user_id" property="authorOauthUserId" />
+        <result column="title" property="title" />
+        <result column="image_url" property="imageUrl" />
+        <result column="pinned_at" property="pinnedAt" />
+        <result column="pinned_by_oauth_user_id" property="pinnedByOauthUserId" />
+        <result column="created_at" property="createdAt" />
+    </resultMap>
+
+    <sql id="PostColumnList">
+        id, club_id, author_oauth_user_id, title, image_url, pinned_at, pinned_by_oauth_user_id, created_at
+    </sql>
+
+    <!-- The CASE WHEN form is required over "(pinned_at IS NOT NULL) DESC": that expression is
+         1/0 in MySQL but BOOLEAN in H2 MODE=MySQL, an engine-dependent difference this repo has
+         already been bitten by (see schema.sql's achievements CLOB-vs-JSON comment). The
+         trailing "id DESC" is a deliberate pagination-stability tiebreaker: created_at only has
+         second granularity, so without it two posts created in the same second could swap
+         places between page requests, duplicating or skipping items across a page boundary. -->
+    <select id="findFeedByClubId" resultMap="ClubPostResultMap">
+        SELECT <include refid="PostColumnList" />
+        FROM club_post
+        WHERE club_id = #{clubId}
+        ORDER BY CASE WHEN pinned_at IS NULL THEN 1 ELSE 0 END ASC,
+                 pinned_at  DESC,
+                 created_at DESC,
+                 id         DESC
+        LIMIT #{limit} OFFSET #{offset}
+    </select>
+
+    <select id="countFeedByClubId" resultType="int">
+        SELECT COUNT(*) FROM club_post WHERE club_id = #{clubId}
+    </select>
+
+    <insert id="insert" parameterType="com.example.demo.club.model.ClubPost"
+            useGeneratedKeys="true" keyProperty="id" keyColumn="id">
+        INSERT INTO club_post (club_id, author_oauth_user_id, title, image_url)
+        VALUES (#{clubId}, #{authorOauthUserId}, #{title}, #{imageUrl})
+    </insert>
+
+    <delete id="delete">
+        DELETE FROM club_post WHERE id = #{id}
+    </delete>
+
+    <update id="pin">
+        UPDATE club_post
+        SET pinned_at = CURRENT_TIMESTAMP,
+            pinned_by_oauth_user_id = #{pinnedByOauthUserId}
+        WHERE id = #{id}
+    </update>
+
+    <update id="unpin">
+        UPDATE club_post
+        SET pinned_at = NULL,
+            pinned_by_oauth_user_id = NULL
+        WHERE id = #{id}
+    </update>
+
+    <select id="countPinnedByClubId" resultType="int">
+        SELECT COUNT(*) FROM club_post WHERE club_id = #{clubId} AND pinned_at IS NOT NULL
+    </select>
+
+    <resultMap id="ClubPostCommentResultMap" type="com.example.demo.club.model.ClubPostComment">
+        <id column="id" property="id" />
+        <result column="post_id" property="postId" />
+        <result column="author_oauth_user_id" property="authorOauthUserId" />
+        <result column="body" property="body" />
+        <result column="created_at" property="createdAt" />
+    </resultMap>
+
+    <select id="findCommentsByPostId" resultMap="ClubPostCommentResultMap">
+        SELECT id, post_id, author_oauth_user_id, body, created_at
+        FROM club_post_comment
+        WHERE post_id = #{postId}
+        ORDER BY created_at ASC, id ASC
+    </select>
+
+    <insert id="insertComment" parameterType="com.example.demo.club.model.ClubPostComment"
+            useGeneratedKeys="true" keyProperty="id" keyColumn="id">
+        INSERT INTO club_post_comment (post_id, author_oauth_user_id, body)
+        VALUES (#{postId}, #{authorOauthUserId}, #{body})
+    </insert>
+
+    <delete id="deleteComment">
+        DELETE FROM club_post_comment WHERE id = #{id}
+    </delete>
+
+    <select id="countCommentsByPostId" resultType="int">
+        SELECT COUNT(*) FROM club_post_comment WHERE post_id = #{postId}
+    </select>
+
+    <!-- Not called by UploadCleanupService yet: that rework is #77. Exists now so #77 can
+         union this with clubs.image_url to know which stored files under club-posts/ are still
+         referenced and must not be deleted as orphans. -->
+    <select id="findAllImageUrls" resultType="string">
+        SELECT image_url FROM club_post
+    </select>
+
+</mapper>

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -136,3 +136,29 @@ CREATE TABLE IF NOT EXISTS calenders (
     PRIMARY KEY (club_id, week_day),
     CONSTRAINT fk_calender_club FOREIGN KEY (club_id) REFERENCES clubs(id) ON DELETE CASCADE
 );
+
+CREATE TABLE IF NOT EXISTS club_post (
+    id                      BIGINT PRIMARY KEY AUTO_INCREMENT,
+    club_id                 BIGINT       NOT NULL,
+    author_oauth_user_id    BIGINT       NOT NULL,
+    title                   VARCHAR(140) NOT NULL,
+    image_url               VARCHAR(300) NOT NULL,
+    pinned_at               TIMESTAMP    NULL,
+    pinned_by_oauth_user_id BIGINT       NULL,
+    created_at              TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_post_club      FOREIGN KEY (club_id) REFERENCES clubs(id) ON DELETE CASCADE,
+    CONSTRAINT fk_post_author    FOREIGN KEY (author_oauth_user_id) REFERENCES oauth_users(uid) ON DELETE CASCADE,
+    CONSTRAINT fk_post_pinned_by FOREIGN KEY (pinned_by_oauth_user_id) REFERENCES oauth_users(uid) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_post_club_feed ON club_post (club_id, pinned_at, created_at);
+
+CREATE TABLE IF NOT EXISTS club_post_comment (
+    id                   BIGINT PRIMARY KEY AUTO_INCREMENT,
+    post_id              BIGINT       NOT NULL,
+    author_oauth_user_id BIGINT       NOT NULL,
+    body                 VARCHAR(300) NOT NULL,
+    created_at           TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_comment_post   FOREIGN KEY (post_id) REFERENCES club_post(id) ON DELETE CASCADE,
+    CONSTRAINT fk_comment_author FOREIGN KEY (author_oauth_user_id) REFERENCES oauth_users(uid) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_comment_post ON club_post_comment (post_id, created_at);

--- a/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
+++ b/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
@@ -1,0 +1,271 @@
+package com.example.demo.club.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.demo.club.model.ClubPost;
+import com.example.demo.club.model.ClubPostComment;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+// Runs on its own in-memory database (see commit 9b8368b): the default test datasource is
+// shared across Spring contexts in the same JVM, and other mapper tests rebuild oauth_users
+// and clubs with different column sets.
+@SpringBootTest(properties = "spring.datasource.url=jdbc:h2:mem:club_post_mapper_test;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE")
+class ClubPostMapperTest {
+
+    @Autowired
+    private ClubPostMapper clubPostMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("DROP TABLE IF EXISTS club_post_comment");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS club_post");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS clubs");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS oauth_users");
+        jdbcTemplate.execute("""
+            CREATE TABLE oauth_users (
+                uid BIGINT PRIMARY KEY AUTO_INCREMENT,
+                provider VARCHAR(50) NOT NULL,
+                provider_user_id VARCHAR(150) NOT NULL
+            )
+            """);
+        jdbcTemplate.execute("""
+            CREATE TABLE clubs (
+                id BIGINT PRIMARY KEY AUTO_INCREMENT,
+                name VARCHAR(150) NOT NULL
+            )
+            """);
+        jdbcTemplate.execute("""
+            CREATE TABLE club_post (
+                id                      BIGINT PRIMARY KEY AUTO_INCREMENT,
+                club_id                 BIGINT       NOT NULL,
+                author_oauth_user_id    BIGINT       NOT NULL,
+                title                   VARCHAR(140) NOT NULL,
+                image_url               VARCHAR(300) NOT NULL,
+                pinned_at               TIMESTAMP    NULL,
+                pinned_by_oauth_user_id BIGINT       NULL,
+                created_at              TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                CONSTRAINT fk_post_club      FOREIGN KEY (club_id) REFERENCES clubs(id) ON DELETE CASCADE,
+                CONSTRAINT fk_post_author    FOREIGN KEY (author_oauth_user_id) REFERENCES oauth_users(uid) ON DELETE CASCADE,
+                CONSTRAINT fk_post_pinned_by FOREIGN KEY (pinned_by_oauth_user_id) REFERENCES oauth_users(uid) ON DELETE SET NULL
+            )
+            """);
+        jdbcTemplate.execute("""
+            CREATE TABLE club_post_comment (
+                id                   BIGINT PRIMARY KEY AUTO_INCREMENT,
+                post_id              BIGINT       NOT NULL,
+                author_oauth_user_id BIGINT       NOT NULL,
+                body                 VARCHAR(300) NOT NULL,
+                created_at           TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                CONSTRAINT fk_comment_post   FOREIGN KEY (post_id) REFERENCES club_post(id) ON DELETE CASCADE,
+                CONSTRAINT fk_comment_author FOREIGN KEY (author_oauth_user_id) REFERENCES oauth_users(uid) ON DELETE CASCADE
+            )
+            """);
+
+        jdbcTemplate.update("INSERT INTO oauth_users (uid, provider, provider_user_id) VALUES (1, 'google', 'g-1')");
+        jdbcTemplate.update("INSERT INTO clubs (id, name) VALUES (1, 'Chess Club')");
+    }
+
+    @Test
+    void insertPersistsAPostThatFindFeedByClubIdCanReadBack() {
+        ClubPost post = new ClubPost();
+        post.setClubId(1L);
+        post.setAuthorOauthUserId(1L);
+        post.setTitle("First meeting");
+        post.setImageUrl("/uploads/club-posts/a.jpg");
+
+        clubPostMapper.insert(post);
+
+        List<ClubPost> feed = clubPostMapper.findFeedByClubId(1L, 0, 10);
+        assertThat(feed).singleElement().satisfies(found -> {
+            assertThat(found.getId()).isEqualTo(post.getId());
+            assertThat(found.getTitle()).isEqualTo("First meeting");
+            assertThat(found.getImageUrl()).isEqualTo("/uploads/club-posts/a.jpg");
+        });
+    }
+
+    // Feed order: pinned posts first, then created_at DESC, with id DESC as the tiebreaker for
+    // two posts sharing the same created_at second.
+    @Test
+    void findFeedByClubIdSortsPinnedFirstThenNewestFirstWithIdAsTheTiebreaker() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        insertPost(2L, 1L, "2024-01-01 10:00:00", null);
+        insertPost(3L, 1L, "2024-01-02 10:00:00", null);
+        insertPost(4L, 1L, "2023-01-01 10:00:00", "2024-06-01 00:00:00");
+
+        List<ClubPost> feed = clubPostMapper.findFeedByClubId(1L, 0, 10);
+
+        assertThat(feed).extracting(ClubPost::getId)
+            .containsExactly(4L, 3L, 2L, 1L);
+    }
+
+    // Among pinned posts, order is driven by pinned_at DESC, not created_at: post 2 is pinned
+    // later (2024-07) despite being created earlier (2024-02), and must still sort before
+    // post 1, which was created later (2024-08) but pinned earlier (2024-01).
+    @Test
+    void findFeedByClubIdSortsPinnedPostsByPinnedAtDescNotCreatedAt() {
+        insertPost(1L, 1L, "2024-08-01 10:00:00", "2024-01-01 00:00:00");
+        insertPost(2L, 1L, "2024-02-01 10:00:00", "2024-07-01 00:00:00");
+
+        List<ClubPost> feed = clubPostMapper.findFeedByClubId(1L, 0, 10);
+
+        assertThat(feed).extracting(ClubPost::getId)
+            .containsExactly(2L, 1L);
+    }
+
+    // Pagination must not duplicate or skip rows across a page boundary. Five posts, page size
+    // two: page 0 -> [5, 4], page 1 -> [3, 2], page 2 -> [1].
+    @Test
+    void findFeedByClubIdIsStableAcrossAPageBoundary() {
+        for (long id = 1; id <= 5; id++) {
+            insertPost(id, 1L, "2024-01-0" + id + " 10:00:00", null);
+        }
+
+        List<Long> firstPage = idsOf(clubPostMapper.findFeedByClubId(1L, 0, 2));
+        List<Long> secondPage = idsOf(clubPostMapper.findFeedByClubId(1L, 2, 2));
+        List<Long> thirdPage = idsOf(clubPostMapper.findFeedByClubId(1L, 4, 2));
+
+        assertThat(firstPage).containsExactly(5L, 4L);
+        assertThat(secondPage).containsExactly(3L, 2L);
+        assertThat(thirdPage).containsExactly(1L);
+    }
+
+    @Test
+    void deleteRemovesThePostFromTheFeed() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        insertPost(2L, 1L, "2024-01-02 10:00:00", null);
+
+        clubPostMapper.delete(1L);
+
+        assertThat(idsOf(clubPostMapper.findFeedByClubId(1L, 0, 10))).containsExactly(2L);
+    }
+
+    @Test
+    void insertCommentPersistsACommentThatFindCommentsByPostIdCanReadBack() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+
+        ClubPostComment comment = new ClubPostComment();
+        comment.setPostId(1L);
+        comment.setAuthorOauthUserId(1L);
+        comment.setBody("Great photo!");
+
+        clubPostMapper.insertComment(comment);
+
+        List<ClubPostComment> comments = clubPostMapper.findCommentsByPostId(1L);
+        assertThat(comments).singleElement().satisfies(found -> {
+            assertThat(found.getId()).isEqualTo(comment.getId());
+            assertThat(found.getBody()).isEqualTo("Great photo!");
+        });
+    }
+
+    @Test
+    void deletingAPostCascadesItsComments() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        ClubPostComment comment = new ClubPostComment();
+        comment.setPostId(1L);
+        comment.setAuthorOauthUserId(1L);
+        comment.setBody("Nice!");
+        clubPostMapper.insertComment(comment);
+
+        clubPostMapper.delete(1L);
+
+        assertThat(clubPostMapper.findCommentsByPostId(1L)).isEmpty();
+    }
+
+    @Test
+    void deletingAClubCascadesItsPosts() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        insertPost(2L, 1L, "2024-01-02 10:00:00", null);
+        ClubPostComment comment = new ClubPostComment();
+        comment.setPostId(1L);
+        comment.setAuthorOauthUserId(1L);
+        comment.setBody("Nice!");
+        clubPostMapper.insertComment(comment);
+
+        jdbcTemplate.update("DELETE FROM clubs WHERE id = 1");
+
+        assertThat(clubPostMapper.findFeedByClubId(1L, 0, 10)).isEmpty();
+        assertThat(clubPostMapper.findCommentsByPostId(1L)).isEmpty();
+    }
+
+    @Test
+    void countFeedByClubIdCountsEveryPostRegardlessOfPageSize() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        insertPost(2L, 1L, "2024-01-02 10:00:00", null);
+        insertPost(3L, 1L, "2024-01-03 10:00:00", null);
+
+        assertThat(clubPostMapper.countFeedByClubId(1L)).isEqualTo(3);
+    }
+
+    @Test
+    void pinSetsPinnedAtAndPinnedByAndMovesThePostToTheFrontOfTheFeed() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        insertPost(2L, 1L, "2024-01-02 10:00:00", null);
+
+        clubPostMapper.pin(1L, 1L);
+
+        assertThat(idsOf(clubPostMapper.findFeedByClubId(1L, 0, 10))).containsExactly(1L, 2L);
+        assertThat(clubPostMapper.countPinnedByClubId(1L)).isEqualTo(1);
+    }
+
+    @Test
+    void unpinClearsPinnedAtAndPinnedByAndReturnsThePostToChronologicalOrder() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        insertPost(2L, 1L, "2024-01-02 10:00:00", null);
+        clubPostMapper.pin(1L, 1L);
+
+        clubPostMapper.unpin(1L);
+
+        assertThat(idsOf(clubPostMapper.findFeedByClubId(1L, 0, 10))).containsExactly(2L, 1L);
+        assertThat(clubPostMapper.countPinnedByClubId(1L)).isZero();
+    }
+
+    @Test
+    void deleteCommentRemovesOnlyThatCommentAndCountCommentsByPostIdReflectsIt() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        ClubPostComment first = new ClubPostComment();
+        first.setPostId(1L);
+        first.setAuthorOauthUserId(1L);
+        first.setBody("First");
+        clubPostMapper.insertComment(first);
+        ClubPostComment second = new ClubPostComment();
+        second.setPostId(1L);
+        second.setAuthorOauthUserId(1L);
+        second.setBody("Second");
+        clubPostMapper.insertComment(second);
+
+        clubPostMapper.deleteComment(first.getId());
+
+        assertThat(clubPostMapper.countCommentsByPostId(1L)).isEqualTo(1);
+        assertThat(clubPostMapper.findCommentsByPostId(1L)).singleElement()
+            .satisfies(remaining -> assertThat(remaining.getBody()).isEqualTo("Second"));
+    }
+
+    @Test
+    void findAllImageUrlsReturnsEveryPostsImageUrlAcrossClubs() {
+        jdbcTemplate.update("INSERT INTO clubs (id, name) VALUES (2, 'Robotics')");
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        insertPost(2L, 2L, "2024-01-02 10:00:00", null);
+
+        assertThat(clubPostMapper.findAllImageUrls())
+            .containsExactlyInAnyOrder("/uploads/club-posts/1.jpg", "/uploads/club-posts/2.jpg");
+    }
+
+    private void insertPost(long id, long clubId, String createdAt, String pinnedAt) {
+        jdbcTemplate.update(
+            "INSERT INTO club_post (id, club_id, author_oauth_user_id, title, image_url, created_at, pinned_at) "
+                + "VALUES (?, ?, 1, 'Post ' || ?, '/uploads/club-posts/' || ? || '.jpg', ?, ?)",
+            id, clubId, id, id, createdAt, pinnedAt);
+    }
+
+    private static List<Long> idsOf(List<ClubPost> posts) {
+        return posts.stream().map(ClubPost::getId).toList();
+    }
+}

--- a/docs/club-media-migration.sql
+++ b/docs/club-media-migration.sql
@@ -1,0 +1,33 @@
+-- Production migration for club media (club_post / club_post_comment).
+-- Run by hand against the MySQL production database; there is no Flyway/Liquibase in this
+-- project and spring.sql.init.mode defaults to "never" in production (see backend/.env).
+
+CREATE TABLE club_post (
+    id                      BIGINT PRIMARY KEY AUTO_INCREMENT,
+    club_id                 BIGINT       NOT NULL,
+    author_oauth_user_id    BIGINT       NOT NULL,
+    title                   VARCHAR(140) NOT NULL,
+    image_url               VARCHAR(300) NOT NULL,
+    pinned_at               TIMESTAMP    NULL,
+    pinned_by_oauth_user_id BIGINT       NULL,
+    created_at              TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_post_club      FOREIGN KEY (club_id) REFERENCES clubs(id) ON DELETE CASCADE,
+    CONSTRAINT fk_post_author    FOREIGN KEY (author_oauth_user_id) REFERENCES oauth_users(uid) ON DELETE CASCADE,
+    CONSTRAINT fk_post_pinned_by FOREIGN KEY (pinned_by_oauth_user_id) REFERENCES oauth_users(uid) ON DELETE SET NULL
+);
+CREATE INDEX idx_post_club_feed ON club_post (club_id, pinned_at, created_at);
+
+CREATE TABLE club_post_comment (
+    id                   BIGINT PRIMARY KEY AUTO_INCREMENT,
+    post_id              BIGINT       NOT NULL,
+    author_oauth_user_id BIGINT       NOT NULL,
+    body                 VARCHAR(300) NOT NULL,
+    created_at           TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_comment_post   FOREIGN KEY (post_id) REFERENCES club_post(id) ON DELETE CASCADE,
+    CONSTRAINT fk_comment_author FOREIGN KEY (author_oauth_user_id) REFERENCES oauth_users(uid) ON DELETE CASCADE
+);
+CREATE INDEX idx_comment_post ON club_post_comment (post_id, created_at);
+
+-- club_activities has zero references anywhere in the codebase, and its columns (no author,
+-- no timestamps) do not fit this feature. Drop it rather than repurpose it.
+DROP TABLE IF EXISTS club_activities;


### PR DESCRIPTION
## Summary

- Add the club post and comment schema to the H2 fixture and production migration.
- Add the MyBatis mapper and isolated integration coverage for feed ordering, pagination, and cascades.
- Keep the H2 reset dependency-safe and remove the obsolete production club_activities table.

## Verification

- ./mvnw -q -Dtest=ClubPostMapperTest test
- ./mvnw test (111 tests passed)
- H2 profile started twice against the same database with 50 seeded clubs each time

Closes bangxiao0927/HSclubs#76

---
Generated by Codet
