### PR TITLE
Club media: pin up to three posts

### DIFF
--- a/backend/src/main/java/com/example/demo/club/controller/ClubPostController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubPostController.java
@@ -7,10 +7,13 @@ import com.example.demo.club.service.ClubPostService;
 import com.example.demo.club.service.ClubService;
 import com.example.demo.security.AuthenticatedUserResolver;
 import org.springframework.http.HttpStatus;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -98,5 +101,60 @@ public class ClubPostController {
         }
 
         return clubPostService.findPublicFeed(club.getId(), page, size);
+    }
+
+    // ---- Pinning (president or platform owner only) ----
+
+    @PutMapping("/{clubSlugOrId}/posts/{postId}/pin")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void pin(@PathVariable String clubSlugOrId,
+                     @PathVariable Long postId,
+                     Authentication authentication) {
+        Club club = requireManageAccess(clubSlugOrId, authentication);
+        String viewerEmail = authenticatedUserResolver.requireEmail(authentication);
+        Long pinnedByOauthUserId = oAuthUserMapper.findIdByEmail(viewerEmail);
+        try {
+            clubPostService.pin(club.getId(), postId, pinnedByOauthUserId);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        } catch (IllegalStateException e) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
+        } catch (PessimisticLockingFailureException e) {
+            // H2's ~2s lock timeout (SQL error 50200) and InnoDB's 50s one both translate here
+            // via Spring's SQLErrorCodeSQLExceptionTranslator -- a lock held by a concurrent
+            // pin() call must read as "try again", not as a server error.
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Could not pin post right now, please try again");
+        }
+    }
+
+    @DeleteMapping("/{clubSlugOrId}/posts/{postId}/pin")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void unpin(@PathVariable String clubSlugOrId,
+                       @PathVariable Long postId,
+                       Authentication authentication) {
+        Club club = requireManageAccess(clubSlugOrId, authentication);
+        try {
+            clubPostService.unpin(club.getId(), postId);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
+    // Same matrix as ClubController/ClubImageController's requireManageAccess: the club's own
+    // president, or a platform owner. Pinning is an editorial power, not a publishing one, so an
+    // ordinary member (even the post's own author) is not enough.
+    private Club requireManageAccess(String clubSlugOrId, Authentication authentication) {
+        String viewerEmail = authenticatedUserResolver.requireEmail(authentication);
+        Club club = clubService.resolveBySlugOrId(clubSlugOrId, viewerEmail);
+        if (club == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
+        }
+        boolean canManage = Boolean.TRUE.equals(club.getCanManage())
+            || authenticatedUserResolver.isPlatformOwner(authentication);
+        if (!canManage) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                "Only the club president or a platform owner can pin posts");
+        }
+        return club;
     }
 }

--- a/backend/src/main/java/com/example/demo/club/mapper/ClubMapper.java
+++ b/backend/src/main/java/com/example/demo/club/mapper/ClubMapper.java
@@ -95,4 +95,9 @@ public interface ClubMapper {
 
     ViewerMembershipStatus findMembershipStatusByUserId(@Param("clubId") Long clubId,
                                                          @Param("oauthUserId") Long oauthUserId);
+
+    // Pessimistic row lock for the pin cap (see ClubPostService#pin): a FOR UPDATE matching
+    // zero rows takes no lock at all, so callers must treat a null result as "club not found"
+    // rather than falling through to an unguarded write.
+    Long lockClubIdForUpdate(@Param("id") Long id);
 }

--- a/backend/src/main/java/com/example/demo/club/mapper/ClubPostMapper.java
+++ b/backend/src/main/java/com/example/demo/club/mapper/ClubPostMapper.java
@@ -30,6 +30,11 @@ public interface ClubPostMapper {
     // by-ID lookup in this codebase.
     PublicClubPost findPublicPostByIdAndClubId(@Param("id") Long id, @Param("clubId") Long clubId);
 
+    // Scoped lookup for the pin/unpin path (ClubPostService#pin/#unpin): a post ID that exists
+    // but under a different club must read back null, exactly like every other by-ID lookup in
+    // this mapper, so cross-club pinning 404s instead of silently touching someone else's post.
+    ClubPost findByIdAndClubId(@Param("id") Long id, @Param("clubId") Long clubId);
+
     int insert(ClubPost post);
 
     int delete(@Param("id") Long id);

--- a/backend/src/main/java/com/example/demo/club/service/ClubPostService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubPostService.java
@@ -1,9 +1,12 @@
 package com.example.demo.club.service;
 
+import com.example.demo.club.mapper.ClubMapper;
 import com.example.demo.club.mapper.ClubPostMapper;
+import com.example.demo.club.model.ClubPost;
 import com.example.demo.club.model.PublicClubPost;
 import com.example.demo.common.PaginationClamps;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -24,14 +27,17 @@ import java.util.List;
 public class ClubPostService {
 
     private static final int MAX_TITLE_LENGTH = 140;
+    private static final int MAX_PINNED_POSTS_PER_CLUB = 3;
 
     private final ClubPostMapper clubPostMapper;
+    private final ClubMapper clubMapper;
     private final ImageStorageService imageStorageService;
     private final ClubPostWriter clubPostWriter;
 
-    public ClubPostService(ClubPostMapper clubPostMapper, ImageStorageService imageStorageService,
-                            ClubPostWriter clubPostWriter) {
+    public ClubPostService(ClubPostMapper clubPostMapper, ClubMapper clubMapper,
+                            ImageStorageService imageStorageService, ClubPostWriter clubPostWriter) {
         this.clubPostMapper = clubPostMapper;
+        this.clubMapper = clubMapper;
         this.imageStorageService = imageStorageService;
         this.clubPostWriter = clubPostWriter;
     }
@@ -63,6 +69,40 @@ public class ClubPostService {
         int total = clubPostMapper.countFeedByClubId(clubId);
 
         return new PostFeedPage(items, clampedPage, limit, total);
+    }
+
+    // The cap is not safe as a plain count-then-update: at REPEATABLE READ, SELECT COUNT(*) is
+    // a non-locking consistent read, so two presidents pinning at once could each see 2 and
+    // both commit a 3rd pin. Locking the parent club row first serializes every concurrent call
+    // for that club, so the count that follows is always accurate. Lock, count and update all
+    // live in this one @Transactional method -- called only from the controller, so the Spring
+    // proxy is always in play (see ClubPostWriter's Javadoc for why self-invocation would
+    // silently drop this).
+    @Transactional
+    public void pin(Long clubId, Long postId, Long pinnedByOauthUserId) {
+        Long lockedClubId = clubMapper.lockClubIdForUpdate(clubId);
+        if (lockedClubId == null) {
+            throw new IllegalArgumentException("Club not found");
+        }
+        ClubPost post = clubPostMapper.findByIdAndClubId(postId, clubId);
+        if (post == null) {
+            throw new IllegalArgumentException("Post not found for this club");
+        }
+        boolean alreadyPinned = post.getPinnedAt() != null;
+        int pinnedCount = clubPostMapper.countPinnedByClubId(clubId);
+        if (!alreadyPinned && pinnedCount >= MAX_PINNED_POSTS_PER_CLUB) {
+            throw new IllegalStateException(
+                "At most " + MAX_PINNED_POSTS_PER_CLUB + " posts can be pinned. Unpin one first.");
+        }
+        clubPostMapper.pin(postId, pinnedByOauthUserId);
+    }
+
+    public void unpin(Long clubId, Long postId) {
+        ClubPost post = clubPostMapper.findByIdAndClubId(postId, clubId);
+        if (post == null) {
+            throw new IllegalArgumentException("Post not found for this club");
+        }
+        clubPostMapper.unpin(postId);
     }
 
     private static String validateTitle(String title) {

--- a/backend/src/main/resources/mapper/ClubMapper.xml
+++ b/backend/src/main/resources/mapper/ClubMapper.xml
@@ -383,4 +383,12 @@
         LEFT JOIN club_member cm ON cm.club_id = #{clubId} AND cm.oauth_user_id = #{oauthUserId}
     </select>
 
+    <!-- ClubPostService#pin's cap-safety lock: InnoDB at REPEATABLE READ makes a plain
+         SELECT COUNT(*) a non-locking consistent read, so two presidents pinning at once could
+         each see 2 pinned posts and both commit a 3rd, over-running the cap of 3. Locking this
+         row first serializes every concurrent pin() call for the same club. -->
+    <select id="lockClubIdForUpdate" resultType="long">
+        SELECT id FROM clubs WHERE id = #{id} FOR UPDATE
+    </select>
+
 </mapper>

--- a/backend/src/main/resources/mapper/ClubPostMapper.xml
+++ b/backend/src/main/resources/mapper/ClubPostMapper.xml
@@ -90,6 +90,12 @@
         WHERE cp.id = #{id} AND cp.club_id = #{clubId}
     </select>
 
+    <select id="findByIdAndClubId" resultMap="ClubPostResultMap">
+        SELECT <include refid="PostColumnList" />
+        FROM club_post
+        WHERE id = #{id} AND club_id = #{clubId}
+    </select>
+
     <insert id="insert" parameterType="com.example.demo.club.model.ClubPost"
             useGeneratedKeys="true" keyProperty="id" keyColumn="id">
         INSERT INTO club_post (club_id, author_oauth_user_id, title, image_url)

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostControllerTest.java
@@ -5,8 +5,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -29,6 +31,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
@@ -269,6 +272,143 @@ class ClubPostControllerTest {
 
         mockMvc.perform(get("/api/clubs/1/posts").principal(oauthToken(MEMBER_EMAIL)))
             .andExpect(status().isOk());
+    }
+
+    // ---- pin ----
+
+    @Test
+    void pinRequiresAuthentication() throws Exception {
+        mockMvc.perform(put("/api/clubs/1/posts/9/pin"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void pinReturnsNotFoundForAnUnknownClub() throws Exception {
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(null);
+
+        mockMvc.perform(put("/api/clubs/1/posts/9/pin").principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void pinRejectsAnOrdinaryMemberWithForbidden() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setCanManage(false);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+
+        mockMvc.perform(put("/api/clubs/1/posts/9/pin").principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void pinSucceedsForThePresidentAndReturnsNoContent() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setCanManage(true);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(oAuthUserMapper.findIdByEmail(MEMBER_EMAIL)).thenReturn(42L);
+
+        mockMvc.perform(put("/api/clubs/1/posts/9/pin").principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void pinSucceedsForAPlatformOwnerWhoIsNotTheClubPresident() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setCanManage(false);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(oAuthUserMapper.findIdByEmail("test-owner@example.com")).thenReturn(7L);
+
+        mockMvc.perform(put("/api/clubs/1/posts/9/pin").principal(oauthToken("test-owner@example.com")))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void pinReturnsNotFoundWhenTheServiceReportsTheClubOrPostIsMissing() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setCanManage(true);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(oAuthUserMapper.findIdByEmail(MEMBER_EMAIL)).thenReturn(42L);
+        org.mockito.Mockito.doThrow(new IllegalArgumentException("Post not found for this club"))
+            .when(clubPostService).pin(any(), any(), any());
+
+        mockMvc.perform(put("/api/clubs/1/posts/9/pin").principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void pinReturnsConflictWhenTheServiceReportsTheCapIsReached() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setCanManage(true);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(oAuthUserMapper.findIdByEmail(MEMBER_EMAIL)).thenReturn(42L);
+        org.mockito.Mockito.doThrow(new IllegalStateException("At most 3 posts can be pinned. Unpin one first."))
+            .when(clubPostService).pin(any(), any(), any());
+
+        mockMvc.perform(put("/api/clubs/1/posts/9/pin").principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isConflict())
+            .andExpect(status().reason("At most 3 posts can be pinned. Unpin one first."));
+    }
+
+    @Test
+    void pinReturnsConflictWhenTheServiceReportsALockTimeout() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setCanManage(true);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(oAuthUserMapper.findIdByEmail(MEMBER_EMAIL)).thenReturn(42L);
+        org.mockito.Mockito.doThrow(new CannotAcquireLockException("lock wait timeout"))
+            .when(clubPostService).pin(any(), any(), any());
+
+        mockMvc.perform(put("/api/clubs/1/posts/9/pin").principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isConflict());
+    }
+
+    // ---- unpin ----
+
+    @Test
+    void unpinRequiresAuthentication() throws Exception {
+        mockMvc.perform(delete("/api/clubs/1/posts/9/pin"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void unpinRejectsAnOrdinaryMemberWithForbidden() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setCanManage(false);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+
+        mockMvc.perform(delete("/api/clubs/1/posts/9/pin").principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void unpinSucceedsForThePresidentAndReturnsNoContent() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setCanManage(true);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+
+        mockMvc.perform(delete("/api/clubs/1/posts/9/pin").principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void unpinReturnsNotFoundWhenTheServiceReportsThePostIsMissing() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setCanManage(true);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        org.mockito.Mockito.doThrow(new IllegalArgumentException("Post not found for this club"))
+            .when(clubPostService).unpin(any(), any());
+
+        mockMvc.perform(delete("/api/clubs/1/posts/9/pin").principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isNotFound());
     }
 
     private static MockMultipartFile aPhoto() {

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostPinIntegrationTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostPinIntegrationTest.java
@@ -1,0 +1,329 @@
+package com.example.demo.club.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Full-stack acceptance coverage for #80: real DB, real security filter chain, the real
+ * {@link com.example.demo.club.service.ClubPostService}. Unit/mapper/service/controller tests
+ * elsewhere cover each layer in isolation; this proves the whole PUT/DELETE .../pin request
+ * works end to end for every acceptance criterion that spans layers.
+ */
+@SpringBootTest(properties =
+    "spring.datasource.url=jdbc:h2:mem:club_post_pin_test;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE")
+@AutoConfigureMockMvc
+@Sql(scripts = "classpath:schema.sql")
+class ClubPostPinIntegrationTest {
+
+    private static final String PRESIDENT_EMAIL = "president@example.com";
+    private static final String MEMBER_EMAIL = "member@example.com";
+    private static final String OWNER_EMAIL = "test-owner@example.com";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    // @Sql's schema.sql only CREATE TABLE IF NOT EXISTS, so it does not reset data between test
+    // methods sharing this class's Spring context; cascade deletes clear club_member/club_post
+    // along with their owning rows.
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update("DELETE FROM clubs");
+        jdbcTemplate.update("DELETE FROM oauth_users");
+    }
+
+    private long createActiveClubWithAPresidentAndAMember() {
+        jdbcTemplate.update("MERGE INTO club_category (cate_name) KEY (cate_name) VALUES ('STEM & Innovation')");
+        long clubId = insertClub("Chess Club", "active");
+        long presidentUid = insertOauthUser(PRESIDENT_EMAIL, "President Ada", null);
+        long memberUid = insertOauthUser(MEMBER_EMAIL, "Member Bob", null);
+        insertOauthUser(OWNER_EMAIL, "Owner", null);
+        jdbcTemplate.update(
+            "INSERT INTO club_member (club_id, oauth_user_id, role_name) VALUES (?, ?, 'president')",
+            clubId, presidentUid);
+        jdbcTemplate.update(
+            "INSERT INTO club_member (club_id, oauth_user_id, role_name) VALUES (?, ?, 'member')",
+            clubId, memberUid);
+        return clubId;
+    }
+
+    @Test
+    void presidentCanPinAndUnpinAPost() throws Exception {
+        long clubId = createActiveClubWithAPresidentAndAMember();
+        long postId = insertPost(clubId, "Post 1");
+
+        mockMvc.perform(put("/api/clubs/" + clubId + "/posts/" + postId + "/pin")
+                .with(authentication(oauthToken(PRESIDENT_EMAIL))))
+            .andExpect(status().isNoContent());
+
+        Boolean pinned = jdbcTemplate.queryForObject(
+            "SELECT pinned_at IS NOT NULL FROM club_post WHERE id = ?", Boolean.class, postId);
+        assertThat(pinned).isTrue();
+
+        mockMvc.perform(delete("/api/clubs/" + clubId + "/posts/" + postId + "/pin")
+                .with(authentication(oauthToken(PRESIDENT_EMAIL))))
+            .andExpect(status().isNoContent());
+
+        Boolean unpinned = jdbcTemplate.queryForObject(
+            "SELECT pinned_at IS NULL FROM club_post WHERE id = ?", Boolean.class, postId);
+        assertThat(unpinned).isTrue();
+    }
+
+    @Test
+    void platformOwnerCanPinEvenWithoutBeingAMember() throws Exception {
+        long clubId = createActiveClubWithAPresidentAndAMember();
+        long postId = insertPost(clubId, "Post 1");
+
+        mockMvc.perform(put("/api/clubs/" + clubId + "/posts/" + postId + "/pin")
+                .with(authentication(oauthToken(OWNER_EMAIL))))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void ordinaryMemberAttemptingToPinGetsForbidden() throws Exception {
+        long clubId = createActiveClubWithAPresidentAndAMember();
+        long postId = insertPost(clubId, "Post 1");
+
+        mockMvc.perform(put("/api/clubs/" + clubId + "/posts/" + postId + "/pin")
+                .with(authentication(oauthToken(MEMBER_EMAIL))))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void pinRecordsPinnedByOauthUserIdAndUnpinClearsIt() throws Exception {
+        long clubId = createActiveClubWithAPresidentAndAMember();
+        long postId = insertPost(clubId, "Post 1");
+        long presidentUid = jdbcTemplate.queryForObject(
+            "SELECT uid FROM oauth_users WHERE email = ?", Long.class, PRESIDENT_EMAIL);
+
+        mockMvc.perform(put("/api/clubs/" + clubId + "/posts/" + postId + "/pin")
+                .with(authentication(oauthToken(PRESIDENT_EMAIL))))
+            .andExpect(status().isNoContent());
+
+        Long pinnedBy = jdbcTemplate.queryForObject(
+            "SELECT pinned_by_oauth_user_id FROM club_post WHERE id = ?", Long.class, postId);
+        assertThat(pinnedBy).isEqualTo(presidentUid);
+
+        mockMvc.perform(delete("/api/clubs/" + clubId + "/posts/" + postId + "/pin")
+                .with(authentication(oauthToken(PRESIDENT_EMAIL))))
+            .andExpect(status().isNoContent());
+
+        Long pinnedByAfterUnpin = jdbcTemplate.queryForObject(
+            "SELECT pinned_by_oauth_user_id FROM club_post WHERE id = ?", Long.class, postId);
+        assertThat(pinnedByAfterUnpin).isNull();
+    }
+
+    // The core rule the whole feature exists to enforce: a fourth pin must fail with a message
+    // naming the limit, and none of the first three pins may be silently evicted to make room.
+    @Test
+    void pinningAFourthPostReturnsConflictAndDoesNotEvictAnyExistingPin() throws Exception {
+        long clubId = createActiveClubWithAPresidentAndAMember();
+        long firstPostId = insertPost(clubId, "Post 1");
+        long secondPostId = insertPost(clubId, "Post 2");
+        long thirdPostId = insertPost(clubId, "Post 3");
+        long fourthPostId = insertPost(clubId, "Post 4");
+
+        mockMvc.perform(put("/api/clubs/" + clubId + "/posts/" + firstPostId + "/pin")
+                .with(authentication(oauthToken(PRESIDENT_EMAIL))))
+            .andExpect(status().isNoContent());
+        mockMvc.perform(put("/api/clubs/" + clubId + "/posts/" + secondPostId + "/pin")
+                .with(authentication(oauthToken(PRESIDENT_EMAIL))))
+            .andExpect(status().isNoContent());
+        mockMvc.perform(put("/api/clubs/" + clubId + "/posts/" + thirdPostId + "/pin")
+                .with(authentication(oauthToken(PRESIDENT_EMAIL))))
+            .andExpect(status().isNoContent());
+
+        mockMvc.perform(put("/api/clubs/" + clubId + "/posts/" + fourthPostId + "/pin")
+                .with(authentication(oauthToken(PRESIDENT_EMAIL))))
+            .andExpect(status().isConflict())
+            .andExpect(status().reason("At most 3 posts can be pinned. Unpin one first."));
+
+        List<Long> stillPinned = jdbcTemplate.queryForList(
+            "SELECT id FROM club_post WHERE club_id = ? AND pinned_at IS NOT NULL ORDER BY id", Long.class, clubId);
+        assertThat(stillPinned).containsExactly(firstPostId, secondPostId, thirdPostId);
+    }
+
+    @Test
+    void pinningAPostBelongingToAnotherClubReturnsNotFound() throws Exception {
+        long clubId = createActiveClubWithAPresidentAndAMember();
+        jdbcTemplate.update("MERGE INTO club_category (cate_name) KEY (cate_name) VALUES ('Culture & Identity')");
+        long otherClubId = insertClub("Robotics", "active");
+        long otherClubPostId = insertPostForClub(otherClubId, "Other club post");
+
+        mockMvc.perform(put("/api/clubs/" + clubId + "/posts/" + otherClubPostId + "/pin")
+                .with(authentication(oauthToken(PRESIDENT_EMAIL))))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void pinningANonExistentPostReturnsNotFound() throws Exception {
+        long clubId = createActiveClubWithAPresidentAndAMember();
+
+        mockMvc.perform(put("/api/clubs/" + clubId + "/posts/999999/pin")
+                .with(authentication(oauthToken(PRESIDENT_EMAIL))))
+            .andExpect(status().isNotFound());
+    }
+
+    // No promotion logic exists anywhere in this feature: removing a pinned post's row must
+    // never cause a different post to become pinned in its place.
+    @Test
+    void deletingAPinnedPostLeavesTheRemainingPinsUntouchedAndPromotesNothing() throws Exception {
+        long clubId = createActiveClubWithAPresidentAndAMember();
+        long firstPostId = insertPost(clubId, "Post 1");
+        long secondPostId = insertPost(clubId, "Post 2");
+        mockMvc.perform(put("/api/clubs/" + clubId + "/posts/" + firstPostId + "/pin")
+                .with(authentication(oauthToken(PRESIDENT_EMAIL))))
+            .andExpect(status().isNoContent());
+
+        jdbcTemplate.update("DELETE FROM club_post WHERE id = ?", firstPostId);
+
+        List<Long> stillPinned = jdbcTemplate.queryForList(
+            "SELECT id FROM club_post WHERE club_id = ? AND pinned_at IS NOT NULL", Long.class, clubId);
+        assertThat(stillPinned).isEmpty();
+        Boolean secondPostStillUnpinned = jdbcTemplate.queryForObject(
+            "SELECT pinned_at IS NULL FROM club_post WHERE id = ?", Boolean.class, secondPostId);
+        assertThat(secondPostStillUnpinned).isTrue();
+    }
+
+    @Test
+    void unpinReturnsThePostToItsChronologicalPositionInTheFeed() throws Exception {
+        long clubId = createActiveClubWithAPresidentAndAMember();
+        long olderPostId = insertPostWithCreatedAt(clubId, "Older", "2024-01-01 10:00:00");
+        long newerPostId = insertPostWithCreatedAt(clubId, "Newer", "2024-01-02 10:00:00");
+        mockMvc.perform(put("/api/clubs/" + clubId + "/posts/" + olderPostId + "/pin")
+                .with(authentication(oauthToken(PRESIDENT_EMAIL))))
+            .andExpect(status().isNoContent());
+
+        mockMvc.perform(delete("/api/clubs/" + clubId + "/posts/" + olderPostId + "/pin")
+                .with(authentication(oauthToken(PRESIDENT_EMAIL))))
+            .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/clubs/" + clubId + "/posts"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.items", Matchers.hasSize(2)))
+            .andExpect(jsonPath("$.items[0].id").value(newerPostId))
+            .andExpect(jsonPath("$.items[1].id").value(olderPostId));
+    }
+
+    private long insertClub(String name, String status) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO clubs (name, category, status, visibility) VALUES (?, 'STEM & Innovation', ?, 'public')",
+                Statement.RETURN_GENERATED_KEYS);
+            statement.setString(1, name);
+            statement.setString(2, status);
+            return statement;
+        }, keyHolder);
+        return extractId(keyHolder);
+    }
+
+    private long insertOauthUser(String email, String displayName, String avatarUrl) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO oauth_users (provider, provider_user_id, email, display_name, avatar_url) "
+                    + "VALUES ('google', ?, ?, ?, ?)",
+                Statement.RETURN_GENERATED_KEYS);
+            statement.setString(1, email);
+            statement.setString(2, email);
+            statement.setString(3, displayName);
+            statement.setString(4, avatarUrl);
+            return statement;
+        }, keyHolder);
+        return extractId(keyHolder, "uid");
+    }
+
+    private long insertPost(long clubId, String title) {
+        long authorUid = jdbcTemplate.queryForObject(
+            "SELECT oauth_user_id FROM club_member WHERE club_id = ? LIMIT 1", Long.class, clubId);
+        return insertPostAsAuthor(clubId, authorUid, title);
+    }
+
+    private long insertPostForClub(long clubId, String title) {
+        long authorUid = insertOauthUser("author-" + clubId + "@example.com", "Author", null);
+        return insertPostAsAuthor(clubId, authorUid, title);
+    }
+
+    private long insertPostAsAuthor(long clubId, long authorUid, String title) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO club_post (club_id, author_oauth_user_id, title, image_url) "
+                    + "VALUES (?, ?, ?, '/uploads/club-posts/seed.jpg')",
+                Statement.RETURN_GENERATED_KEYS);
+            statement.setLong(1, clubId);
+            statement.setLong(2, authorUid);
+            statement.setString(3, title);
+            return statement;
+        }, keyHolder);
+        return extractId(keyHolder);
+    }
+
+    private long insertPostWithCreatedAt(long clubId, String title, String createdAt) {
+        long authorUid = jdbcTemplate.queryForObject(
+            "SELECT oauth_user_id FROM club_member WHERE club_id = ? LIMIT 1", Long.class, clubId);
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO club_post (club_id, author_oauth_user_id, title, image_url, created_at) "
+                    + "VALUES (?, ?, ?, '/uploads/club-posts/seed.jpg', ?)",
+                Statement.RETURN_GENERATED_KEYS);
+            statement.setLong(1, clubId);
+            statement.setLong(2, authorUid);
+            statement.setString(3, title);
+            statement.setTimestamp(4, java.sql.Timestamp.valueOf(createdAt));
+            return statement;
+        }, keyHolder);
+        return extractId(keyHolder);
+    }
+
+    // H2 reports every column with a default (id, created_at, updated_at) as "generated" here,
+    // so getKey() (which requires exactly one) throws; look the id column up by name instead,
+    // tolerating either case since drivers differ on how they report generated column names.
+    private static long extractId(KeyHolder keyHolder) {
+        return extractId(keyHolder, "id");
+    }
+
+    private static long extractId(KeyHolder keyHolder, String columnName) {
+        Map<String, Object> keys = keyHolder.getKeys();
+        Object idValue = keys.containsKey(columnName) ? keys.get(columnName) : keys.get(columnName.toUpperCase(Locale.ROOT));
+        return ((Number) idValue).longValue();
+    }
+
+    private OAuth2AuthenticationToken oauthToken(String email) {
+        OAuth2User principal = new DefaultOAuth2User(
+            List.of(() -> "ROLE_USER"),
+            Map.of("email", email, "sub", email),
+            "sub");
+        return new OAuth2AuthenticationToken(principal, principal.getAuthorities(), "google");
+    }
+}

--- a/backend/src/test/java/com/example/demo/club/mapper/ClubMapperTest.java
+++ b/backend/src/test/java/com/example/demo/club/mapper/ClubMapperTest.java
@@ -87,6 +87,23 @@ class ClubMapperTest {
     }
 
     @Test
+    void lockClubIdForUpdateReturnsTheIdWhenTheClubExists() {
+        jdbcTemplate.update(
+            "INSERT INTO clubs (id, name, category, status) VALUES (1, 'Chess Club', 'Competition & Strategy', 'active')");
+
+        Long lockedId = clubMapper.lockClubIdForUpdate(1L);
+
+        assertThat(lockedId).isEqualTo(1L);
+    }
+
+    @Test
+    void lockClubIdForUpdateReturnsNullForAMissingClub() {
+        Long lockedId = clubMapper.lockClubIdForUpdate(999L);
+
+        assertThat(lockedId).isNull();
+    }
+
+    @Test
     void findAllPaginatedReportsMemberCountFromClubMemberTableNotTheStaleColumn() {
         jdbcTemplate.update(
             "INSERT INTO clubs (id, name, category, member_count, status) VALUES (1, 'Chess Club', 'Competition & Strategy', 0, 'active')");

--- a/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
+++ b/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
@@ -342,6 +342,36 @@ class ClubPostMapperTest {
         assertThat(post).isNull();
     }
 
+    @Test
+    void findByIdAndClubIdReturnsThePostWhenItBelongsToTheClub() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+
+        ClubPost post = clubPostMapper.findByIdAndClubId(1L, 1L);
+
+        assertThat(post).isNotNull();
+        assertThat(post.getId()).isEqualTo(1L);
+        assertThat(post.getClubId()).isEqualTo(1L);
+    }
+
+    // Scoped the same way findPublicPostByIdAndClubId is: cross-club pinning must 404, not
+    // silently touch someone else's post.
+    @Test
+    void findByIdAndClubIdReturnsNullForAMismatchedClubId() {
+        jdbcTemplate.update("INSERT INTO clubs (id, name) VALUES (2, 'Robotics')");
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+
+        ClubPost post = clubPostMapper.findByIdAndClubId(1L, 2L);
+
+        assertThat(post).isNull();
+    }
+
+    @Test
+    void findByIdAndClubIdReturnsNullForANonExistentPost() {
+        ClubPost post = clubPostMapper.findByIdAndClubId(999L, 1L);
+
+        assertThat(post).isNull();
+    }
+
     private void insertPost(long id, long clubId, String createdAt, String pinnedAt) {
         jdbcTemplate.update(
             "INSERT INTO club_post (id, club_id, author_oauth_user_id, title, image_url, created_at, pinned_at) "

--- a/backend/src/test/java/com/example/demo/club/service/ClubPostPinConcurrencyTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubPostPinConcurrencyTest.java
@@ -1,0 +1,202 @@
+package com.example.demo.club.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.example.demo.club.mapper.ClubPostMapper;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.PessimisticLockingFailureException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.test.context.jdbc.Sql;
+
+/**
+ * Proves the cap in {@link ClubPostService#pin} is actually concurrency-safe (#80): a plain
+ * count-then-update is not, since InnoDB (and H2 in MySQL mode) at REPEATABLE READ makes
+ * {@code SELECT COUNT(*)} a non-locking consistent read. A mapper test cannot prove this --
+ * mapper tests run without a surrounding Spring transaction, so a {@code FOR UPDATE} there
+ * would take no lock and pass vacuously. This test runs against a real, autowired (proxied)
+ * {@link ClubPostService} bean and a real H2 database so the actual row lock is exercised.
+ */
+@SpringBootTest(properties =
+    "spring.datasource.url=jdbc:h2:mem:club_post_pin_concurrency_test;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE")
+@Sql(scripts = "classpath:schema.sql")
+class ClubPostPinConcurrencyTest {
+
+    @Autowired
+    private ClubPostService clubPostService;
+
+    @Autowired
+    private ClubPostMapper clubPostMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update("DELETE FROM clubs");
+        jdbcTemplate.update("DELETE FROM oauth_users");
+    }
+
+    // Forces the two pin() calls below to genuinely overlap, rather than merely happening to
+    // race (which would make the test's outcome depend on scheduling luck): a raw JDBC
+    // connection takes the same club-row FOR UPDATE lock first and holds it while both
+    // background threads call the real, autowired (proxied) ClubPostService.pin(), so both are
+    // guaranteed to queue up behind it. Releasing the held lock lets them proceed one at a
+    // time -- whichever commits its pin first makes the count 3 for the other, which must then
+    // see the cap and reject.
+    @Test
+    void pinningTwoDifferentPostsConcurrentlyNeverExceedsTheCapOfThree() throws Exception {
+        long clubId = insertClub("Chess Club");
+        long uid = insertOauthUser("author@example.com");
+        long alreadyPinnedFirst = insertPost(clubId, uid, "Already pinned 1");
+        long alreadyPinnedSecond = insertPost(clubId, uid, "Already pinned 2");
+        long candidateA = insertPost(clubId, uid, "Candidate A");
+        long candidateB = insertPost(clubId, uid, "Candidate B");
+        clubPostMapper.pin(alreadyPinnedFirst, uid);
+        clubPostMapper.pin(alreadyPinnedSecond, uid);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try (Connection rawConnection = dataSource.getConnection()) {
+            rawConnection.setAutoCommit(false);
+            try (PreparedStatement statement =
+                     rawConnection.prepareStatement("SELECT id FROM clubs WHERE id = ? FOR UPDATE")) {
+                statement.setLong(1, clubId);
+                statement.executeQuery();
+            }
+
+            Callable<Exception> pinCandidateA = () -> attemptPin(clubId, candidateA, uid);
+            Callable<Exception> pinCandidateB = () -> attemptPin(clubId, candidateB, uid);
+            Future<Exception> resultA = executor.submit(pinCandidateA);
+            Future<Exception> resultB = executor.submit(pinCandidateB);
+            // Give both background threads time to reach and queue up behind the held lock
+            // before it is released, so releasing it is what actually lets either proceed.
+            Thread.sleep(300);
+
+            rawConnection.commit();
+
+            Exception failureA = resultA.get(5, TimeUnit.SECONDS);
+            Exception failureB = resultB.get(5, TimeUnit.SECONDS);
+
+            List<Exception> failures = Arrays.asList(failureA, failureB).stream()
+                .filter(Objects::nonNull)
+                .toList();
+            assertThat(failures).hasSize(1);
+            assertThat(failures.get(0)).isInstanceOf(IllegalStateException.class);
+            assertThat(failures.get(0).getMessage()).contains("3");
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(clubPostMapper.countPinnedByClubId(clubId)).isEqualTo(3);
+    }
+
+    private Exception attemptPin(long clubId, long postId, long uid) {
+        try {
+            clubPostService.pin(clubId, postId, uid);
+            return null;
+        } catch (Exception e) {
+            return e;
+        }
+    }
+
+    // H2's lock timeout is roughly 2 seconds (SQL error 50200); this asserts a concurrent
+    // FOR UPDATE holder makes pin() surface that as a Spring PessimisticLockingFailureException
+    // (translated by Spring's SQLErrorCodeSQLExceptionTranslator), which the controller maps to
+    // 409 -- not the 500 an unmapped SQLException/PersistenceException would otherwise produce.
+    @Test
+    void pinSurfacesALockTimeoutAsAPessimisticLockingFailure() throws Exception {
+        long clubId = insertClub("Chess Club");
+        long uid = insertOauthUser("author@example.com");
+        long postId = insertPost(clubId, uid, "Post 1");
+
+        try (Connection rawConnection = dataSource.getConnection()) {
+            rawConnection.setAutoCommit(false);
+            try (PreparedStatement statement =
+                     rawConnection.prepareStatement("SELECT id FROM clubs WHERE id = ? FOR UPDATE")) {
+                statement.setLong(1, clubId);
+                statement.executeQuery();
+            }
+
+            assertThatThrownBy(() -> clubPostService.pin(clubId, postId, uid))
+                .isInstanceOf(PessimisticLockingFailureException.class);
+        }
+    }
+
+    private long insertClub(String name) {
+        jdbcTemplate.update("MERGE INTO club_category (cate_name) KEY (cate_name) VALUES ('STEM & Innovation')");
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO clubs (name, category, status, visibility) VALUES (?, 'STEM & Innovation', 'active', 'public')",
+                Statement.RETURN_GENERATED_KEYS);
+            statement.setString(1, name);
+            return statement;
+        }, keyHolder);
+        return extractId(keyHolder);
+    }
+
+    private long insertOauthUser(String email) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO oauth_users (provider, provider_user_id, email, display_name) "
+                    + "VALUES ('google', ?, ?, ?)",
+                Statement.RETURN_GENERATED_KEYS);
+            statement.setString(1, email);
+            statement.setString(2, email);
+            statement.setString(3, "Author");
+            return statement;
+        }, keyHolder);
+        return extractId(keyHolder, "uid");
+    }
+
+    private long insertPost(long clubId, long authorUid, String title) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO club_post (club_id, author_oauth_user_id, title, image_url) "
+                    + "VALUES (?, ?, ?, '/uploads/club-posts/seed.jpg')",
+                Statement.RETURN_GENERATED_KEYS);
+            statement.setLong(1, clubId);
+            statement.setLong(2, authorUid);
+            statement.setString(3, title);
+            return statement;
+        }, keyHolder);
+        return extractId(keyHolder);
+    }
+
+    private static long extractId(KeyHolder keyHolder) {
+        return extractId(keyHolder, "id");
+    }
+
+    private static long extractId(KeyHolder keyHolder, String columnName) {
+        Map<String, Object> keys = keyHolder.getKeys();
+        Object idValue = keys.containsKey(columnName) ? keys.get(columnName) : keys.get(columnName.toUpperCase(Locale.ROOT));
+        return ((Number) idValue).longValue();
+    }
+}

--- a/backend/src/test/java/com/example/demo/club/service/ClubPostServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubPostServiceTest.java
@@ -12,6 +12,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.example.demo.club.mapper.ClubPostMapper;
+import com.example.demo.club.mapper.ClubMapper;
+import com.example.demo.club.model.ClubPost;
 import com.example.demo.club.model.PublicClubPost;
 import java.io.IOException;
 import java.util.List;
@@ -24,6 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 class ClubPostServiceTest {
 
     private ClubPostMapper clubPostMapper;
+    private ClubMapper clubMapper;
     private ImageStorageService imageStorageService;
     private ClubPostWriter clubPostWriter;
     private ClubPostService clubPostService;
@@ -31,9 +34,10 @@ class ClubPostServiceTest {
     @BeforeEach
     void setUp() {
         clubPostMapper = mock(ClubPostMapper.class);
+        clubMapper = mock(ClubMapper.class);
         imageStorageService = mock(ImageStorageService.class);
         clubPostWriter = mock(ClubPostWriter.class);
-        clubPostService = new ClubPostService(clubPostMapper, imageStorageService, clubPostWriter);
+        clubPostService = new ClubPostService(clubPostMapper, clubMapper, imageStorageService, clubPostWriter);
     }
 
     private static MultipartFile aFile() {
@@ -217,5 +221,104 @@ class ClubPostServiceTest {
         assertThat(feedPage.total()).isEqualTo(57);
         assertThat(feedPage.page()).isEqualTo(0);
         assertThat(feedPage.size()).isEqualTo(12);
+    }
+
+    // ---- pin ----
+
+    @Test
+    void pinLocksTheClubRowCountsAndUpdatesInsideOnePinCall() {
+        when(clubMapper.lockClubIdForUpdate(1L)).thenReturn(1L);
+        ClubPost post = new ClubPost();
+        post.setId(10L);
+        post.setClubId(1L);
+        when(clubPostMapper.findByIdAndClubId(10L, 1L)).thenReturn(post);
+        when(clubPostMapper.countPinnedByClubId(1L)).thenReturn(0);
+
+        clubPostService.pin(1L, 10L, 42L);
+
+        InOrder inOrder = inOrder(clubMapper, clubPostMapper);
+        inOrder.verify(clubMapper).lockClubIdForUpdate(1L);
+        inOrder.verify(clubPostMapper).countPinnedByClubId(1L);
+        inOrder.verify(clubPostMapper).pin(10L, 42L);
+    }
+
+    @Test
+    void pinThrowsWhenTheClubDoesNotExist() {
+        when(clubMapper.lockClubIdForUpdate(1L)).thenReturn(null);
+
+        assertThatThrownBy(() -> clubPostService.pin(1L, 10L, 42L))
+            .isInstanceOf(IllegalArgumentException.class);
+
+        verify(clubPostMapper, never()).pin(any(), any());
+    }
+
+    @Test
+    void pinThrowsWhenThePostBelongsToAnotherClub() {
+        when(clubMapper.lockClubIdForUpdate(1L)).thenReturn(1L);
+        when(clubPostMapper.findByIdAndClubId(10L, 1L)).thenReturn(null);
+
+        assertThatThrownBy(() -> clubPostService.pin(1L, 10L, 42L))
+            .isInstanceOf(IllegalArgumentException.class);
+
+        verify(clubPostMapper, never()).pin(any(), any());
+    }
+
+    // The cap the whole feature exists to enforce: a fourth pin must not silently evict the
+    // oldest one, so it is a 409-worthy failure, not a 400.
+    @Test
+    void pinThrowsWhenTheClubAlreadyHasThreePinnedPosts() {
+        when(clubMapper.lockClubIdForUpdate(1L)).thenReturn(1L);
+        ClubPost post = new ClubPost();
+        post.setId(10L);
+        post.setClubId(1L);
+        when(clubPostMapper.findByIdAndClubId(10L, 1L)).thenReturn(post);
+        when(clubPostMapper.countPinnedByClubId(1L)).thenReturn(3);
+
+        assertThatThrownBy(() -> clubPostService.pin(1L, 10L, 42L))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("3");
+
+        verify(clubPostMapper, never()).pin(any(), any());
+    }
+
+    // Re-pinning an already-pinned post (e.g. to bump it to the front again) must not be
+    // blocked by the cap: it is already one of the (at most) three, not a fourth.
+    @Test
+    void pinDoesNotCountAnAlreadyPinnedPostAgainstItsOwnCap() {
+        when(clubMapper.lockClubIdForUpdate(1L)).thenReturn(1L);
+        ClubPost post = new ClubPost();
+        post.setId(10L);
+        post.setClubId(1L);
+        post.setPinnedAt(java.time.LocalDateTime.of(2024, 1, 1, 0, 0));
+        when(clubPostMapper.findByIdAndClubId(10L, 1L)).thenReturn(post);
+        when(clubPostMapper.countPinnedByClubId(1L)).thenReturn(3);
+
+        clubPostService.pin(1L, 10L, 42L);
+
+        verify(clubPostMapper).pin(10L, 42L);
+    }
+
+    // ---- unpin ----
+
+    @Test
+    void unpinClearsThePinOnAnExistingPost() {
+        ClubPost post = new ClubPost();
+        post.setId(10L);
+        post.setClubId(1L);
+        when(clubPostMapper.findByIdAndClubId(10L, 1L)).thenReturn(post);
+
+        clubPostService.unpin(1L, 10L);
+
+        verify(clubPostMapper).unpin(10L);
+    }
+
+    @Test
+    void unpinThrowsWhenThePostBelongsToAnotherClub() {
+        when(clubPostMapper.findByIdAndClubId(10L, 1L)).thenReturn(null);
+
+        assertThatThrownBy(() -> clubPostService.unpin(1L, 10L))
+            .isInstanceOf(IllegalArgumentException.class);
+
+        verify(clubPostMapper, never()).unpin(any());
     }
 }


### PR DESCRIPTION
## Summary

- Add president/platform-owner pin and unpin endpoints with club-scoped 404 behavior.
- Enforce the three-pin cap under a club-row lock without silently evicting posts.
- Record and clear the pinning actor while preserving the existing single-feed ordering.

## Verification

- `./mvnw test` (247 tests passed)
- Real H2 concurrency and lock-timeout tests passed repeatedly
- Independent review completed with no findings

Closes bangxiao0927/HSclubs#80

---
Generated by Codet
