### PR TITLE
Club media: publish posts and read the feed

### DIFF
--- a/backend/src/main/java/com/example/demo/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/demo/auth/config/SecurityConfig.java
@@ -151,10 +151,17 @@ public class SecurityConfig {
 
     /**
      * Path patterns that carry a permitAll() GET in SecurityConfig's authorizeHttpRequests
-     * block above (public club data meant for future data-collection clients, plus the cached
-     * Instagram avatar images those clients would also want to fetch() rather than just
-     * <img>-load). Kept as a constant so the authorization rules and the CORS policy can't
-     * silently drift apart.
+     * block above -- but not every one of them: only the ones meant to be readable by
+     * literally any origin (public club data meant for future data-collection clients, plus
+     * the cached Instagram avatar images those clients would also want to fetch() rather than
+     * just <img>-load). GET /api/clubs/{clubSlugOrId}/posts (#78) is deliberately excluded
+     * even though it is also permitAll(): a club's activity photos and student display names
+     * are not the kind of data this wildcard-CORS list exists to let off-site aggregators
+     * script-read, so a cross-origin caller for that path falls through to the authenticated,
+     * exact-origin CORS policy instead (see SecurityConfigCorsTest for the behavior this
+     * protects). Kept as a constant so *this* list and the CORS policy built from it can't
+     * silently drift apart -- it is a deliberate subset of the permitAll() GETs above, not a
+     * mechanical mirror of all of them.
      */
     private static final List<String> PUBLIC_READ_ONLY_CORS_PATTERNS = List.of(
         "/api/summary",

--- a/backend/src/main/java/com/example/demo/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/demo/auth/config/SecurityConfig.java
@@ -73,6 +73,10 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/api/clubs").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/clubs/calendar").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/clubs/*").permitAll()
+                // Club media feed (#78): "/api/clubs/*" above does not span path segments, so
+                // it does not cover this. Deliberately its own matcher, not added to
+                // PUBLIC_READ_ONLY_CORS_PATTERNS below -- see that list's Javadoc.
+                .requestMatchers(HttpMethod.GET, "/api/clubs/*/posts").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/avatars/instagram/*").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/summary").permitAll()
                 // Everything else under /api requires authentication

--- a/backend/src/main/java/com/example/demo/club/controller/ClubController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubController.java
@@ -275,12 +275,7 @@ public class ClubController {
     // ---- Permission helpers ----
 
     private Club resolveClub(String clubSlugOrId, String viewerEmail) {
-        try {
-            Long numericId = Long.valueOf(clubSlugOrId);
-            return clubService.findById(numericId, viewerEmail);
-        } catch (NumberFormatException e) {
-            return clubService.findBySlug(clubSlugOrId, viewerEmail);
-        }
+        return clubService.resolveBySlugOrId(clubSlugOrId, viewerEmail);
     }
 
     private String resolveViewerEmail(Authentication authentication) {

--- a/backend/src/main/java/com/example/demo/club/controller/ClubImageController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubImageController.java
@@ -56,18 +56,11 @@ public class ClubImageController {
     }
 
     private Club resolveClub(String clubSlugOrId, String viewerEmail) {
-        try {
-            Long numericId = Long.valueOf(clubSlugOrId);
-            Club club = clubService.findById(numericId, viewerEmail);
-            if (club == null) throw new IllegalArgumentException("Club not found");
-            return club;
-        } catch (NumberFormatException e) {
-            Club club = clubService.findBySlug(clubSlugOrId, viewerEmail);
-            if (club == null) throw new IllegalArgumentException("Club not found");
-            return club;
-        } catch (IllegalArgumentException ex) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage());
+        Club club = clubService.resolveBySlugOrId(clubSlugOrId, viewerEmail);
+        if (club == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
         }
+        return club;
     }
 
     private Club requireManageAccess(String clubSlugOrId, Authentication authentication) {

--- a/backend/src/main/java/com/example/demo/club/controller/ClubPostController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubPostController.java
@@ -52,7 +52,7 @@ public class ClubPostController {
                                    @RequestParam("file") MultipartFile file,
                                    Authentication authentication) {
         String viewerEmail = authenticatedUserResolver.requireEmail(authentication);
-        Club club = resolveClub(clubSlugOrId, viewerEmail);
+        Club club = clubService.resolveBySlugOrId(clubSlugOrId, viewerEmail);
         if (club == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
         }
@@ -69,8 +69,8 @@ public class ClubPostController {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to store file");
         } catch (IllegalStateException e) {
             // The read-back immediately after insert() could not find the row (see
-            // ClubPostService#publish); the transaction has already been rolled back and the
-            // file cleaned up, so this is a genuine, if unexpected, server-side failure.
+            // ClubPostWriter#insertAndReadBack); the transaction has already been rolled back
+            // and the file cleaned up, so this is a genuine, if unexpected, server-side failure.
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to publish post");
         }
     }
@@ -84,7 +84,7 @@ public class ClubPostController {
                                              @RequestParam(defaultValue = "12") int size,
                                              Authentication authentication) {
         String viewerEmail = authenticatedUserResolver.resolveEmail(authentication);
-        Club club = resolveClub(clubSlugOrId, viewerEmail);
+        Club club = clubService.resolveBySlugOrId(clubSlugOrId, viewerEmail);
         if (club == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
         }
@@ -98,14 +98,5 @@ public class ClubPostController {
         }
 
         return clubPostService.findPublicFeed(club.getId(), page, size);
-    }
-
-    private Club resolveClub(String clubSlugOrId, String viewerEmail) {
-        try {
-            Long numericId = Long.valueOf(clubSlugOrId);
-            return clubService.findById(numericId, viewerEmail);
-        } catch (NumberFormatException e) {
-            return clubService.findBySlug(clubSlugOrId, viewerEmail);
-        }
     }
 }

--- a/backend/src/main/java/com/example/demo/club/controller/ClubPostController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubPostController.java
@@ -1,0 +1,106 @@
+package com.example.demo.club.controller;
+
+import com.example.demo.auth.mapper.OAuthUserMapper;
+import com.example.demo.club.model.Club;
+import com.example.demo.club.model.ClubPost;
+import com.example.demo.club.service.ClubPostService;
+import com.example.demo.club.service.ClubService;
+import com.example.demo.security.AuthenticatedUserResolver;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.IOException;
+
+/**
+ * Publishing a club media post and reading a club's public feed. Publishing is one atomic
+ * multipart request (title + file); a "upload the photo, then create the post" two-request
+ * design would either orphan the file when a caller abandons the form or force the server to
+ * prove a client-supplied imageUrl was actually minted by us for this request.
+ */
+@RestController
+@RequestMapping("/api/clubs")
+public class ClubPostController {
+
+    private final ClubService clubService;
+    private final ClubPostService clubPostService;
+    private final OAuthUserMapper oAuthUserMapper;
+    private final AuthenticatedUserResolver authenticatedUserResolver;
+
+    public ClubPostController(ClubService clubService,
+                              ClubPostService clubPostService,
+                              OAuthUserMapper oAuthUserMapper,
+                              AuthenticatedUserResolver authenticatedUserResolver) {
+        this.clubService = clubService;
+        this.clubPostService = clubPostService;
+        this.oAuthUserMapper = oAuthUserMapper;
+        this.authenticatedUserResolver = authenticatedUserResolver;
+    }
+
+    @PostMapping("/{clubSlugOrId}/posts")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ClubPost publish(@PathVariable String clubSlugOrId,
+                            @RequestParam("title") String title,
+                            @RequestParam("file") MultipartFile file,
+                            Authentication authentication) {
+        String viewerEmail = authenticatedUserResolver.requireEmail(authentication);
+        Club club = resolveClub(clubSlugOrId, viewerEmail);
+        if (club == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
+        }
+        if (!Boolean.TRUE.equals(club.getViewerIsMember())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Members only");
+        }
+
+        Long authorOauthUserId = oAuthUserMapper.findIdByEmail(viewerEmail);
+        try {
+            return clubPostService.publish(club.getId(), authorOauthUserId, title, file);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+        } catch (IOException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to store file");
+        }
+    }
+
+    // Gated on clubs.status = 'active', not clubs.visibility (that column has no semantics yet
+    // -- see #78/#83). A non-active club's feed 404s to anyone who is not a member, the club
+    // president, or a platform owner, so an unapproved club cannot publish to a public page.
+    @GetMapping("/{clubSlugOrId}/posts")
+    public ClubPostService.PostFeedPage feed(@PathVariable String clubSlugOrId,
+                                             @RequestParam(defaultValue = "0") int page,
+                                             @RequestParam(defaultValue = "12") int size,
+                                             Authentication authentication) {
+        String viewerEmail = authenticatedUserResolver.resolveEmail(authentication);
+        Club club = resolveClub(clubSlugOrId, viewerEmail);
+        if (club == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
+        }
+
+        boolean isActive = "active".equalsIgnoreCase(club.getStatus());
+        boolean canViewNonActiveClub = Boolean.TRUE.equals(club.getViewerIsMember())
+            || Boolean.TRUE.equals(club.getCanManage())
+            || authenticatedUserResolver.isPlatformOwner(authentication);
+        if (!isActive && !canViewNonActiveClub) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
+        }
+
+        return clubPostService.findPublicFeed(club.getId(), page, size);
+    }
+
+    private Club resolveClub(String clubSlugOrId, String viewerEmail) {
+        try {
+            Long numericId = Long.valueOf(clubSlugOrId);
+            return clubService.findById(numericId, viewerEmail);
+        } catch (NumberFormatException e) {
+            return clubService.findBySlug(clubSlugOrId, viewerEmail);
+        }
+    }
+}

--- a/backend/src/main/java/com/example/demo/club/controller/ClubPostController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubPostController.java
@@ -2,7 +2,7 @@ package com.example.demo.club.controller;
 
 import com.example.demo.auth.mapper.OAuthUserMapper;
 import com.example.demo.club.model.Club;
-import com.example.demo.club.model.ClubPost;
+import com.example.demo.club.model.PublicClubPost;
 import com.example.demo.club.service.ClubPostService;
 import com.example.demo.club.service.ClubService;
 import com.example.demo.security.AuthenticatedUserResolver;
@@ -47,10 +47,10 @@ public class ClubPostController {
 
     @PostMapping("/{clubSlugOrId}/posts")
     @ResponseStatus(HttpStatus.CREATED)
-    public ClubPost publish(@PathVariable String clubSlugOrId,
-                            @RequestParam("title") String title,
-                            @RequestParam("file") MultipartFile file,
-                            Authentication authentication) {
+    public PublicClubPost publish(@PathVariable String clubSlugOrId,
+                                   @RequestParam("title") String title,
+                                   @RequestParam("file") MultipartFile file,
+                                   Authentication authentication) {
         String viewerEmail = authenticatedUserResolver.requireEmail(authentication);
         Club club = resolveClub(clubSlugOrId, viewerEmail);
         if (club == null) {
@@ -67,6 +67,11 @@ public class ClubPostController {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
         } catch (IOException e) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to store file");
+        } catch (IllegalStateException e) {
+            // The read-back immediately after insert() could not find the row (see
+            // ClubPostService#publish); the transaction has already been rolled back and the
+            // file cleaned up, so this is a genuine, if unexpected, server-side failure.
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to publish post");
         }
     }
 

--- a/backend/src/main/java/com/example/demo/club/mapper/ClubPostMapper.java
+++ b/backend/src/main/java/com/example/demo/club/mapper/ClubPostMapper.java
@@ -2,6 +2,7 @@ package com.example.demo.club.mapper;
 
 import com.example.demo.club.model.ClubPost;
 import com.example.demo.club.model.ClubPostComment;
+import com.example.demo.club.model.PublicClubPost;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -15,6 +16,13 @@ public interface ClubPostMapper {
                                      @Param("limit") int limit);
 
     int countFeedByClubId(@Param("clubId") Long clubId);
+
+    // Public projection for the anonymous club feed: post columns plus the author's display
+    // name/avatar only, never any oauth_users column that could identify or contact them (see
+    // PublicClubPost's Javadoc for the exact forbidden list).
+    List<PublicClubPost> findPublicFeedByClubId(@Param("clubId") Long clubId,
+                                                 @Param("offset") int offset,
+                                                 @Param("limit") int limit);
 
     int insert(ClubPost post);
 

--- a/backend/src/main/java/com/example/demo/club/mapper/ClubPostMapper.java
+++ b/backend/src/main/java/com/example/demo/club/mapper/ClubPostMapper.java
@@ -24,6 +24,12 @@ public interface ClubPostMapper {
                                                  @Param("offset") int offset,
                                                  @Param("limit") int limit);
 
+    // Read-back for ClubPostService#publish, so a just-published post can be returned with the
+    // exact same safe shape a feed item has (author display name/avatar, never the internal
+    // author_oauth_user_id). Scoped to clubId as a defense-in-depth guard, matching every other
+    // by-ID lookup in this codebase.
+    PublicClubPost findPublicPostByIdAndClubId(@Param("id") Long id, @Param("clubId") Long clubId);
+
     int insert(ClubPost post);
 
     int delete(@Param("id") Long id);

--- a/backend/src/main/java/com/example/demo/club/model/PublicClubPost.java
+++ b/backend/src/main/java/com/example/demo/club/model/PublicClubPost.java
@@ -1,0 +1,87 @@
+package com.example.demo.club.model;
+
+import java.time.LocalDateTime;
+
+/**
+ * Public projection of a {@link ClubPost} for the anonymous, unauthenticated club feed. Exposes
+ * only the post's own columns plus the author's display name and avatar: never {@code email},
+ * {@code uid}/{@code author_oauth_user_id}, {@code provider}, {@code provider_user_id},
+ * {@code role}, {@code accepted_terms_at}, the user's {@code created_at}/{@code last_login_at},
+ * or {@code graduation_year}. See ClubPostMapperTest for the regression test that a wildcard
+ * select or a copied result map cannot silently reintroduce one of those columns here.
+ */
+public class PublicClubPost {
+
+    private Long id;
+    private Long clubId;
+    private String title;
+    private String imageUrl;
+    private LocalDateTime pinnedAt;
+    private LocalDateTime createdAt;
+    private String authorDisplayName;
+    private String authorAvatarUrl;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getClubId() {
+        return clubId;
+    }
+
+    public void setClubId(Long clubId) {
+        this.clubId = clubId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public LocalDateTime getPinnedAt() {
+        return pinnedAt;
+    }
+
+    public void setPinnedAt(LocalDateTime pinnedAt) {
+        this.pinnedAt = pinnedAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getAuthorDisplayName() {
+        return authorDisplayName;
+    }
+
+    public void setAuthorDisplayName(String authorDisplayName) {
+        this.authorDisplayName = authorDisplayName;
+    }
+
+    public String getAuthorAvatarUrl() {
+        return authorAvatarUrl;
+    }
+
+    public void setAuthorAvatarUrl(String authorAvatarUrl) {
+        this.authorAvatarUrl = authorAvatarUrl;
+    }
+}

--- a/backend/src/main/java/com/example/demo/club/service/ClubPostService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubPostService.java
@@ -5,6 +5,7 @@ import com.example.demo.club.model.ClubPost;
 import com.example.demo.club.model.PublicClubPost;
 import com.example.demo.common.PaginationClamps;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -13,9 +14,12 @@ import java.util.List;
 
 /**
  * Publishing a post and reading a club's public feed. Publishing is a single atomic operation:
- * the photo is written by {@link ImageStorageService} first, and if the subsequent row insert
- * fails for any reason, that file is deleted again so a failed publish never leaves an orphaned
- * file on disk with no corresponding row.
+ * the photo is written by {@link ImageStorageService} first, then the row is inserted and
+ * immediately read back in the same DB transaction so the response can carry the same safe
+ * shape a feed item has (author display name/avatar, {@code createdAt}, never the internal
+ * {@code author_oauth_user_id}). If the insert or the read-back fails for any reason, the
+ * transaction rolls back (no committed, unreadable row left behind) and the file is deleted
+ * again (no orphan left on disk either).
  */
 @Service
 public class ClubPostService {
@@ -30,7 +34,14 @@ public class ClubPostService {
         this.imageStorageService = imageStorageService;
     }
 
-    public ClubPost publish(Long clubId, Long authorOauthUserId, String title, MultipartFile file)
+    // @Transactional so the insert does not auto-commit before the read-back has succeeded:
+    // MyBatis auto-commits each statement on its own connection otherwise, which would leave a
+    // successfully inserted row committed even if the read-back that follows it throws. Wrapping
+    // both in one transaction means a read-back failure rolls the insert back too, not just the
+    // in-memory object -- the file cleanup in the catch block below is the other half of that
+    // same guarantee, for the disk side a DB rollback cannot touch.
+    @Transactional
+    public PublicClubPost publish(Long clubId, Long authorOauthUserId, String title, MultipartFile file)
             throws IOException {
         String trimmedTitle = validateTitle(title);
         if (file == null || file.isEmpty()) {
@@ -45,7 +56,13 @@ public class ClubPostService {
             post.setTitle(trimmedTitle);
             post.setImageUrl(imageUrl);
             clubPostMapper.insert(post);
-            return post;
+
+            PublicClubPost created = clubPostMapper.findPublicPostByIdAndClubId(post.getId(), clubId);
+            if (created == null) {
+                throw new IllegalStateException(
+                    "Post " + post.getId() + " was not found immediately after being inserted");
+            }
+            return created;
         } catch (RuntimeException e) {
             // The single-atomic-request contract: a file the row insert never ends up
             // referencing must not be left behind as an orphan.

--- a/backend/src/main/java/com/example/demo/club/service/ClubPostService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubPostService.java
@@ -1,11 +1,9 @@
 package com.example.demo.club.service;
 
 import com.example.demo.club.mapper.ClubPostMapper;
-import com.example.demo.club.model.ClubPost;
 import com.example.demo.club.model.PublicClubPost;
 import com.example.demo.common.PaginationClamps;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -14,12 +12,13 @@ import java.util.List;
 
 /**
  * Publishing a post and reading a club's public feed. Publishing is a single atomic operation:
- * the photo is written by {@link ImageStorageService} first, then the row is inserted and
- * immediately read back in the same DB transaction so the response can carry the same safe
- * shape a feed item has (author display name/avatar, {@code createdAt}, never the internal
- * {@code author_oauth_user_id}). If the insert or the read-back fails for any reason, the
- * transaction rolls back (no committed, unreadable row left behind) and the file is deleted
- * again (no orphan left on disk either).
+ * the photo is validated and written by {@link ImageStorageService} first, entirely outside any
+ * DB transaction (image decode/re-encode is CPU-bound work that must not hold a JDBC connection
+ * open), then {@link ClubPostWriter} inserts the row and immediately reads it back in one real
+ * DB transaction so the response can carry the same safe shape a feed item has (author display
+ * name/avatar, {@code createdAt}, never the internal {@code author_oauth_user_id}). If that
+ * insert-and-read-back fails for any reason, its transaction rolls back (no committed, unreadable
+ * row left behind) and the file is deleted here (no orphan left on disk either).
  */
 @Service
 public class ClubPostService {
@@ -28,19 +27,15 @@ public class ClubPostService {
 
     private final ClubPostMapper clubPostMapper;
     private final ImageStorageService imageStorageService;
+    private final ClubPostWriter clubPostWriter;
 
-    public ClubPostService(ClubPostMapper clubPostMapper, ImageStorageService imageStorageService) {
+    public ClubPostService(ClubPostMapper clubPostMapper, ImageStorageService imageStorageService,
+                            ClubPostWriter clubPostWriter) {
         this.clubPostMapper = clubPostMapper;
         this.imageStorageService = imageStorageService;
+        this.clubPostWriter = clubPostWriter;
     }
 
-    // @Transactional so the insert does not auto-commit before the read-back has succeeded:
-    // MyBatis auto-commits each statement on its own connection otherwise, which would leave a
-    // successfully inserted row committed even if the read-back that follows it throws. Wrapping
-    // both in one transaction means a read-back failure rolls the insert back too, not just the
-    // in-memory object -- the file cleanup in the catch block below is the other half of that
-    // same guarantee, for the disk side a DB rollback cannot touch.
-    @Transactional
     public PublicClubPost publish(Long clubId, Long authorOauthUserId, String title, MultipartFile file)
             throws IOException {
         String trimmedTitle = validateTitle(title);
@@ -50,19 +45,7 @@ public class ClubPostService {
 
         String imageUrl = imageStorageService.store(file);
         try {
-            ClubPost post = new ClubPost();
-            post.setClubId(clubId);
-            post.setAuthorOauthUserId(authorOauthUserId);
-            post.setTitle(trimmedTitle);
-            post.setImageUrl(imageUrl);
-            clubPostMapper.insert(post);
-
-            PublicClubPost created = clubPostMapper.findPublicPostByIdAndClubId(post.getId(), clubId);
-            if (created == null) {
-                throw new IllegalStateException(
-                    "Post " + post.getId() + " was not found immediately after being inserted");
-            }
-            return created;
+            return clubPostWriter.insertAndReadBack(clubId, authorOauthUserId, trimmedTitle, imageUrl);
         } catch (RuntimeException e) {
             // The single-atomic-request contract: a file the row insert never ends up
             // referencing must not be left behind as an orphan.

--- a/backend/src/main/java/com/example/demo/club/service/ClubPostService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubPostService.java
@@ -1,0 +1,86 @@
+package com.example.demo.club.service;
+
+import com.example.demo.club.mapper.ClubPostMapper;
+import com.example.demo.club.model.ClubPost;
+import com.example.demo.club.model.PublicClubPost;
+import com.example.demo.common.PaginationClamps;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Publishing a post and reading a club's public feed. Publishing is a single atomic operation:
+ * the photo is written by {@link ImageStorageService} first, and if the subsequent row insert
+ * fails for any reason, that file is deleted again so a failed publish never leaves an orphaned
+ * file on disk with no corresponding row.
+ */
+@Service
+public class ClubPostService {
+
+    private static final int MAX_TITLE_LENGTH = 140;
+
+    private final ClubPostMapper clubPostMapper;
+    private final ImageStorageService imageStorageService;
+
+    public ClubPostService(ClubPostMapper clubPostMapper, ImageStorageService imageStorageService) {
+        this.clubPostMapper = clubPostMapper;
+        this.imageStorageService = imageStorageService;
+    }
+
+    public ClubPost publish(Long clubId, Long authorOauthUserId, String title, MultipartFile file)
+            throws IOException {
+        String trimmedTitle = validateTitle(title);
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("A photo is required");
+        }
+
+        String imageUrl = imageStorageService.store(file);
+        try {
+            ClubPost post = new ClubPost();
+            post.setClubId(clubId);
+            post.setAuthorOauthUserId(authorOauthUserId);
+            post.setTitle(trimmedTitle);
+            post.setImageUrl(imageUrl);
+            clubPostMapper.insert(post);
+            return post;
+        } catch (RuntimeException e) {
+            // The single-atomic-request contract: a file the row insert never ends up
+            // referencing must not be left behind as an orphan.
+            imageStorageService.delete(imageUrl);
+            throw e;
+        }
+    }
+
+    public PostFeedPage findPublicFeed(Long clubId, int page, int size) {
+        int limit = PaginationClamps.clampPageSize(size);
+        int offset = PaginationClamps.clampOffset(page, limit);
+        int clampedPage = PaginationClamps.clampPage(page);
+
+        List<PublicClubPost> items = clubPostMapper.findPublicFeedByClubId(clubId, offset, limit);
+        int total = clubPostMapper.countFeedByClubId(clubId);
+
+        return new PostFeedPage(items, clampedPage, limit, total);
+    }
+
+    private static String validateTitle(String title) {
+        if (!StringUtils.hasText(title)) {
+            throw new IllegalArgumentException("Title is required");
+        }
+        String trimmed = title.trim();
+        if (trimmed.length() > MAX_TITLE_LENGTH) {
+            throw new IllegalArgumentException("Title must be " + MAX_TITLE_LENGTH + " characters or fewer");
+        }
+        return trimmed;
+    }
+
+    /**
+     * The public feed envelope: {@code page} and {@code size} echo the values actually served
+     * (post-clamp), never the raw request parameters, so a client computing
+     * {@code ceil(total / size)} cannot be misled into thinking there is only one page.
+     */
+    public record PostFeedPage(List<PublicClubPost> items, int page, int size, int total) {
+    }
+}

--- a/backend/src/main/java/com/example/demo/club/service/ClubPostWriter.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubPostWriter.java
@@ -1,0 +1,46 @@
+package com.example.demo.club.service;
+
+import com.example.demo.club.mapper.ClubPostMapper;
+import com.example.demo.club.model.ClubPost;
+import com.example.demo.club.model.PublicClubPost;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The database half of {@link ClubPostService#publish}: insert the row and immediately read
+ * it back, in one real transaction. Split into its own Spring bean so that transaction is a
+ * genuine proxied call from {@link ClubPostService} -- annotating a same-class private method
+ * with {@code @Transactional} and calling it via {@code this} would bypass Spring's proxy and
+ * silently run without a transaction. Deliberately does not touch {@link ImageStorageService}:
+ * the photo is validated and written by the caller before this runs, so this method never holds
+ * a JDBC connection open during image decode/re-encode/write.
+ */
+@Service
+class ClubPostWriter {
+
+    private final ClubPostMapper clubPostMapper;
+
+    ClubPostWriter(ClubPostMapper clubPostMapper) {
+        this.clubPostMapper = clubPostMapper;
+    }
+
+    // @Transactional so the insert does not auto-commit before the read-back has succeeded:
+    // MyBatis auto-commits each statement on its own connection otherwise, which would leave a
+    // successfully inserted row committed even if the read-back that follows it throws.
+    @Transactional
+    PublicClubPost insertAndReadBack(Long clubId, Long authorOauthUserId, String title, String imageUrl) {
+        ClubPost post = new ClubPost();
+        post.setClubId(clubId);
+        post.setAuthorOauthUserId(authorOauthUserId);
+        post.setTitle(title);
+        post.setImageUrl(imageUrl);
+        clubPostMapper.insert(post);
+
+        PublicClubPost created = clubPostMapper.findPublicPostByIdAndClubId(post.getId(), clubId);
+        if (created == null) {
+            throw new IllegalStateException(
+                "Post " + post.getId() + " was not found immediately after being inserted");
+        }
+        return created;
+    }
+}

--- a/backend/src/main/java/com/example/demo/club/service/ClubService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubService.java
@@ -85,6 +85,19 @@ public class ClubService {
         return club;
     }
 
+    // The one place every controller with a {clubSlugOrId} path variable resolves it: a purely
+    // numeric segment is looked up by id, anything else by slug. Returns null, like findById()
+    // and findBySlug() themselves, when neither lookup finds a club -- callers decide how to
+    // report that (404, permission checks, etc.).
+    public Club resolveBySlugOrId(String clubSlugOrId, String viewerEmail) {
+        try {
+            Long numericId = Long.valueOf(clubSlugOrId);
+            return findById(numericId, viewerEmail);
+        } catch (NumberFormatException e) {
+            return findBySlug(clubSlugOrId, viewerEmail);
+        }
+    }
+
     // ---- Members ----
 
     public List<ClubMemberView> findMembers(Long clubId) {

--- a/backend/src/main/java/com/example/demo/common/PaginationClamps.java
+++ b/backend/src/main/java/com/example/demo/common/PaginationClamps.java
@@ -17,6 +17,13 @@ public final class PaginationClamps {
         return Math.max(1, Math.min(size, MAX_PAGE_SIZE));
     }
 
+    // Mirrors the same "negative page treated as first page" rule clampOffset already applies
+    // internally, so an envelope that echoes the page number back to the caller (see the club
+    // post feed) reports what was actually served rather than a raw, possibly-negative input.
+    public static int clampPage(int page) {
+        return Math.max(0, page);
+    }
+
     // Uses long arithmetic so a huge page number can't wrap around into a negative int offset,
     // and clamps to Integer.MAX_VALUE (the widest legal offset) rather than overflowing.
     public static int clampOffset(int page, int limit) {

--- a/backend/src/main/resources/mapper/ClubPostMapper.xml
+++ b/backend/src/main/resources/mapper/ClubPostMapper.xml
@@ -19,6 +19,12 @@
         id, club_id, author_oauth_user_id, title, image_url, pinned_at, pinned_by_oauth_user_id, created_at
     </sql>
 
+    <!-- Shared by findFeedByClubId, findPublicFeedByClubId, and countFeedByClubId so the count
+         can never disagree with either items query about which rows are "this club's feed". -->
+    <sql id="FeedClause">
+        club_id = #{clubId}
+    </sql>
+
     <!-- The CASE WHEN form is required over "(pinned_at IS NOT NULL) DESC": that expression is
          1/0 in MySQL but BOOLEAN in H2 MODE=MySQL, an engine-dependent difference this repo has
          already been bitten by (see schema.sql's achievements CLOB-vs-JSON comment). The
@@ -28,7 +34,7 @@
     <select id="findFeedByClubId" resultMap="ClubPostResultMap">
         SELECT <include refid="PostColumnList" />
         FROM club_post
-        WHERE club_id = #{clubId}
+        WHERE <include refid="FeedClause" />
         ORDER BY CASE WHEN pinned_at IS NULL THEN 1 ELSE 0 END ASC,
                  pinned_at  DESC,
                  created_at DESC,
@@ -37,7 +43,37 @@
     </select>
 
     <select id="countFeedByClubId" resultType="int">
-        SELECT COUNT(*) FROM club_post WHERE club_id = #{clubId}
+        SELECT COUNT(*) FROM club_post WHERE <include refid="FeedClause" />
+    </select>
+
+    <resultMap id="PublicClubPostResultMap" type="com.example.demo.club.model.PublicClubPost">
+        <id column="id" property="id" />
+        <result column="club_id" property="clubId" />
+        <result column="title" property="title" />
+        <result column="image_url" property="imageUrl" />
+        <result column="pinned_at" property="pinnedAt" />
+        <result column="created_at" property="createdAt" />
+        <result column="author_display_name" property="authorDisplayName" />
+        <result column="author_avatar_url" property="authorAvatarUrl" />
+    </resultMap>
+
+    <!-- Deliberately not a wildcard select and not a reuse of ClubMemberView's/
+         ClubMembershipRequest's result maps (both select ou.email and both sit behind
+         requireManageAccess): this is the first anonymous, unauthenticated endpoint to join
+         oauth_users, so only its display_name/avatar_url columns are selected, aliased so the
+         result map above cannot accidentally widen into any other oauth_users column. -->
+    <select id="findPublicFeedByClubId" resultMap="PublicClubPostResultMap">
+        SELECT cp.id, cp.club_id, cp.title, cp.image_url, cp.pinned_at, cp.created_at,
+               ou.display_name AS author_display_name,
+               ou.avatar_url   AS author_avatar_url
+        FROM club_post cp
+            JOIN oauth_users ou ON ou.uid = cp.author_oauth_user_id
+        WHERE <include refid="FeedClause" />
+        ORDER BY CASE WHEN cp.pinned_at IS NULL THEN 1 ELSE 0 END ASC,
+                 cp.pinned_at  DESC,
+                 cp.created_at DESC,
+                 cp.id         DESC
+        LIMIT #{limit} OFFSET #{offset}
     </select>
 
     <insert id="insert" parameterType="com.example.demo.club.model.ClubPost"

--- a/backend/src/main/resources/mapper/ClubPostMapper.xml
+++ b/backend/src/main/resources/mapper/ClubPostMapper.xml
@@ -57,15 +57,22 @@
         <result column="author_avatar_url" property="authorAvatarUrl" />
     </resultMap>
 
+    <!-- Shared by findPublicFeedByClubId and findPublicPostByIdAndClubId so a freshly published
+         post reads back in exactly the same safe shape a feed item has: never author_oauth_
+         user_id or any other oauth_users column. -->
+    <sql id="PublicPostColumnList">
+        cp.id, cp.club_id, cp.title, cp.image_url, cp.pinned_at, cp.created_at,
+        ou.display_name AS author_display_name,
+        ou.avatar_url   AS author_avatar_url
+    </sql>
+
     <!-- Deliberately not a wildcard select and not a reuse of ClubMemberView's/
          ClubMembershipRequest's result maps (both select ou.email and both sit behind
          requireManageAccess): this is the first anonymous, unauthenticated endpoint to join
          oauth_users, so only its display_name/avatar_url columns are selected, aliased so the
          result map above cannot accidentally widen into any other oauth_users column. -->
     <select id="findPublicFeedByClubId" resultMap="PublicClubPostResultMap">
-        SELECT cp.id, cp.club_id, cp.title, cp.image_url, cp.pinned_at, cp.created_at,
-               ou.display_name AS author_display_name,
-               ou.avatar_url   AS author_avatar_url
+        SELECT <include refid="PublicPostColumnList" />
         FROM club_post cp
             JOIN oauth_users ou ON ou.uid = cp.author_oauth_user_id
         WHERE <include refid="FeedClause" />
@@ -74,6 +81,13 @@
                  cp.created_at DESC,
                  cp.id         DESC
         LIMIT #{limit} OFFSET #{offset}
+    </select>
+
+    <select id="findPublicPostByIdAndClubId" resultMap="PublicClubPostResultMap">
+        SELECT <include refid="PublicPostColumnList" />
+        FROM club_post cp
+            JOIN oauth_users ou ON ou.uid = cp.author_oauth_user_id
+        WHERE cp.id = #{id} AND cp.club_id = #{clubId}
     </select>
 
     <insert id="insert" parameterType="com.example.demo.club.model.ClubPost"

--- a/backend/src/test/java/com/example/demo/auth/config/SecurityConfigCorsTest.java
+++ b/backend/src/test/java/com/example/demo/auth/config/SecurityConfigCorsTest.java
@@ -148,4 +148,32 @@ class SecurityConfigCorsTest {
         assertThat(response.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualTo(FIRST_PARTY_ORIGIN);
         assertThat(response.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS)).isEqualTo("true");
     }
+
+    /**
+     * The club posts feed (#78, GET .../posts) is deliberately reachable without authentication (that's what
+     * makes the public feed public) but is NOT in PUBLIC_READ_ONLY_CORS_PATTERNS: activity photos
+     * and student display names are not the kind of data the wildcard-CORS list exists to let
+     * off-site aggregators script-read. An arbitrary cross-origin caller must fall through to
+     * the authenticated, exact-origin CORS policy instead of the public wildcard one.
+     */
+    @Test
+    void postsFeedGetDoesNotRequireAuthentication() throws Exception {
+        // No Origin header: a same-origin or non-browser request, which is what actually
+        // exercises Spring Security's authorization decision -- a cross-origin Origin header
+        // from a non-permitted origin gets rejected by Spring's CORS handling itself (403)
+        // before authorization is ever considered, which would make this assertion meaningless.
+        MockHttpServletResponse response = mockMvc.perform(get("/api/clubs/1/posts"))
+            .andReturn().getResponse();
+
+        assertThat(response.getStatus()).isNotEqualTo(401);
+    }
+
+    @Test
+    void postsFeedGetIsNotOpenedToArbitraryOrigins() throws Exception {
+        MockHttpServletResponse response = mockMvc.perform(get("/api/clubs/1/posts")
+                .header(HttpHeaders.ORIGIN, ARBITRARY_ORIGIN))
+            .andReturn().getResponse();
+
+        assertThat(response.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN)).isNotEqualTo("*");
+    }
 }

--- a/backend/src/test/java/com/example/demo/club/controller/ClubControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubControllerTest.java
@@ -71,7 +71,7 @@ class ClubControllerTest {
     void deleteClubSucceedsForPlatformOwner() throws Exception {
         Club club = new Club();
         club.setId(1L);
-        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
 
         mockMvc.perform(delete("/api/clubs/1").principal(oauthToken(OWNER_EMAIL)))
             .andExpect(status().isNoContent());
@@ -82,7 +82,7 @@ class ClubControllerTest {
         Club club = new Club();
         club.setId(1L);
         club.setCanManage(false);
-        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
 
         mockMvc.perform(put("/api/clubs/1")
                 .principal(oauthToken(STUDENT_EMAIL))
@@ -97,7 +97,7 @@ class ClubControllerTest {
         club.setId(1L);
         club.setCategory("STEM & Innovation");
         club.setCanManage(true);
-        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
         when(clubService.update(anyLong(), any())).thenReturn(club);
 
         mockMvc.perform(put("/api/clubs/1")

--- a/backend/src/test/java/com/example/demo/club/controller/ClubImageControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubImageControllerTest.java
@@ -74,7 +74,7 @@ class ClubImageControllerTest {
         Club club = new Club();
         club.setId(1L);
         club.setCanManage(false);
-        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
 
         MockMultipartFile file = realPngFile();
 
@@ -89,7 +89,7 @@ class ClubImageControllerTest {
         Club club = new Club();
         club.setId(1L);
         club.setCanManage(false);
-        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
         when(imageStorageService.store(any())).thenReturn("/uploads/club-posts/generated-uuid.jpg");
 
         MockMultipartFile file = realPngFile();
@@ -116,7 +116,7 @@ class ClubImageControllerTest {
         Club club = new Club();
         club.setId(1L);
         club.setCanManage(false);
-        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
         when(imageStorageService.store(any())).thenThrow(new IllegalArgumentException("Unreadable image"));
 
         MockMultipartFile file = realPngFile();
@@ -135,7 +135,7 @@ class ClubImageControllerTest {
         Club club = new Club();
         club.setId(1L);
         club.setCanManage(false);
-        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
         when(imageStorageService.store(any())).thenThrow(new IOException("disk full"));
 
         MockMultipartFile file = realPngFile();

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostControllerTest.java
@@ -83,7 +83,7 @@ class ClubPostControllerTest {
 
     @Test
     void publishReturnsNotFoundForAnUnknownClub() throws Exception {
-        when(clubService.findById(eq(1L), any())).thenReturn(null);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(null);
 
         mockMvc.perform(multipart("/api/clubs/1/posts")
                 .file(aPhoto())
@@ -97,7 +97,7 @@ class ClubPostControllerTest {
         Club club = new Club();
         club.setId(1L);
         club.setViewerIsMember(false);
-        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
 
         mockMvc.perform(multipart("/api/clubs/1/posts")
                 .file(aPhoto())
@@ -111,7 +111,7 @@ class ClubPostControllerTest {
         Club club = new Club();
         club.setId(1L);
         club.setViewerIsMember(true);
-        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
         when(oAuthUserMapper.findIdByEmail(MEMBER_EMAIL)).thenReturn(42L);
         PublicClubPost created = new PublicClubPost();
         created.setId(9L);
@@ -144,7 +144,7 @@ class ClubPostControllerTest {
         Club club = new Club();
         club.setId(1L);
         club.setViewerIsMember(true);
-        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
         when(oAuthUserMapper.findIdByEmail(MEMBER_EMAIL)).thenReturn(42L);
         when(clubPostService.publish(any(), any(), any(), any()))
             .thenThrow(new IllegalArgumentException("Title is required"));
@@ -161,7 +161,7 @@ class ClubPostControllerTest {
         Club club = new Club();
         club.setId(1L);
         club.setViewerIsMember(true);
-        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
 
         mockMvc.perform(multipart("/api/clubs/1/posts")
                 .file(aPhoto())
@@ -174,7 +174,7 @@ class ClubPostControllerTest {
         Club club = new Club();
         club.setId(1L);
         club.setViewerIsMember(true);
-        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
 
         mockMvc.perform(multipart("/api/clubs/1/posts")
                 .param("title", "Meeting recap")
@@ -187,7 +187,7 @@ class ClubPostControllerTest {
         Club club = new Club();
         club.setId(1L);
         club.setViewerIsMember(true);
-        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
         when(oAuthUserMapper.findIdByEmail(MEMBER_EMAIL)).thenReturn(42L);
         when(clubPostService.publish(any(), any(), any(), any())).thenThrow(new IOException("disk full"));
 
@@ -207,7 +207,7 @@ class ClubPostControllerTest {
         Club club = new Club();
         club.setId(1L);
         club.setViewerIsMember(true);
-        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
         when(oAuthUserMapper.findIdByEmail(MEMBER_EMAIL)).thenReturn(42L);
         when(clubPostService.publish(any(), any(), any(), any()))
             .thenThrow(new IllegalStateException("Post 9 was not found immediately after being inserted"));
@@ -224,7 +224,7 @@ class ClubPostControllerTest {
         Club club = new Club();
         club.setId(1L);
         club.setStatus("active");
-        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
         when(clubPostService.findPublicFeed(eq(1L), anyInt(), anyInt()))
             .thenReturn(new ClubPostService.PostFeedPage(List.of(), 0, 12, 0));
 
@@ -238,7 +238,7 @@ class ClubPostControllerTest {
 
     @Test
     void feedReturnsNotFoundForAnUnknownClub() throws Exception {
-        when(clubService.findById(eq(1L), any())).thenReturn(null);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(null);
 
         mockMvc.perform(get("/api/clubs/1/posts"))
             .andExpect(status().isNotFound());
@@ -251,7 +251,7 @@ class ClubPostControllerTest {
         club.setStatus("pending");
         club.setViewerIsMember(false);
         club.setCanManage(false);
-        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
 
         mockMvc.perform(get("/api/clubs/1/posts"))
             .andExpect(status().isNotFound());
@@ -263,7 +263,7 @@ class ClubPostControllerTest {
         club.setId(1L);
         club.setStatus("pending");
         club.setViewerIsMember(true);
-        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
         when(clubPostService.findPublicFeed(eq(1L), anyInt(), anyInt()))
             .thenReturn(new ClubPostService.PostFeedPage(List.of(), 0, 12, 0));
 

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostControllerTest.java
@@ -1,5 +1,6 @@
 package com.example.demo.club.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -12,11 +13,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.example.demo.auth.config.SecurityProperties;
 import com.example.demo.auth.mapper.OAuthUserMapper;
 import com.example.demo.club.model.Club;
-import com.example.demo.club.model.ClubPost;
+import com.example.demo.club.model.PublicClubPost;
 import com.example.demo.club.service.ClubPostService;
 import com.example.demo.club.service.ClubService;
 import com.example.demo.security.AuthenticatedUserResolver;
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -105,28 +107,36 @@ class ClubPostControllerTest {
     }
 
     @Test
-    void publishSucceedsForAMemberAndReturnsTheCreatedPost() throws Exception {
+    void publishSucceedsForAMemberAndReturnsTheCreatedPostInTheSameSafeShapeAsTheFeed() throws Exception {
         Club club = new Club();
         club.setId(1L);
         club.setViewerIsMember(true);
         when(clubService.findById(eq(1L), any())).thenReturn(club);
         when(oAuthUserMapper.findIdByEmail(MEMBER_EMAIL)).thenReturn(42L);
-        ClubPost created = new ClubPost();
+        PublicClubPost created = new PublicClubPost();
         created.setId(9L);
         created.setClubId(1L);
-        created.setAuthorOauthUserId(42L);
         created.setTitle("Meeting recap");
         created.setImageUrl("/uploads/club-posts/uuid.jpg");
+        created.setCreatedAt(LocalDateTime.of(2024, 1, 1, 10, 0));
+        created.setAuthorDisplayName("Ada Lovelace");
+        created.setAuthorAvatarUrl("/uploads/avatar-cache/ada.jpg");
         when(clubPostService.publish(eq(1L), eq(42L), eq("Meeting recap"), any())).thenReturn(created);
 
-        mockMvc.perform(multipart("/api/clubs/1/posts")
+        String responseBody = mockMvc.perform(multipart("/api/clubs/1/posts")
                 .file(aPhoto())
                 .param("title", "Meeting recap")
                 .principal(oauthToken(MEMBER_EMAIL)))
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.id").value(9))
             .andExpect(jsonPath("$.title").value("Meeting recap"))
-            .andExpect(jsonPath("$.imageUrl").value("/uploads/club-posts/uuid.jpg"));
+            .andExpect(jsonPath("$.imageUrl").value("/uploads/club-posts/uuid.jpg"))
+            .andExpect(jsonPath("$.createdAt").exists())
+            .andExpect(jsonPath("$.authorDisplayName").value("Ada Lovelace"))
+            .andExpect(jsonPath("$.authorAvatarUrl").value("/uploads/avatar-cache/ada.jpg"))
+            .andReturn().getResponse().getContentAsString();
+
+        assertThat(responseBody).doesNotContain("authorOauthUserId");
     }
 
     @Test
@@ -180,6 +190,27 @@ class ClubPostControllerTest {
         when(clubService.findById(eq(1L), any())).thenReturn(club);
         when(oAuthUserMapper.findIdByEmail(MEMBER_EMAIL)).thenReturn(42L);
         when(clubPostService.publish(any(), any(), any(), any())).thenThrow(new IOException("disk full"));
+
+        mockMvc.perform(multipart("/api/clubs/1/posts")
+                .file(aPhoto())
+                .param("title", "Meeting recap")
+                .principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isInternalServerError());
+    }
+
+    // ClubPostService#publish throws IllegalStateException when its post-insert read-back
+    // cannot find the row it just inserted (the transaction has already rolled back and the
+    // file has already been cleaned up by then); the controller must still translate that into
+    // a 500, not let it escape as an unhandled exception.
+    @Test
+    void publishReturnsServerErrorWhenTheReadBackCannotFindTheRow() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setViewerIsMember(true);
+        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(oAuthUserMapper.findIdByEmail(MEMBER_EMAIL)).thenReturn(42L);
+        when(clubPostService.publish(any(), any(), any(), any()))
+            .thenThrow(new IllegalStateException("Post 9 was not found immediately after being inserted"));
 
         mockMvc.perform(multipart("/api/clubs/1/posts")
                 .file(aPhoto())

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostControllerTest.java
@@ -1,0 +1,254 @@
+package com.example.demo.club.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.demo.auth.config.SecurityProperties;
+import com.example.demo.auth.mapper.OAuthUserMapper;
+import com.example.demo.club.model.Club;
+import com.example.demo.club.model.ClubPost;
+import com.example.demo.club.service.ClubPostService;
+import com.example.demo.club.service.ClubService;
+import com.example.demo.security.AuthenticatedUserResolver;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.security.oauth2.client.autoconfigure.servlet.OAuth2ClientWebSecurityAutoConfiguration;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    controllers = ClubPostController.class,
+    excludeAutoConfiguration = {
+        OAuth2ClientAutoConfiguration.class,
+        OAuth2ClientWebSecurityAutoConfiguration.class
+    })
+@AutoConfigureMockMvc(addFilters = false)
+class ClubPostControllerTest {
+
+    private static final String MEMBER_EMAIL = "member@example.com";
+    private static final String NON_MEMBER_EMAIL = "outsider@example.com";
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        SecurityProperties securityProperties() {
+            return new SecurityProperties();
+        }
+
+        @Bean
+        AuthenticatedUserResolver authenticatedUserResolver(SecurityProperties securityProperties) {
+            return new AuthenticatedUserResolver(securityProperties);
+        }
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ClubService clubService;
+
+    @MockitoBean
+    private ClubPostService clubPostService;
+
+    @MockitoBean
+    private OAuthUserMapper oAuthUserMapper;
+
+    @Test
+    void publishRequiresAuthentication() throws Exception {
+        mockMvc.perform(multipart("/api/clubs/1/posts")
+                .file(aPhoto())
+                .param("title", "Meeting recap"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void publishReturnsNotFoundForAnUnknownClub() throws Exception {
+        when(clubService.findById(eq(1L), any())).thenReturn(null);
+
+        mockMvc.perform(multipart("/api/clubs/1/posts")
+                .file(aPhoto())
+                .param("title", "Meeting recap")
+                .principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void publishRejectsANonMemberWithForbidden() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setViewerIsMember(false);
+        when(clubService.findById(eq(1L), any())).thenReturn(club);
+
+        mockMvc.perform(multipart("/api/clubs/1/posts")
+                .file(aPhoto())
+                .param("title", "Meeting recap")
+                .principal(oauthToken(NON_MEMBER_EMAIL)))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void publishSucceedsForAMemberAndReturnsTheCreatedPost() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setViewerIsMember(true);
+        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(oAuthUserMapper.findIdByEmail(MEMBER_EMAIL)).thenReturn(42L);
+        ClubPost created = new ClubPost();
+        created.setId(9L);
+        created.setClubId(1L);
+        created.setAuthorOauthUserId(42L);
+        created.setTitle("Meeting recap");
+        created.setImageUrl("/uploads/club-posts/uuid.jpg");
+        when(clubPostService.publish(eq(1L), eq(42L), eq("Meeting recap"), any())).thenReturn(created);
+
+        mockMvc.perform(multipart("/api/clubs/1/posts")
+                .file(aPhoto())
+                .param("title", "Meeting recap")
+                .principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.id").value(9))
+            .andExpect(jsonPath("$.title").value("Meeting recap"))
+            .andExpect(jsonPath("$.imageUrl").value("/uploads/club-posts/uuid.jpg"));
+    }
+
+    @Test
+    void publishReturnsBadRequestWhenTheServiceRejectsTheTitleOrFile() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setViewerIsMember(true);
+        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(oAuthUserMapper.findIdByEmail(MEMBER_EMAIL)).thenReturn(42L);
+        when(clubPostService.publish(any(), any(), any(), any()))
+            .thenThrow(new IllegalArgumentException("Title is required"));
+
+        mockMvc.perform(multipart("/api/clubs/1/posts")
+                .file(aPhoto())
+                .param("title", "   ")
+                .principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void publishReturnsBadRequestWhenTheTitleParameterIsMissingEntirely() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setViewerIsMember(true);
+        when(clubService.findById(eq(1L), any())).thenReturn(club);
+
+        mockMvc.perform(multipart("/api/clubs/1/posts")
+                .file(aPhoto())
+                .principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void publishReturnsBadRequestWhenTheFilePartIsMissingEntirely() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setViewerIsMember(true);
+        when(clubService.findById(eq(1L), any())).thenReturn(club);
+
+        mockMvc.perform(multipart("/api/clubs/1/posts")
+                .param("title", "Meeting recap")
+                .principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void publishReturnsServerErrorWhenStorageFailsWithAnIOException() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setViewerIsMember(true);
+        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(oAuthUserMapper.findIdByEmail(MEMBER_EMAIL)).thenReturn(42L);
+        when(clubPostService.publish(any(), any(), any(), any())).thenThrow(new IOException("disk full"));
+
+        mockMvc.perform(multipart("/api/clubs/1/posts")
+                .file(aPhoto())
+                .param("title", "Meeting recap")
+                .principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    void feedIsReachableByALoggedOutVisitor() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setStatus("active");
+        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(clubPostService.findPublicFeed(eq(1L), anyInt(), anyInt()))
+            .thenReturn(new ClubPostService.PostFeedPage(List.of(), 0, 12, 0));
+
+        mockMvc.perform(get("/api/clubs/1/posts"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.items").isArray())
+            .andExpect(jsonPath("$.page").value(0))
+            .andExpect(jsonPath("$.size").value(12))
+            .andExpect(jsonPath("$.total").value(0));
+    }
+
+    @Test
+    void feedReturnsNotFoundForAnUnknownClub() throws Exception {
+        when(clubService.findById(eq(1L), any())).thenReturn(null);
+
+        mockMvc.perform(get("/api/clubs/1/posts"))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void feedOfANonActiveClubReturnsNotFoundToALoggedOutVisitor() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setStatus("pending");
+        club.setViewerIsMember(false);
+        club.setCanManage(false);
+        when(clubService.findById(eq(1L), any())).thenReturn(club);
+
+        mockMvc.perform(get("/api/clubs/1/posts"))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void feedOfANonActiveClubIsVisibleToAMember() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setStatus("pending");
+        club.setViewerIsMember(true);
+        when(clubService.findById(eq(1L), any())).thenReturn(club);
+        when(clubPostService.findPublicFeed(eq(1L), anyInt(), anyInt()))
+            .thenReturn(new ClubPostService.PostFeedPage(List.of(), 0, 12, 0));
+
+        mockMvc.perform(get("/api/clubs/1/posts").principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isOk());
+    }
+
+    private static MockMultipartFile aPhoto() {
+        return new MockMultipartFile("file", "photo.jpg", "image/jpeg", new byte[] {1, 2, 3});
+    }
+
+    private OAuth2AuthenticationToken oauthToken(String email) {
+        OAuth2User principal = new DefaultOAuth2User(
+            List.of(() -> "ROLE_USER"),
+            Map.of("email", email, "sub", email),
+            "sub");
+        return new OAuth2AuthenticationToken(principal, principal.getAuthorities(), "google");
+    }
+}

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostFeedIntegrationTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostFeedIntegrationTest.java
@@ -3,6 +3,7 @@ package com.example.demo.club.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -11,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.demo.club.mapper.ClubPostMapper;
+import com.example.demo.club.service.ImageStorageService;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
@@ -26,6 +28,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
@@ -52,6 +55,7 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
  * Full-stack acceptance coverage for #78: real DB, real security filter chain, real
@@ -82,6 +86,9 @@ class ClubPostFeedIntegrationTest {
     // database, since this class is proving full-stack behavior.
     @MockitoSpyBean
     private ClubPostMapper clubPostMapperSpy;
+
+    @MockitoSpyBean
+    private ImageStorageService imageStorageServiceSpy;
 
     @DynamicPropertySource
     static void uploadDir(DynamicPropertyRegistry registry) {
@@ -201,6 +208,28 @@ class ClubPostFeedIntegrationTest {
 
         assertThat(countPostRows(clubId)).isEqualTo(rowsBefore);
         assertThat(countRegularFiles(clubPostsDir)).isEqualTo(filesBefore);
+    }
+
+    // The transaction-boundary fix this test guards: ImageStorageService.store() -- the
+    // CPU-bound image decode/re-encode/write -- must run to completion before the DB
+    // transaction that inserts the row and reads it back even starts, so it never holds a JDBC
+    // connection open. Publishing must still succeed; this only asserts where the boundary is.
+    @Test
+    void publishStoresTheImageBeforeAnyDatabaseTransactionIsActive() throws Exception {
+        long clubId = createActiveClubWithAMember();
+        AtomicBoolean transactionActiveDuringStore = new AtomicBoolean(true);
+        doAnswer(invocation -> {
+            transactionActiveDuringStore.set(TransactionSynchronizationManager.isActualTransactionActive());
+            return invocation.callRealMethod();
+        }).when(imageStorageServiceSpy).store(any());
+
+        mockMvc.perform(multipart("/api/clubs/" + clubId + "/posts")
+                .file(new MockMultipartFile("file", "photo.jpg", "image/jpeg", tinyJpeg()))
+                .param("title", "Meeting recap")
+                .with(authentication(oauthToken(MEMBER_EMAIL))))
+            .andExpect(status().isCreated());
+
+        assertThat(transactionActiveDuringStore.get()).isFalse();
     }
 
     private int countPostRows(long clubId) {

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostFeedIntegrationTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostFeedIntegrationTest.java
@@ -1,0 +1,416 @@
+package com.example.demo.club.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+
+import javax.imageio.IIOImage;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Full-stack acceptance coverage for #78: real DB, real security filter chain, real
+ * {@link com.example.demo.club.service.ImageStorageService}. Unit/mapper/service/controller
+ * tests elsewhere cover each layer in isolation; this proves the whole request actually works
+ * end to end for every acceptance criterion that spans layers.
+ */
+@SpringBootTest(properties =
+    "spring.datasource.url=jdbc:h2:mem:club_post_feed_test;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE")
+@AutoConfigureMockMvc
+@Sql(scripts = "classpath:schema.sql")
+class ClubPostFeedIntegrationTest {
+
+    private static final String MEMBER_EMAIL = "member@example.com";
+    private static final String OUTSIDER_EMAIL = "outsider@example.com";
+
+    @TempDir
+    static Path uploadDir;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @DynamicPropertySource
+    static void uploadDir(DynamicPropertyRegistry registry) {
+        registry.add("app.upload.dir", () -> uploadDir.toString());
+    }
+
+    // @Sql's schema.sql only CREATE TABLE IF NOT EXISTS, so it does not reset data between test
+    // methods sharing this class's Spring context; cascade deletes clear club_member/club_post/
+    // membership_requests along with their owning rows.
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update("DELETE FROM clubs");
+        jdbcTemplate.update("DELETE FROM oauth_users");
+    }
+
+    private long createActiveClubWithAMember() {
+        jdbcTemplate.update("MERGE INTO club_category (cate_name) KEY (cate_name) VALUES ('STEM & Innovation')");
+        long clubId = insertClub("Chess Club", "active");
+        long memberUid = insertOauthUser(MEMBER_EMAIL, "Ada Lovelace", "/uploads/avatar-cache/ada.jpg");
+        insertOauthUser(OUTSIDER_EMAIL, "Outsider", null);
+        jdbcTemplate.update(
+            "INSERT INTO club_member (club_id, oauth_user_id, role_name) VALUES (?, ?, 'member')",
+            clubId, memberUid);
+        return clubId;
+    }
+
+    private long insertClub(String name, String status) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO clubs (name, category, status, visibility) VALUES (?, 'STEM & Innovation', ?, 'public')",
+                Statement.RETURN_GENERATED_KEYS);
+            statement.setString(1, name);
+            statement.setString(2, status);
+            return statement;
+        }, keyHolder);
+        return extractId(keyHolder);
+    }
+
+    private long insertOauthUser(String email, String displayName, String avatarUrl) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO oauth_users (provider, provider_user_id, email, display_name, avatar_url) "
+                    + "VALUES ('google', ?, ?, ?, ?)",
+                Statement.RETURN_GENERATED_KEYS);
+            statement.setString(1, email);
+            statement.setString(2, email);
+            statement.setString(3, displayName);
+            statement.setString(4, avatarUrl);
+            return statement;
+        }, keyHolder);
+        return extractId(keyHolder, "uid");
+    }
+
+    @Test
+    void memberCanPublishAndTheStoredFileIsShrunkBelowFourHundredKilobytesWithNoExif() throws Exception {
+        long clubId = createActiveClubWithAMember();
+        byte[] fourMegabyteJpeg = fourMegabyteJpegWithExif();
+
+        String responseBody = mockMvc.perform(multipart("/api/clubs/" + clubId + "/posts")
+                .file(new MockMultipartFile("file", "photo.jpg", "image/jpeg", fourMegabyteJpeg))
+                .param("title", "Meeting recap")
+                .with(authentication(oauthToken(MEMBER_EMAIL))))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.title").value("Meeting recap"))
+            .andReturn().getResponse().getContentAsString();
+
+        String imageUrl = extractJsonStringField(responseBody, "imageUrl");
+        Path storedFile = uploadDir.resolve(imageUrl.substring("/uploads/".length()));
+        assertThat(Files.exists(storedFile)).isTrue();
+        byte[] storedBytes = Files.readAllBytes(storedFile);
+        assertThat(storedBytes.length).isLessThan(400 * 1024);
+        assertThat(containsApp1ExifMarker(storedBytes)).isFalse();
+    }
+
+    @Test
+    void nonMemberCannotPublish() throws Exception {
+        long clubId = createActiveClubWithAMember();
+
+        mockMvc.perform(multipart("/api/clubs/" + clubId + "/posts")
+                .file(new MockMultipartFile("file", "photo.jpg", "image/jpeg", tinyJpeg()))
+                .param("title", "Meeting recap")
+                .with(authentication(oauthToken(OUTSIDER_EMAIL))))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void unauthenticatedCallerCannotPublish() throws Exception {
+        long clubId = createActiveClubWithAMember();
+
+        mockMvc.perform(multipart("/api/clubs/" + clubId + "/posts")
+                .file(new MockMultipartFile("file", "photo.jpg", "image/jpeg", tinyJpeg()))
+                .param("title", "Meeting recap"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void loggedOutVisitorCanReadTheFeed() throws Exception {
+        long clubId = createActiveClubWithAMember();
+        insertPost(clubId, "Post 1", null);
+
+        mockMvc.perform(get("/api/clubs/" + clubId + "/posts"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.items", Matchers.hasSize(1)))
+            .andExpect(jsonPath("$.items[0].authorDisplayName").value("Ada Lovelace"))
+            .andExpect(jsonPath("$.items[0].authorAvatarUrl").value("/uploads/avatar-cache/ada.jpg"));
+    }
+
+    @Test
+    void pinnedPostsSortToTheFrontExactlyOnce() throws Exception {
+        long clubId = createActiveClubWithAMember();
+        long firstId = insertPost(clubId, "First", "2024-01-01 10:00:00");
+        long secondId = insertPost(clubId, "Second", "2024-01-02 10:00:00");
+        long thirdId = insertPost(clubId, "Third pinned", "2023-06-01 10:00:00");
+        jdbcTemplate.update("UPDATE club_post SET pinned_at = '2024-06-01 00:00:00' WHERE id = ?", thirdId);
+
+        String responseBody = mockMvc.perform(get("/api/clubs/" + clubId + "/posts"))
+            .andExpect(status().isOk())
+            .andReturn().getResponse().getContentAsString();
+
+        List<String> ids = extractJsonArrayField(responseBody, "id");
+        assertThat(ids).containsExactly(String.valueOf(thirdId), String.valueOf(secondId), String.valueOf(firstId));
+        assertThat(ids).doesNotHaveDuplicates();
+    }
+
+    @Test
+    void feedOfANonActiveClubReturnsNotFoundToANonMemberAndOkToAMember() throws Exception {
+        jdbcTemplate.update("MERGE INTO club_category (cate_name) KEY (cate_name) VALUES ('STEM & Innovation')");
+        long clubId = insertClub("Pending Club", "pending");
+        long memberUid = insertOauthUser(MEMBER_EMAIL, "Ada Lovelace", null);
+        insertOauthUser(OUTSIDER_EMAIL, "Outsider", null);
+        jdbcTemplate.update(
+            "INSERT INTO club_member (club_id, oauth_user_id, role_name) VALUES (?, ?, 'member')",
+            clubId, memberUid);
+
+        mockMvc.perform(get("/api/clubs/" + clubId + "/posts"))
+            .andExpect(status().isNotFound());
+
+        mockMvc.perform(get("/api/clubs/" + clubId + "/posts")
+                .with(authentication(oauthToken(OUTSIDER_EMAIL))))
+            .andExpect(status().isNotFound());
+
+        mockMvc.perform(get("/api/clubs/" + clubId + "/posts")
+                .with(authentication(oauthToken(MEMBER_EMAIL))))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void requestingSizeOneThousandEchoesOneHundred() throws Exception {
+        long clubId = createActiveClubWithAMember();
+        insertPost(clubId, "Post 1", null);
+
+        mockMvc.perform(get("/api/clubs/" + clubId + "/posts").param("size", "1000"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.size").value(100));
+    }
+
+    @Test
+    void totalMatchesTheNumberOfPostsForTheClub() throws Exception {
+        long clubId = createActiveClubWithAMember();
+        insertPost(clubId, "Post 1", null);
+        insertPost(clubId, "Post 2", null);
+        insertPost(clubId, "Post 3", null);
+
+        mockMvc.perform(get("/api/clubs/" + clubId + "/posts"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.total").value(3))
+            .andExpect(jsonPath("$.items", Matchers.hasSize(3)));
+    }
+
+    @Test
+    void publicFeedResponseContainsNoEmailKeyOrAtSubstring() throws Exception {
+        long clubId = createActiveClubWithAMember();
+        insertPost(clubId, "Post 1", null);
+
+        String responseBody = mockMvc.perform(get("/api/clubs/" + clubId + "/posts"))
+            .andExpect(status().isOk())
+            .andReturn().getResponse().getContentAsString();
+
+        assertThat(responseBody).doesNotContain("\"email\"");
+        assertThat(responseBody).doesNotContain("@");
+    }
+
+    private long insertPost(long clubId, String title, String createdAt) {
+        long authorUid = jdbcTemplate.queryForObject(
+            "SELECT oauth_user_id FROM club_member WHERE club_id = ? LIMIT 1", Long.class, clubId);
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        if (createdAt == null) {
+            jdbcTemplate.update(connection -> {
+                PreparedStatement statement = connection.prepareStatement(
+                    "INSERT INTO club_post (club_id, author_oauth_user_id, title, image_url) "
+                        + "VALUES (?, ?, ?, '/uploads/club-posts/seed.jpg')",
+                    Statement.RETURN_GENERATED_KEYS);
+                statement.setLong(1, clubId);
+                statement.setLong(2, authorUid);
+                statement.setString(3, title);
+                return statement;
+            }, keyHolder);
+            return extractId(keyHolder);
+        }
+        jdbcTemplate.update(connection -> {
+            PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO club_post (club_id, author_oauth_user_id, title, image_url, created_at) "
+                    + "VALUES (?, ?, ?, '/uploads/club-posts/seed.jpg', ?)",
+                Statement.RETURN_GENERATED_KEYS);
+            statement.setLong(1, clubId);
+            statement.setLong(2, authorUid);
+            statement.setString(3, title);
+            statement.setTimestamp(4, Timestamp.valueOf(createdAt));
+            return statement;
+        }, keyHolder);
+        return extractId(keyHolder);
+    }
+
+    // H2 reports every column with a default (id, created_at, updated_at) as "generated" here,
+    // so getKey() (which requires exactly one) throws; look the id column up by name instead,
+    // tolerating either case since drivers differ on how they report generated column names.
+    private static long extractId(KeyHolder keyHolder) {
+        return extractId(keyHolder, "id");
+    }
+
+    private static long extractId(KeyHolder keyHolder, String columnName) {
+        Map<String, Object> keys = keyHolder.getKeys();
+        Object idValue = keys.containsKey(columnName) ? keys.get(columnName) : keys.get(columnName.toUpperCase(Locale.ROOT));
+        return ((Number) idValue).longValue();
+    }
+
+    private static String extractJsonStringField(String json, String field) {
+        String needle = "\"" + field + "\":\"";
+        int start = json.indexOf(needle) + needle.length();
+        int end = json.indexOf('"', start);
+        return json.substring(start, end);
+    }
+
+    private static List<String> extractJsonArrayField(String json, String field) {
+        List<String> values = new ArrayList<>();
+        String needle = "\"" + field + "\":";
+        int index = 0;
+        while (true) {
+            int at = json.indexOf(needle, index);
+            if (at < 0) {
+                break;
+            }
+            int start = at + needle.length();
+            int end = start;
+            while (end < json.length() && Character.isDigit(json.charAt(end))) {
+                end++;
+            }
+            values.add(json.substring(start, end));
+            index = end;
+        }
+        return values;
+    }
+
+    private static boolean containsApp1ExifMarker(byte[] bytes) {
+        for (int i = 0; i < bytes.length - 1; i++) {
+            if ((bytes[i] & 0xFF) == 0xFF && (bytes[i + 1] & 0xFF) == 0xE1) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static byte[] tinyJpeg() throws Exception {
+        BufferedImage image = new BufferedImage(4, 4, BufferedImage.TYPE_INT_RGB);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ImageIO.write(image, "jpg", out);
+        return out.toByteArray();
+    }
+
+    // A large (~4MB), fine-grained-but-not-uniformly-random JPEG: real camera photos are large
+    // because of sensor-level detail across a big canvas, which mostly averages away once
+    // Thumbnailator downscales to 1600x1600 -- unlike pure per-pixel noise, which doesn't
+    // compress any better after resampling and would fail the "under 400KB" expectation.
+    // Embeds a minimal Exif APP1 segment so "carries no EXIF" is a meaningful assertion rather
+    // than trivially true for any input.
+    private static byte[] fourMegabyteJpegWithExif() throws Exception {
+        int size = 4000;
+        BufferedImage image = new BufferedImage(size, size, BufferedImage.TYPE_INT_RGB);
+        Random random = new Random(3);
+        int[] row = new int[size];
+        for (int y = 0; y < size; y++) {
+            for (int x = 0; x < size; x++) {
+                int base = 120 + (int) (20 * Math.sin(x / 50.0) + 20 * Math.cos(y / 70.0));
+                int noise = random.nextInt(30) - 15;
+                int v = Math.max(0, Math.min(255, base + noise));
+                row[x] = (v << 16) | (v << 8) | v;
+            }
+            image.setRGB(0, y, size, 1, row, 0, size);
+        }
+
+        ImageWriter writer = ImageIO.getImageWritersByFormatName("jpg").next();
+        try {
+            ImageWriteParam param = writer.getDefaultWriteParam();
+            param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+            param.setCompressionQuality(0.85f);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            try (ImageOutputStream ios = ImageIO.createImageOutputStream(out)) {
+                writer.setOutput(ios);
+                writer.write(null, new IIOImage(image, null, null), param);
+            }
+            byte[] plain = out.toByteArray();
+            byte[] app1 = buildMinimalExifApp1Segment();
+            ByteArrayOutputStream combined = new ByteArrayOutputStream();
+            combined.write(plain, 0, 2);
+            combined.write(app1);
+            combined.write(plain, 2, plain.length - 2);
+            return combined.toByteArray();
+        } finally {
+            writer.dispose();
+        }
+    }
+
+    private static byte[] buildMinimalExifApp1Segment() {
+        // TIFF header + an empty IFD0 (0 entries) -- enough for the sniff/header-read/full-decode
+        // pipeline to see a real Exif segment without needing a specific tag for this test.
+        ByteBuffer tiff = ByteBuffer.allocate(10).order(ByteOrder.LITTLE_ENDIAN);
+        tiff.put((byte) 'I').put((byte) 'I');
+        tiff.putShort((short) 42);
+        tiff.putInt(8);
+        tiff.putShort((short) 0); // 0 IFD0 entries
+
+        byte[] exifHeader = {'E', 'x', 'i', 'f', 0, 0};
+        byte[] tiffBytes = tiff.array();
+        int payloadLength = exifHeader.length + tiffBytes.length;
+        int segmentLength = 2 + payloadLength;
+
+        ByteBuffer buffer = ByteBuffer.allocate(2 + 2 + payloadLength).order(ByteOrder.BIG_ENDIAN);
+        buffer.put((byte) 0xFF).put((byte) 0xE1);
+        buffer.putShort((short) segmentLength);
+        buffer.put(exifHeader);
+        buffer.put(tiffBytes);
+        return buffer.array();
+    }
+
+    private OAuth2AuthenticationToken oauthToken(String email) {
+        OAuth2User principal = new DefaultOAuth2User(
+            List.of(() -> "ROLE_USER"),
+            Map.of("email", email, "sub", email),
+            "sub");
+        return new OAuth2AuthenticationToken(principal, principal.getAuthorities(), "google");
+    }
+}

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostFeedIntegrationTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostFeedIntegrationTest.java
@@ -1,11 +1,16 @@
 package com.example.demo.club.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.demo.club.mapper.ClubPostMapper;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
@@ -45,6 +50,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 /**
@@ -70,6 +76,12 @@ class ClubPostFeedIntegrationTest {
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
+
+    // A spy, not a mock: every test except the one that explicitly stubs
+    // findPublicPostByIdAndClubId must keep going through the real mapper against the real H2
+    // database, since this class is proving full-stack behavior.
+    @MockitoSpyBean
+    private ClubPostMapper clubPostMapperSpy;
 
     @DynamicPropertySource
     static void uploadDir(DynamicPropertyRegistry registry) {
@@ -144,6 +156,65 @@ class ClubPostFeedIntegrationTest {
         byte[] storedBytes = Files.readAllBytes(storedFile);
         assertThat(storedBytes.length).isLessThan(400 * 1024);
         assertThat(containsApp1ExifMarker(storedBytes)).isFalse();
+    }
+
+    // The POST response must carry the same safe shape a GET feed item does: real DB-generated
+    // createdAt, the author's display name/avatar, and never the internal author_oauth_user_id
+    // -- not a bare echo of what the client sent.
+    @Test
+    void publishReturnsTheSameSafeShapeAndNonNullCreatedAtAsAFeedItem() throws Exception {
+        long clubId = createActiveClubWithAMember();
+
+        String responseBody = mockMvc.perform(multipart("/api/clubs/" + clubId + "/posts")
+                .file(new MockMultipartFile("file", "photo.jpg", "image/jpeg", tinyJpeg()))
+                .param("title", "Meeting recap")
+                .with(authentication(oauthToken(MEMBER_EMAIL))))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.title").value("Meeting recap"))
+            .andExpect(jsonPath("$.createdAt").exists())
+            .andExpect(jsonPath("$.authorDisplayName").value("Ada Lovelace"))
+            .andExpect(jsonPath("$.authorAvatarUrl").value("/uploads/avatar-cache/ada.jpg"))
+            .andReturn().getResponse().getContentAsString();
+
+        assertThat(responseBody).doesNotContain("authorOauthUserId");
+        assertThat(responseBody).doesNotContain("\"email\"");
+        assertThat(responseBody).doesNotContain("@example.com");
+    }
+
+    // Forces the read-back ClubPostService#publish performs immediately after insert() to fail
+    // (as if the row somehow could not be found), proving the whole publish is atomic: no row
+    // left committed in club_post, and no file left behind under club-posts/.
+    @Test
+    void publishLeavesNoOrphanedRowOrFileWhenTheReadBackFails() throws Exception {
+        long clubId = createActiveClubWithAMember();
+        Path clubPostsDir = uploadDir.resolve("club-posts");
+        long filesBefore = countRegularFiles(clubPostsDir);
+        int rowsBefore = countPostRows(clubId);
+
+        doReturn(null).when(clubPostMapperSpy).findPublicPostByIdAndClubId(any(), eq(clubId));
+
+        mockMvc.perform(multipart("/api/clubs/" + clubId + "/posts")
+                .file(new MockMultipartFile("file", "photo.jpg", "image/jpeg", tinyJpeg()))
+                .param("title", "Meeting recap")
+                .with(authentication(oauthToken(MEMBER_EMAIL))))
+            .andExpect(status().is5xxServerError());
+
+        assertThat(countPostRows(clubId)).isEqualTo(rowsBefore);
+        assertThat(countRegularFiles(clubPostsDir)).isEqualTo(filesBefore);
+    }
+
+    private int countPostRows(long clubId) {
+        return jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM club_post WHERE club_id = ?", Integer.class, clubId);
+    }
+
+    private static long countRegularFiles(Path directory) throws Exception {
+        if (!Files.isDirectory(directory)) {
+            return 0L;
+        }
+        try (var entries = Files.list(directory)) {
+            return entries.filter(Files::isRegularFile).count();
+        }
     }
 
     @Test

--- a/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
+++ b/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.example.demo.club.model.ClubPost;
 import com.example.demo.club.model.ClubPostComment;
+import com.example.demo.club.model.PublicClubPost;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,7 +34,10 @@ class ClubPostMapperTest {
             CREATE TABLE oauth_users (
                 uid BIGINT PRIMARY KEY AUTO_INCREMENT,
                 provider VARCHAR(50) NOT NULL,
-                provider_user_id VARCHAR(150) NOT NULL
+                provider_user_id VARCHAR(150) NOT NULL,
+                email VARCHAR(200),
+                display_name VARCHAR(200),
+                avatar_url VARCHAR(500)
             )
             """);
         jdbcTemplate.execute("""
@@ -69,7 +73,9 @@ class ClubPostMapperTest {
             )
             """);
 
-        jdbcTemplate.update("INSERT INTO oauth_users (uid, provider, provider_user_id) VALUES (1, 'google', 'g-1')");
+        jdbcTemplate.update(
+            "INSERT INTO oauth_users (uid, provider, provider_user_id, email, display_name, avatar_url) "
+                + "VALUES (1, 'google', 'g-1', 'student1@example.com', 'Ada Lovelace', '/uploads/avatar-cache/ada.jpg')");
         jdbcTemplate.update("INSERT INTO clubs (id, name) VALUES (1, 'Chess Club')");
     }
 
@@ -256,6 +262,53 @@ class ClubPostMapperTest {
 
         assertThat(clubPostMapper.findAllImageUrls())
             .containsExactlyInAnyOrder("/uploads/club-posts/1.jpg", "/uploads/club-posts/2.jpg");
+    }
+
+    @Test
+    void findPublicFeedByClubIdIncludesAuthorDisplayNameAndAvatarUrl() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+
+        List<PublicClubPost> feed = clubPostMapper.findPublicFeedByClubId(1L, 0, 10);
+
+        assertThat(feed).singleElement().satisfies(post -> {
+            assertThat(post.getId()).isEqualTo(1L);
+            assertThat(post.getTitle()).isEqualTo("Post 1");
+            assertThat(post.getImageUrl()).isEqualTo("/uploads/club-posts/1.jpg");
+            assertThat(post.getAuthorDisplayName()).isEqualTo("Ada Lovelace");
+            assertThat(post.getAuthorAvatarUrl()).isEqualTo("/uploads/avatar-cache/ada.jpg");
+        });
+    }
+
+    // Same ordering contract as findFeedByClubId: pinned posts first (by pinned_at DESC), then
+    // created_at DESC, with id DESC as the same-created_at tiebreaker. Exercised here too
+    // because the public projection is a separate SQL statement, not a reuse of the internal one.
+    @Test
+    void findPublicFeedByClubIdSortsPinnedPostsFirstAndExactlyOnce() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        insertPost(2L, 1L, "2023-01-01 10:00:00", "2024-06-01 00:00:00");
+        insertPost(3L, 1L, "2024-01-02 10:00:00", null);
+
+        List<PublicClubPost> feed = clubPostMapper.findPublicFeedByClubId(1L, 0, 10);
+
+        assertThat(feed).extracting(PublicClubPost::getId).containsExactly(2L, 3L, 1L);
+        assertThat(feed).extracting(PublicClubPost::getId).doesNotHaveDuplicates();
+    }
+
+    // countFeedByClubId and findPublicFeedByClubId both include the shared FeedClause SQL
+    // fragment (WHERE club_id = #{clubId}), so this asserts they can never disagree on which
+    // rows are "this club's feed" -- exactly the property the issue calls out.
+    @Test
+    void countFeedByClubIdMatchesThePublicFeedSizeWhenUnpaginated() {
+        jdbcTemplate.update("INSERT INTO clubs (id, name) VALUES (2, 'Robotics')");
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        insertPost(2L, 1L, "2024-01-02 10:00:00", null);
+        insertPost(3L, 2L, "2024-01-03 10:00:00", null);
+
+        int count = clubPostMapper.countFeedByClubId(1L);
+        List<PublicClubPost> feed = clubPostMapper.findPublicFeedByClubId(1L, 0, 100);
+
+        assertThat(count).isEqualTo(2);
+        assertThat(feed).hasSize(count);
     }
 
     private void insertPost(long id, long clubId, String createdAt, String pinnedAt) {

--- a/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
+++ b/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
@@ -311,6 +311,37 @@ class ClubPostMapperTest {
         assertThat(feed).hasSize(count);
     }
 
+    // The read-back ClubPostService#publish uses to return the same safe shape a feed item
+    // has: author display name/avatar, no author_oauth_user_id -- sharing PublicPostColumnList
+    // with findPublicFeedByClubId so the two can never present a different shape for the same
+    // post.
+    @Test
+    void findPublicPostByIdAndClubIdReturnsTheSameSafeShapeAsTheFeed() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+
+        PublicClubPost post = clubPostMapper.findPublicPostByIdAndClubId(1L, 1L);
+
+        assertThat(post).isNotNull();
+        assertThat(post.getId()).isEqualTo(1L);
+        assertThat(post.getTitle()).isEqualTo("Post 1");
+        assertThat(post.getImageUrl()).isEqualTo("/uploads/club-posts/1.jpg");
+        assertThat(post.getCreatedAt()).isNotNull();
+        assertThat(post.getAuthorDisplayName()).isEqualTo("Ada Lovelace");
+        assertThat(post.getAuthorAvatarUrl()).isEqualTo("/uploads/avatar-cache/ada.jpg");
+    }
+
+    // Scoped to the club: a post ID that exists but under a different club must not read back,
+    // the same guard the mapper already applies everywhere else a post is looked up by ID.
+    @Test
+    void findPublicPostByIdAndClubIdReturnsNullForAMismatchedClubId() {
+        jdbcTemplate.update("INSERT INTO clubs (id, name) VALUES (2, 'Robotics')");
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+
+        PublicClubPost post = clubPostMapper.findPublicPostByIdAndClubId(1L, 2L);
+
+        assertThat(post).isNull();
+    }
+
     private void insertPost(long id, long clubId, String createdAt, String pinnedAt) {
         jdbcTemplate.update(
             "INSERT INTO club_post (id, club_id, author_oauth_user_id, title, image_url, created_at, pinned_at) "

--- a/backend/src/test/java/com/example/demo/club/model/PublicClubPostTest.java
+++ b/backend/src/test/java/com/example/demo/club/model/PublicClubPostTest.java
@@ -1,0 +1,41 @@
+package com.example.demo.club.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression guard for the DTO's own contract, independent of the mapper: nothing on this class
+ * should ever be named after an oauth_users column that could identify or contact the author
+ * (email, uid, provider, provider_user_id, role, accepted_terms_at, the user's created_at/
+ * last_login_at, or graduation_year). A field or getter named after one of those would leak it
+ * to anonymous callers the moment someone wired it up in ClubPostMapper.xml, without this test
+ * failing any differently than adding a normal field.
+ */
+class PublicClubPostTest {
+
+    private static final String[] FORBIDDEN_SUBSTRINGS = {
+        "email", "uid", "provider", "role", "acceptedterms", "graduationyear", "lastlogin"
+    };
+
+    @Test
+    void hasNoFieldOrAccessorNamedAfterAForbiddenOauthUserColumn() {
+        Stream.concat(
+                Stream.of(PublicClubPost.class.getDeclaredFields()).map(Field::getName),
+                Stream.of(PublicClubPost.class.getDeclaredMethods()).map(Method::getName))
+            .forEach(name -> {
+                String normalized = name.toLowerCase(Locale.ROOT).replace("_", "");
+                for (String forbidden : FORBIDDEN_SUBSTRINGS) {
+                    assertThat(normalized)
+                        .withFailMessage("PublicClubPost member '%s' looks like it exposes the "
+                            + "forbidden oauth_users column pattern '%s'", name, forbidden)
+                        .doesNotContain(forbidden);
+                }
+            });
+    }
+}

--- a/backend/src/test/java/com/example/demo/club/service/ClubPostServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubPostServiceTest.java
@@ -5,20 +5,19 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.example.demo.club.mapper.ClubPostMapper;
-import com.example.demo.club.model.ClubPost;
 import com.example.demo.club.model.PublicClubPost;
 import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -26,20 +25,15 @@ class ClubPostServiceTest {
 
     private ClubPostMapper clubPostMapper;
     private ImageStorageService imageStorageService;
+    private ClubPostWriter clubPostWriter;
     private ClubPostService clubPostService;
 
     @BeforeEach
     void setUp() {
         clubPostMapper = mock(ClubPostMapper.class);
         imageStorageService = mock(ImageStorageService.class);
-        clubPostService = new ClubPostService(clubPostMapper, imageStorageService);
-        // Mirrors MyBatis's useGeneratedKeys behavior: insert() sets the generated id onto the
-        // same ClubPost instance it was given, which publish()'s read-back then looks up by.
-        doAnswer(invocation -> {
-            ClubPost post = invocation.getArgument(0);
-            post.setId(99L);
-            return 1;
-        }).when(clubPostMapper).insert(any());
+        clubPostWriter = mock(ClubPostWriter.class);
+        clubPostService = new ClubPostService(clubPostMapper, imageStorageService, clubPostWriter);
     }
 
     private static MultipartFile aFile() {
@@ -72,7 +66,8 @@ class ClubPostServiceTest {
         when(imageStorageService.store(any())).thenReturn("/uploads/club-posts/uuid.jpg");
         PublicClubPost readBack = new PublicClubPost();
         readBack.setTitle(exactlyMax);
-        when(clubPostMapper.findPublicPostByIdAndClubId(99L, 1L)).thenReturn(readBack);
+        when(clubPostWriter.insertAndReadBack(1L, 10L, exactlyMax, "/uploads/club-posts/uuid.jpg"))
+            .thenReturn(readBack);
 
         PublicClubPost post = clubPostService.publish(1L, 10L, exactlyMax, aFile());
 
@@ -99,43 +94,39 @@ class ClubPostServiceTest {
         PublicClubPost readBack = new PublicClubPost();
         readBack.setTitle("Meeting recap");
         readBack.setImageUrl("/uploads/club-posts/uuid.jpg");
-        when(clubPostMapper.findPublicPostByIdAndClubId(99L, 1L)).thenReturn(readBack);
+        when(clubPostWriter.insertAndReadBack(1L, 10L, "Meeting recap", "/uploads/club-posts/uuid.jpg"))
+            .thenReturn(readBack);
 
         PublicClubPost post = clubPostService.publish(1L, 10L, "  Meeting recap  ", aFile());
 
         assertThat(post.getTitle()).isEqualTo("Meeting recap");
         assertThat(post.getImageUrl()).isEqualTo("/uploads/club-posts/uuid.jpg");
-
-        ArgumentCaptor<ClubPost> insertedPost = ArgumentCaptor.forClass(ClubPost.class);
-        verify(clubPostMapper).insert(insertedPost.capture());
-        assertThat(insertedPost.getValue().getClubId()).isEqualTo(1L);
-        assertThat(insertedPost.getValue().getAuthorOauthUserId()).isEqualTo(10L);
-        assertThat(insertedPost.getValue().getTitle()).isEqualTo("Meeting recap");
+        verify(clubPostWriter).insertAndReadBack(1L, 10L, "Meeting recap", "/uploads/club-posts/uuid.jpg");
     }
 
-    // The atomic-request contract: if the row insert fails after the file was already written,
+    // The atomic-request contract: if the DB write fails after the file was already written,
     // the file must not become an orphan (nor should it be silently kept if the post never
     // actually got created).
     @Test
-    void publishDeletesTheStoredFileWhenTheRowInsertFails() throws IOException {
+    void publishDeletesTheStoredFileWhenTheDatabaseWriteFails() throws IOException {
         when(imageStorageService.store(any())).thenReturn("/uploads/club-posts/uuid.jpg");
-        RuntimeException insertFailure = new RuntimeException("constraint violation");
-        org.mockito.Mockito.doThrow(insertFailure).when(clubPostMapper).insert(any());
+        RuntimeException writeFailure = new RuntimeException("constraint violation");
+        when(clubPostWriter.insertAndReadBack(any(), any(), any(), any())).thenThrow(writeFailure);
 
         assertThatThrownBy(() -> clubPostService.publish(1L, 10L, "Meeting recap", aFile()))
-            .isSameAs(insertFailure);
+            .isSameAs(writeFailure);
 
         verify(imageStorageService).delete("/uploads/club-posts/uuid.jpg");
     }
 
-    // The read-back is what actually returns the safe, feed-shaped post; if it can't find the
-    // row it just inserted (should not happen in practice, since both run in the same
-    // transaction, but this is the last line of defense), the whole publish must fail rather
-    // than return null or a half-populated object, and the file must not be left orphaned.
+    // ClubPostWriter is the last line of defense against an unreadable just-inserted row (see
+    // ClubPostWriterTest); this proves publish() reacts to that failure the same way it reacts
+    // to any other database failure -- by cleaning up the file it already wrote.
     @Test
-    void publishDeletesTheStoredFileWhenTheReadBackFindsNoRow() throws IOException {
+    void publishDeletesTheStoredFileWhenClubPostWriterReportsAnUnreadableRow() throws IOException {
         when(imageStorageService.store(any())).thenReturn("/uploads/club-posts/uuid.jpg");
-        when(clubPostMapper.findPublicPostByIdAndClubId(99L, 1L)).thenReturn(null);
+        when(clubPostWriter.insertAndReadBack(any(), any(), any(), any()))
+            .thenThrow(new IllegalStateException("Post 99 was not found immediately after being inserted"));
 
         assertThatThrownBy(() -> clubPostService.publish(1L, 10L, "Meeting recap", aFile()))
             .isInstanceOf(IllegalStateException.class);
@@ -150,7 +141,7 @@ class ClubPostServiceTest {
         readBack.setId(99L);
         readBack.setAuthorDisplayName("Ada Lovelace");
         readBack.setAuthorAvatarUrl("/uploads/avatar-cache/ada.jpg");
-        when(clubPostMapper.findPublicPostByIdAndClubId(99L, 1L)).thenReturn(readBack);
+        when(clubPostWriter.insertAndReadBack(any(), any(), any(), any())).thenReturn(readBack);
 
         PublicClubPost post = clubPostService.publish(1L, 10L, "Meeting recap", aFile());
 
@@ -158,13 +149,29 @@ class ClubPostServiceTest {
     }
 
     @Test
-    void publishNeverInsertsARowWhenImageStorageServiceRejectsTheFile() throws IOException {
+    void publishNeverWritesToTheDatabaseWhenImageStorageServiceRejectsTheFile() throws IOException {
         when(imageStorageService.store(any())).thenThrow(new IllegalArgumentException("Unsupported image type"));
 
         assertThatThrownBy(() -> clubPostService.publish(1L, 10L, "Meeting recap", aFile()))
             .isInstanceOf(IllegalArgumentException.class);
 
-        verify(clubPostMapper, never()).insert(any());
+        verify(clubPostWriter, never()).insertAndReadBack(any(), any(), any(), any());
+    }
+
+    // The transaction-boundary regression this refactor exists for: ClubPostWriter must never
+    // be invoked until ImageStorageService.store() has already completed, since store() is the
+    // CPU-bound image decode/re-encode/write that must not run inside ClubPostWriter's DB
+    // transaction (see ClubPostWriter's Javadoc).
+    @Test
+    void publishStoresTheImageBeforeWritingToTheDatabase() throws IOException {
+        when(imageStorageService.store(any())).thenReturn("/uploads/club-posts/uuid.jpg");
+        when(clubPostWriter.insertAndReadBack(any(), any(), any(), any())).thenReturn(new PublicClubPost());
+
+        clubPostService.publish(1L, 10L, "Meeting recap", aFile());
+
+        InOrder inOrder = inOrder(imageStorageService, clubPostWriter);
+        inOrder.verify(imageStorageService).store(any());
+        inOrder.verify(clubPostWriter).insertAndReadBack(any(), any(), any(), any());
     }
 
     @Test

--- a/backend/src/test/java/com/example/demo/club/service/ClubPostServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubPostServiceTest.java
@@ -1,0 +1,167 @@
+package com.example.demo.club.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.demo.club.mapper.ClubPostMapper;
+import com.example.demo.club.model.ClubPost;
+import com.example.demo.club.model.PublicClubPost;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+class ClubPostServiceTest {
+
+    private ClubPostMapper clubPostMapper;
+    private ImageStorageService imageStorageService;
+    private ClubPostService clubPostService;
+
+    @BeforeEach
+    void setUp() {
+        clubPostMapper = mock(ClubPostMapper.class);
+        imageStorageService = mock(ImageStorageService.class);
+        clubPostService = new ClubPostService(clubPostMapper, imageStorageService);
+    }
+
+    private static MultipartFile aFile() {
+        return new MockMultipartFile("file", "photo.jpg", "image/jpeg", new byte[] {1, 2, 3});
+    }
+
+    @Test
+    void publishRejectsANullTitle() {
+        assertThatThrownBy(() -> clubPostService.publish(1L, 10L, null, aFile()))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void publishRejectsATitleThatIsBlankAfterTrimming() {
+        assertThatThrownBy(() -> clubPostService.publish(1L, 10L, "   ", aFile()))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void publishRejectsATitleOverOneHundredFortyCharacters() {
+        String tooLong = "x".repeat(141);
+
+        assertThatThrownBy(() -> clubPostService.publish(1L, 10L, tooLong, aFile()))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void publishAcceptsATitleOfExactlyOneHundredFortyCharacters() throws IOException {
+        String exactlyMax = "x".repeat(140);
+        when(imageStorageService.store(any())).thenReturn("/uploads/club-posts/uuid.jpg");
+
+        ClubPost post = clubPostService.publish(1L, 10L, exactlyMax, aFile());
+
+        assertThat(post.getTitle()).isEqualTo(exactlyMax);
+    }
+
+    @Test
+    void publishRejectsAMissingFile() {
+        assertThatThrownBy(() -> clubPostService.publish(1L, 10L, "Meeting recap", null))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void publishRejectsAnEmptyFile() {
+        MultipartFile empty = new MockMultipartFile("file", "photo.jpg", "image/jpeg", new byte[0]);
+
+        assertThatThrownBy(() -> clubPostService.publish(1L, 10L, "Meeting recap", empty))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void publishTrimsTheTitleAndDelegatesTheFileEntirelyToImageStorageService() throws IOException {
+        when(imageStorageService.store(any())).thenReturn("/uploads/club-posts/uuid.jpg");
+
+        ClubPost post = clubPostService.publish(1L, 10L, "  Meeting recap  ", aFile());
+
+        assertThat(post.getTitle()).isEqualTo("Meeting recap");
+        assertThat(post.getImageUrl()).isEqualTo("/uploads/club-posts/uuid.jpg");
+        assertThat(post.getClubId()).isEqualTo(1L);
+        assertThat(post.getAuthorOauthUserId()).isEqualTo(10L);
+        verify(clubPostMapper).insert(post);
+    }
+
+    // The atomic-request contract: if the row insert fails after the file was already written,
+    // the file must not become an orphan (nor should it be silently kept if the post never
+    // actually got created).
+    @Test
+    void publishDeletesTheStoredFileWhenTheRowInsertFails() throws IOException {
+        when(imageStorageService.store(any())).thenReturn("/uploads/club-posts/uuid.jpg");
+        RuntimeException insertFailure = new RuntimeException("constraint violation");
+        org.mockito.Mockito.doThrow(insertFailure).when(clubPostMapper).insert(any());
+
+        assertThatThrownBy(() -> clubPostService.publish(1L, 10L, "Meeting recap", aFile()))
+            .isSameAs(insertFailure);
+
+        verify(imageStorageService).delete("/uploads/club-posts/uuid.jpg");
+    }
+
+    @Test
+    void publishNeverInsertsARowWhenImageStorageServiceRejectsTheFile() throws IOException {
+        when(imageStorageService.store(any())).thenThrow(new IllegalArgumentException("Unsupported image type"));
+
+        assertThatThrownBy(() -> clubPostService.publish(1L, 10L, "Meeting recap", aFile()))
+            .isInstanceOf(IllegalArgumentException.class);
+
+        verify(clubPostMapper, never()).insert(any());
+    }
+
+    @Test
+    void findPublicFeedPassesTheClampedOffsetAndLimitToTheMapper() {
+        when(clubPostMapper.findPublicFeedByClubId(eq(1L), anyInt(), anyInt())).thenReturn(List.of());
+        when(clubPostMapper.countFeedByClubId(1L)).thenReturn(0);
+
+        clubPostService.findPublicFeed(1L, 2, 10);
+
+        verify(clubPostMapper).findPublicFeedByClubId(1L, 20, 10);
+    }
+
+    @Test
+    void findPublicFeedEchoesTheClampedSizeNotTheRequestedOne() {
+        when(clubPostMapper.findPublicFeedByClubId(eq(1L), anyInt(), anyInt())).thenReturn(List.of());
+        when(clubPostMapper.countFeedByClubId(1L)).thenReturn(0);
+
+        ClubPostService.PostFeedPage feedPage = clubPostService.findPublicFeed(1L, 0, 1000);
+
+        assertThat(feedPage.size()).isEqualTo(100);
+        verify(clubPostMapper).findPublicFeedByClubId(1L, 0, 100);
+    }
+
+    @Test
+    void findPublicFeedEchoesTheClampedPageForANegativeRequestedPage() {
+        when(clubPostMapper.findPublicFeedByClubId(eq(1L), anyInt(), anyInt())).thenReturn(List.of());
+        when(clubPostMapper.countFeedByClubId(1L)).thenReturn(0);
+
+        ClubPostService.PostFeedPage feedPage = clubPostService.findPublicFeed(1L, -5, 10);
+
+        assertThat(feedPage.page()).isEqualTo(0);
+    }
+
+    @Test
+    void findPublicFeedReportsTotalFromTheSharedCountQuery() {
+        PublicClubPost item = new PublicClubPost();
+        when(clubPostMapper.findPublicFeedByClubId(eq(1L), anyInt(), anyInt())).thenReturn(List.of(item));
+        when(clubPostMapper.countFeedByClubId(1L)).thenReturn(57);
+
+        ClubPostService.PostFeedPage feedPage = clubPostService.findPublicFeed(1L, 0, 12);
+
+        assertThat(feedPage.items()).containsExactly(item);
+        assertThat(feedPage.total()).isEqualTo(57);
+        assertThat(feedPage.page()).isEqualTo(0);
+        assertThat(feedPage.size()).isEqualTo(12);
+    }
+}

--- a/backend/src/test/java/com/example/demo/club/service/ClubPostServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubPostServiceTest.java
@@ -5,9 +5,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -32,6 +33,13 @@ class ClubPostServiceTest {
         clubPostMapper = mock(ClubPostMapper.class);
         imageStorageService = mock(ImageStorageService.class);
         clubPostService = new ClubPostService(clubPostMapper, imageStorageService);
+        // Mirrors MyBatis's useGeneratedKeys behavior: insert() sets the generated id onto the
+        // same ClubPost instance it was given, which publish()'s read-back then looks up by.
+        doAnswer(invocation -> {
+            ClubPost post = invocation.getArgument(0);
+            post.setId(99L);
+            return 1;
+        }).when(clubPostMapper).insert(any());
     }
 
     private static MultipartFile aFile() {
@@ -62,8 +70,11 @@ class ClubPostServiceTest {
     void publishAcceptsATitleOfExactlyOneHundredFortyCharacters() throws IOException {
         String exactlyMax = "x".repeat(140);
         when(imageStorageService.store(any())).thenReturn("/uploads/club-posts/uuid.jpg");
+        PublicClubPost readBack = new PublicClubPost();
+        readBack.setTitle(exactlyMax);
+        when(clubPostMapper.findPublicPostByIdAndClubId(99L, 1L)).thenReturn(readBack);
 
-        ClubPost post = clubPostService.publish(1L, 10L, exactlyMax, aFile());
+        PublicClubPost post = clubPostService.publish(1L, 10L, exactlyMax, aFile());
 
         assertThat(post.getTitle()).isEqualTo(exactlyMax);
     }
@@ -85,14 +96,21 @@ class ClubPostServiceTest {
     @Test
     void publishTrimsTheTitleAndDelegatesTheFileEntirelyToImageStorageService() throws IOException {
         when(imageStorageService.store(any())).thenReturn("/uploads/club-posts/uuid.jpg");
+        PublicClubPost readBack = new PublicClubPost();
+        readBack.setTitle("Meeting recap");
+        readBack.setImageUrl("/uploads/club-posts/uuid.jpg");
+        when(clubPostMapper.findPublicPostByIdAndClubId(99L, 1L)).thenReturn(readBack);
 
-        ClubPost post = clubPostService.publish(1L, 10L, "  Meeting recap  ", aFile());
+        PublicClubPost post = clubPostService.publish(1L, 10L, "  Meeting recap  ", aFile());
 
         assertThat(post.getTitle()).isEqualTo("Meeting recap");
         assertThat(post.getImageUrl()).isEqualTo("/uploads/club-posts/uuid.jpg");
-        assertThat(post.getClubId()).isEqualTo(1L);
-        assertThat(post.getAuthorOauthUserId()).isEqualTo(10L);
-        verify(clubPostMapper).insert(post);
+
+        ArgumentCaptor<ClubPost> insertedPost = ArgumentCaptor.forClass(ClubPost.class);
+        verify(clubPostMapper).insert(insertedPost.capture());
+        assertThat(insertedPost.getValue().getClubId()).isEqualTo(1L);
+        assertThat(insertedPost.getValue().getAuthorOauthUserId()).isEqualTo(10L);
+        assertThat(insertedPost.getValue().getTitle()).isEqualTo("Meeting recap");
     }
 
     // The atomic-request contract: if the row insert fails after the file was already written,
@@ -108,6 +126,35 @@ class ClubPostServiceTest {
             .isSameAs(insertFailure);
 
         verify(imageStorageService).delete("/uploads/club-posts/uuid.jpg");
+    }
+
+    // The read-back is what actually returns the safe, feed-shaped post; if it can't find the
+    // row it just inserted (should not happen in practice, since both run in the same
+    // transaction, but this is the last line of defense), the whole publish must fail rather
+    // than return null or a half-populated object, and the file must not be left orphaned.
+    @Test
+    void publishDeletesTheStoredFileWhenTheReadBackFindsNoRow() throws IOException {
+        when(imageStorageService.store(any())).thenReturn("/uploads/club-posts/uuid.jpg");
+        when(clubPostMapper.findPublicPostByIdAndClubId(99L, 1L)).thenReturn(null);
+
+        assertThatThrownBy(() -> clubPostService.publish(1L, 10L, "Meeting recap", aFile()))
+            .isInstanceOf(IllegalStateException.class);
+
+        verify(imageStorageService).delete("/uploads/club-posts/uuid.jpg");
+    }
+
+    @Test
+    void publishReturnsExactlyWhatTheReadBackProduces() throws IOException {
+        when(imageStorageService.store(any())).thenReturn("/uploads/club-posts/uuid.jpg");
+        PublicClubPost readBack = new PublicClubPost();
+        readBack.setId(99L);
+        readBack.setAuthorDisplayName("Ada Lovelace");
+        readBack.setAuthorAvatarUrl("/uploads/avatar-cache/ada.jpg");
+        when(clubPostMapper.findPublicPostByIdAndClubId(99L, 1L)).thenReturn(readBack);
+
+        PublicClubPost post = clubPostService.publish(1L, 10L, "Meeting recap", aFile());
+
+        assertThat(post).isSameAs(readBack);
     }
 
     @Test

--- a/backend/src/test/java/com/example/demo/club/service/ClubPostWriterTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubPostWriterTest.java
@@ -1,0 +1,77 @@
+package com.example.demo.club.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.demo.club.mapper.ClubPostMapper;
+import com.example.demo.club.model.ClubPost;
+import com.example.demo.club.model.PublicClubPost;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ClubPostWriterTest {
+
+    private ClubPostMapper clubPostMapper;
+    private ClubPostWriter clubPostWriter;
+
+    @BeforeEach
+    void setUp() {
+        clubPostMapper = mock(ClubPostMapper.class);
+        clubPostWriter = new ClubPostWriter(clubPostMapper);
+        // Mirrors MyBatis's useGeneratedKeys behavior: insert() sets the generated id onto the
+        // same ClubPost instance it was given, which the read-back then looks up by.
+        doAnswer(invocation -> {
+            ClubPost post = invocation.getArgument(0);
+            post.setId(99L);
+            return 1;
+        }).when(clubPostMapper).insert(any());
+    }
+
+    @Test
+    void insertAndReadBackInsertsExactlyWhatItWasGiven() {
+        PublicClubPost readBack = new PublicClubPost();
+        readBack.setTitle("Meeting recap");
+        when(clubPostMapper.findPublicPostByIdAndClubId(99L, 1L)).thenReturn(readBack);
+
+        clubPostWriter.insertAndReadBack(1L, 10L, "Meeting recap", "/uploads/club-posts/uuid.jpg");
+
+        ArgumentCaptor<ClubPost> insertedPost = ArgumentCaptor.forClass(ClubPost.class);
+        verify(clubPostMapper).insert(insertedPost.capture());
+        assertThat(insertedPost.getValue().getClubId()).isEqualTo(1L);
+        assertThat(insertedPost.getValue().getAuthorOauthUserId()).isEqualTo(10L);
+        assertThat(insertedPost.getValue().getTitle()).isEqualTo("Meeting recap");
+        assertThat(insertedPost.getValue().getImageUrl()).isEqualTo("/uploads/club-posts/uuid.jpg");
+    }
+
+    @Test
+    void insertAndReadBackReturnsExactlyWhatTheReadBackProduces() {
+        PublicClubPost readBack = new PublicClubPost();
+        readBack.setId(99L);
+        readBack.setAuthorDisplayName("Ada Lovelace");
+        when(clubPostMapper.findPublicPostByIdAndClubId(99L, 1L)).thenReturn(readBack);
+
+        PublicClubPost result =
+            clubPostWriter.insertAndReadBack(1L, 10L, "Meeting recap", "/uploads/club-posts/uuid.jpg");
+
+        assertThat(result).isSameAs(readBack);
+    }
+
+    // The last line of defense: this should not happen in practice, since both the insert and
+    // the read-back run in the same transaction, but if the read-back cannot find the row it
+    // just inserted, the whole operation must fail rather than return null or a half-populated
+    // object.
+    @Test
+    void insertAndReadBackThrowsWhenTheReadBackFindsNoRow() {
+        when(clubPostMapper.findPublicPostByIdAndClubId(99L, 1L)).thenReturn(null);
+
+        assertThatThrownBy(() ->
+            clubPostWriter.insertAndReadBack(1L, 10L, "Meeting recap", "/uploads/club-posts/uuid.jpg"))
+            .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/backend/src/test/java/com/example/demo/club/service/ClubServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.demo.club.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -10,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import com.example.demo.auth.mapper.OAuthUserMapper;
 import com.example.demo.club.mapper.ClubMapper;
+import com.example.demo.club.model.Club;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -74,5 +76,40 @@ class ClubServiceTest {
 
         verify(clubMapper).updateImageUrl(1L, "/uploads/club-posts/new-uuid.jpg");
         verify(clubMapper, never()).update(any());
+    }
+
+    // The shared slug-or-id resolver every controller that takes a {clubSlugOrId} path
+    // variable delegates to: a purely numeric path segment is looked up by id, anything else
+    // by slug -- never both, so a numeric slug (were one ever created) cannot be reached this
+    // way, which matches every one of these controllers' pre-existing behavior.
+    @Test
+    void resolveBySlugOrIdLooksUpByIdWhenTheSegmentIsNumeric() {
+        Club club = new Club();
+        club.setId(42L);
+        when(clubMapper.findById(42L)).thenReturn(club);
+
+        Club resolved = clubService.resolveBySlugOrId("42", "viewer@example.com");
+
+        assertThat(resolved).isSameAs(club);
+        verify(clubMapper, never()).findBySlug(any());
+    }
+
+    @Test
+    void resolveBySlugOrIdLooksUpBySlugWhenTheSegmentIsNotNumeric() {
+        Club club = new Club();
+        club.setId(42L);
+        when(clubMapper.findBySlug("chess-club")).thenReturn(club);
+
+        Club resolved = clubService.resolveBySlugOrId("chess-club", "viewer@example.com");
+
+        assertThat(resolved).isSameAs(club);
+        verify(clubMapper, never()).findById(any());
+    }
+
+    @Test
+    void resolveBySlugOrIdReturnsNullWhenNeitherLookupFindsTheClub() {
+        Club resolved = clubService.resolveBySlugOrId("does-not-exist", "viewer@example.com");
+
+        assertThat(resolved).isNull();
     }
 }

--- a/backend/src/test/java/com/example/demo/common/PaginationClampsTest.java
+++ b/backend/src/test/java/com/example/demo/common/PaginationClampsTest.java
@@ -36,4 +36,14 @@ class PaginationClampsTest {
     void clampOffsetNeverOverflowsForHugePageNumbers() {
         assertThat(PaginationClamps.clampOffset(Integer.MAX_VALUE, 100)).isEqualTo(Integer.MAX_VALUE);
     }
+
+    @Test
+    void clampPageTreatsNegativePageAsZero() {
+        assertThat(PaginationClamps.clampPage(-5)).isEqualTo(0);
+    }
+
+    @Test
+    void clampPagePassesThroughNonNegativeValues() {
+        assertThat(PaginationClamps.clampPage(3)).isEqualTo(3);
+    }
 }


### PR DESCRIPTION
## Summary

- Add atomic member-only multipart publishing with safe image cleanup and a PII-free public post response.
- Add a public paginated club feed with clamped envelope values, pinned ordering, and active-club visibility rules.
- Keep image processing outside database transactions and consolidate slug-or-ID club resolution.
- Permit anonymous feed reads without opening student activity data to wildcard cross-origin access.

## Verification

- `./mvnw -o clean test` (212 tests passed)
- Targeted controller, service, transaction-boundary, security, mapper, and integration tests passed
- Three independent review rounds completed; final verdict: patch is correct

Closes bangxiao0927/HSclubs#78

---
Generated by Codet
