### PR TITLE
Club media: add comments and content deletion

### DIFF
--- a/backend/src/main/java/com/example/demo/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/demo/auth/config/SecurityConfig.java
@@ -77,6 +77,9 @@ public class SecurityConfig {
                 // it does not cover this. Deliberately its own matcher, not added to
                 // PUBLIC_READ_ONLY_CORS_PATTERNS below -- see that list's Javadoc.
                 .requestMatchers(HttpMethod.GET, "/api/clubs/*/posts").permitAll()
+                // Club post comments (#79): public read, same reasoning and same exclusion
+                // from PUBLIC_READ_ONLY_CORS_PATTERNS as the post feed line above.
+                .requestMatchers(HttpMethod.GET, "/api/clubs/*/posts/*/comments").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/avatars/instagram/*").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/summary").permitAll()
                 // Everything else under /api requires authentication

--- a/backend/src/main/java/com/example/demo/club/controller/ClubPostCommentController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubPostCommentController.java
@@ -5,10 +5,12 @@ import com.example.demo.club.model.Club;
 import com.example.demo.club.model.ClubPost;
 import com.example.demo.club.model.ClubPostComment;
 import com.example.demo.club.model.PublicClubPostComment;
+import com.example.demo.club.service.ClubContentModerationPolicy;
 import com.example.demo.club.service.ClubPostCommentService;
 import com.example.demo.club.service.ClubPostNotFoundException;
 import com.example.demo.club.service.ClubPostService;
 import com.example.demo.club.service.ClubService;
+import com.example.demo.club.service.ClubVisibilityPolicy;
 import com.example.demo.club.service.CommentLimitExceededException;
 import com.example.demo.security.AuthenticatedUserResolver;
 import org.springframework.dao.CannotAcquireLockException;
@@ -28,7 +30,8 @@ import java.util.List;
 
 /**
  * Discussion on a club post (see #79): public read, member-only write, deletable by the
- * comment's own author, the club president, or a platform owner -- the same matrix
+ * comment's own author, the club president, or a platform owner -- see
+ * {@link ClubContentModerationPolicy}, the same moderation decision
  * {@link ClubPostController#deletePost} applies to the post itself.
  */
 @RestController
@@ -40,22 +43,28 @@ public class ClubPostCommentController {
     private final ClubPostCommentService clubPostCommentService;
     private final OAuthUserMapper oAuthUserMapper;
     private final AuthenticatedUserResolver authenticatedUserResolver;
+    private final ClubVisibilityPolicy clubVisibilityPolicy;
+    private final ClubContentModerationPolicy clubContentModerationPolicy;
 
     public ClubPostCommentController(ClubService clubService,
                                       ClubPostService clubPostService,
                                       ClubPostCommentService clubPostCommentService,
                                       OAuthUserMapper oAuthUserMapper,
-                                      AuthenticatedUserResolver authenticatedUserResolver) {
+                                      AuthenticatedUserResolver authenticatedUserResolver,
+                                      ClubVisibilityPolicy clubVisibilityPolicy,
+                                      ClubContentModerationPolicy clubContentModerationPolicy) {
         this.clubService = clubService;
         this.clubPostService = clubPostService;
         this.clubPostCommentService = clubPostCommentService;
         this.oAuthUserMapper = oAuthUserMapper;
         this.authenticatedUserResolver = authenticatedUserResolver;
+        this.clubVisibilityPolicy = clubVisibilityPolicy;
+        this.clubContentModerationPolicy = clubContentModerationPolicy;
     }
 
-    // Gated on clubs.status = 'active', matching ClubPostController#feed: comments belong to a
-    // post on a club's feed, so they must not be visible to anyone the feed itself hides them
-    // from.
+    // Visibility decision delegated to ClubVisibilityPolicy, shared with
+    // ClubPostController#feed: comments belong to a post on a club's feed, so they must not be
+    // visible to anyone the feed itself hides them from.
     @GetMapping("/{clubSlugOrId}/posts/{postId}/comments")
     public List<PublicClubPostComment> list(@PathVariable String clubSlugOrId, @PathVariable Long postId,
                                              Authentication authentication) {
@@ -65,11 +74,7 @@ public class ClubPostCommentController {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
         }
 
-        boolean isActive = "active".equalsIgnoreCase(club.getStatus());
-        boolean canViewNonActiveClub = Boolean.TRUE.equals(club.getViewerIsMember())
-            || Boolean.TRUE.equals(club.getCanManage())
-            || authenticatedUserResolver.isPlatformOwner(authentication);
-        if (!isActive && !canViewNonActiveClub) {
+        if (!clubVisibilityPolicy.isVisibleTo(club, authentication)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
         }
 
@@ -126,10 +131,9 @@ public class ClubPostCommentController {
         }
 
         Long viewerOauthUserId = oAuthUserMapper.findIdByEmail(viewerEmail);
-        boolean isAuthor = viewerOauthUserId != null && viewerOauthUserId.equals(comment.getAuthorOauthUserId());
-        boolean canModerate = Boolean.TRUE.equals(club.getCanManage())
-            || authenticatedUserResolver.isPlatformOwner(authentication);
-        if (!isAuthor && !canModerate) {
+        boolean canModerate = clubContentModerationPolicy.canModerate(
+            viewerOauthUserId, comment.getAuthorOauthUserId(), club, authentication);
+        if (!canModerate) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You do not have access to delete this comment");
         }
 

--- a/backend/src/main/java/com/example/demo/club/controller/ClubPostCommentController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubPostCommentController.java
@@ -1,0 +1,148 @@
+package com.example.demo.club.controller;
+
+import com.example.demo.auth.mapper.OAuthUserMapper;
+import com.example.demo.club.model.Club;
+import com.example.demo.club.model.ClubPost;
+import com.example.demo.club.model.ClubPostComment;
+import com.example.demo.club.model.PublicClubPostComment;
+import com.example.demo.club.service.ClubPostCommentService;
+import com.example.demo.club.service.ClubPostNotFoundException;
+import com.example.demo.club.service.ClubPostService;
+import com.example.demo.club.service.ClubService;
+import com.example.demo.club.service.CommentLimitExceededException;
+import com.example.demo.security.AuthenticatedUserResolver;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+/**
+ * Discussion on a club post (see #79): public read, member-only write, deletable by the
+ * comment's own author, the club president, or a platform owner -- the same matrix
+ * {@link ClubPostController#deletePost} applies to the post itself.
+ */
+@RestController
+@RequestMapping("/api/clubs")
+public class ClubPostCommentController {
+
+    private final ClubService clubService;
+    private final ClubPostService clubPostService;
+    private final ClubPostCommentService clubPostCommentService;
+    private final OAuthUserMapper oAuthUserMapper;
+    private final AuthenticatedUserResolver authenticatedUserResolver;
+
+    public ClubPostCommentController(ClubService clubService,
+                                      ClubPostService clubPostService,
+                                      ClubPostCommentService clubPostCommentService,
+                                      OAuthUserMapper oAuthUserMapper,
+                                      AuthenticatedUserResolver authenticatedUserResolver) {
+        this.clubService = clubService;
+        this.clubPostService = clubPostService;
+        this.clubPostCommentService = clubPostCommentService;
+        this.oAuthUserMapper = oAuthUserMapper;
+        this.authenticatedUserResolver = authenticatedUserResolver;
+    }
+
+    // Gated on clubs.status = 'active', matching ClubPostController#feed: comments belong to a
+    // post on a club's feed, so they must not be visible to anyone the feed itself hides them
+    // from.
+    @GetMapping("/{clubSlugOrId}/posts/{postId}/comments")
+    public List<PublicClubPostComment> list(@PathVariable String clubSlugOrId, @PathVariable Long postId,
+                                             Authentication authentication) {
+        String viewerEmail = authenticatedUserResolver.resolveEmail(authentication);
+        Club club = clubService.resolveBySlugOrId(clubSlugOrId, viewerEmail);
+        if (club == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
+        }
+
+        boolean isActive = "active".equalsIgnoreCase(club.getStatus());
+        boolean canViewNonActiveClub = Boolean.TRUE.equals(club.getViewerIsMember())
+            || Boolean.TRUE.equals(club.getCanManage())
+            || authenticatedUserResolver.isPlatformOwner(authentication);
+        if (!isActive && !canViewNonActiveClub) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
+        }
+
+        requirePostInClub(postId, club.getId());
+
+        return clubPostCommentService.findPublicComments(postId);
+    }
+
+    @PostMapping("/{clubSlugOrId}/posts/{postId}/comments")
+    @ResponseStatus(HttpStatus.CREATED)
+    public PublicClubPostComment create(@PathVariable String clubSlugOrId, @PathVariable Long postId,
+                                         @RequestBody CommentRequest request, Authentication authentication) {
+        String viewerEmail = authenticatedUserResolver.requireEmail(authentication);
+        Club club = clubService.resolveBySlugOrId(clubSlugOrId, viewerEmail);
+        if (club == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
+        }
+        if (!Boolean.TRUE.equals(club.getViewerIsMember())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Members only");
+        }
+
+        Long authorOauthUserId = oAuthUserMapper.findIdByEmail(viewerEmail);
+        try {
+            return clubPostCommentService.create(club.getId(), postId, authorOauthUserId, request.body());
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+        } catch (ClubPostNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        } catch (CommentLimitExceededException e) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
+        } catch (CannotAcquireLockException e) {
+            // The comment cap's FOR UPDATE lock timed out (H2 error 50200 / MySQL 1205, both
+            // translated by Spring into this exception): another request is very likely
+            // mid-insert on the same post, so this is a transient conflict, not a server error.
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                "Too many comments are being posted on this post right now; please try again");
+        }
+    }
+
+    @DeleteMapping("/{clubSlugOrId}/posts/{postId}/comments/{commentId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable String clubSlugOrId, @PathVariable Long postId, @PathVariable Long commentId,
+                        Authentication authentication) {
+        String viewerEmail = authenticatedUserResolver.requireEmail(authentication);
+        Club club = clubService.resolveBySlugOrId(clubSlugOrId, viewerEmail);
+        if (club == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
+        }
+        requirePostInClub(postId, club.getId());
+
+        ClubPostComment comment = clubPostCommentService.findByIdAndPostId(commentId, postId);
+        if (comment == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Comment not found");
+        }
+
+        Long viewerOauthUserId = oAuthUserMapper.findIdByEmail(viewerEmail);
+        boolean isAuthor = viewerOauthUserId != null && viewerOauthUserId.equals(comment.getAuthorOauthUserId());
+        boolean canModerate = Boolean.TRUE.equals(club.getCanManage())
+            || authenticatedUserResolver.isPlatformOwner(authentication);
+        if (!isAuthor && !canModerate) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You do not have access to delete this comment");
+        }
+
+        clubPostCommentService.delete(commentId);
+    }
+
+    private void requirePostInClub(Long postId, Long clubId) {
+        ClubPost post = clubPostService.findByIdAndClubId(postId, clubId);
+        if (post == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Post not found");
+        }
+    }
+
+    public record CommentRequest(String body) {
+    }
+}

--- a/backend/src/main/java/com/example/demo/club/controller/ClubPostController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubPostController.java
@@ -2,6 +2,7 @@ package com.example.demo.club.controller;
 
 import com.example.demo.auth.mapper.OAuthUserMapper;
 import com.example.demo.club.model.Club;
+import com.example.demo.club.model.ClubPost;
 import com.example.demo.club.model.PublicClubPost;
 import com.example.demo.club.service.ClubPostService;
 import com.example.demo.club.service.ClubService;
@@ -137,6 +138,43 @@ public class ClubPostController {
             clubPostService.unpin(club.getId(), postId);
         } catch (IllegalArgumentException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
+    // Same authorization matrix as comment deletion (see ClubPostCommentController): the
+    // post's own author, the club president, or a platform owner. Hard delete; the photo file
+    // and comment cascade are ClubPostService#delete's responsibility, not this controller's.
+    @DeleteMapping("/{clubSlugOrId}/posts/{postId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deletePost(@PathVariable String clubSlugOrId, @PathVariable Long postId,
+                            Authentication authentication) {
+        String viewerEmail = authenticatedUserResolver.requireEmail(authentication);
+        Club club = clubService.resolveBySlugOrId(clubSlugOrId, viewerEmail);
+        if (club == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
+        }
+
+        ClubPost post = clubPostService.findByIdAndClubId(postId, club.getId());
+        if (post == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Post not found");
+        }
+
+        Long viewerOauthUserId = oAuthUserMapper.findIdByEmail(viewerEmail);
+        boolean isAuthor = viewerOauthUserId != null && viewerOauthUserId.equals(post.getAuthorOauthUserId());
+        boolean canModerate = Boolean.TRUE.equals(club.getCanManage())
+            || authenticatedUserResolver.isPlatformOwner(authentication);
+        if (!isAuthor && !canModerate) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You do not have access to delete this post");
+        }
+
+        try {
+            clubPostService.delete(post);
+        } catch (IllegalStateException e) {
+            // ClubPostWriter#delete's own guard against a stale read (the row was already gone
+            // by the time the DELETE statement ran); the transaction has already rolled back,
+            // so this is a genuine, if unexpected, server-side failure -- same translation
+            // publish() applies to its own post-insert read-back guard.
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to delete post");
         }
     }
 

--- a/backend/src/main/java/com/example/demo/club/controller/ClubPostController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubPostController.java
@@ -4,8 +4,10 @@ import com.example.demo.auth.mapper.OAuthUserMapper;
 import com.example.demo.club.model.Club;
 import com.example.demo.club.model.ClubPost;
 import com.example.demo.club.model.PublicClubPost;
+import com.example.demo.club.service.ClubContentModerationPolicy;
 import com.example.demo.club.service.ClubPostService;
 import com.example.demo.club.service.ClubService;
+import com.example.demo.club.service.ClubVisibilityPolicy;
 import com.example.demo.security.AuthenticatedUserResolver;
 import org.springframework.http.HttpStatus;
 import org.springframework.dao.PessimisticLockingFailureException;
@@ -38,15 +40,21 @@ public class ClubPostController {
     private final ClubPostService clubPostService;
     private final OAuthUserMapper oAuthUserMapper;
     private final AuthenticatedUserResolver authenticatedUserResolver;
+    private final ClubVisibilityPolicy clubVisibilityPolicy;
+    private final ClubContentModerationPolicy clubContentModerationPolicy;
 
     public ClubPostController(ClubService clubService,
                               ClubPostService clubPostService,
                               OAuthUserMapper oAuthUserMapper,
-                              AuthenticatedUserResolver authenticatedUserResolver) {
+                              AuthenticatedUserResolver authenticatedUserResolver,
+                              ClubVisibilityPolicy clubVisibilityPolicy,
+                              ClubContentModerationPolicy clubContentModerationPolicy) {
         this.clubService = clubService;
         this.clubPostService = clubPostService;
         this.oAuthUserMapper = oAuthUserMapper;
         this.authenticatedUserResolver = authenticatedUserResolver;
+        this.clubVisibilityPolicy = clubVisibilityPolicy;
+        this.clubContentModerationPolicy = clubContentModerationPolicy;
     }
 
     @PostMapping("/{clubSlugOrId}/posts")
@@ -79,9 +87,8 @@ public class ClubPostController {
         }
     }
 
-    // Gated on clubs.status = 'active', not clubs.visibility (that column has no semantics yet
-    // -- see #78/#83). A non-active club's feed 404s to anyone who is not a member, the club
-    // president, or a platform owner, so an unapproved club cannot publish to a public page.
+    // Visibility decision delegated to ClubVisibilityPolicy, shared with
+    // ClubPostCommentController#list so the feed and its comments can never silently disagree.
     @GetMapping("/{clubSlugOrId}/posts")
     public ClubPostService.PostFeedPage feed(@PathVariable String clubSlugOrId,
                                              @RequestParam(defaultValue = "0") int page,
@@ -93,11 +100,7 @@ public class ClubPostController {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
         }
 
-        boolean isActive = "active".equalsIgnoreCase(club.getStatus());
-        boolean canViewNonActiveClub = Boolean.TRUE.equals(club.getViewerIsMember())
-            || Boolean.TRUE.equals(club.getCanManage())
-            || authenticatedUserResolver.isPlatformOwner(authentication);
-        if (!isActive && !canViewNonActiveClub) {
+        if (!clubVisibilityPolicy.isVisibleTo(club, authentication)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
         }
 
@@ -141,9 +144,9 @@ public class ClubPostController {
         }
     }
 
-    // Same authorization matrix as comment deletion (see ClubPostCommentController): the
-    // post's own author, the club president, or a platform owner. Hard delete; the photo file
-    // and comment cascade are ClubPostService#delete's responsibility, not this controller's.
+    // Moderation decision delegated to ClubContentModerationPolicy, shared with
+    // ClubPostCommentController#delete. Hard delete; the photo file and comment cascade are
+    // ClubPostService#delete's responsibility, not this controller's.
     @DeleteMapping("/{clubSlugOrId}/posts/{postId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deletePost(@PathVariable String clubSlugOrId, @PathVariable Long postId,
@@ -160,10 +163,9 @@ public class ClubPostController {
         }
 
         Long viewerOauthUserId = oAuthUserMapper.findIdByEmail(viewerEmail);
-        boolean isAuthor = viewerOauthUserId != null && viewerOauthUserId.equals(post.getAuthorOauthUserId());
-        boolean canModerate = Boolean.TRUE.equals(club.getCanManage())
-            || authenticatedUserResolver.isPlatformOwner(authentication);
-        if (!isAuthor && !canModerate) {
+        boolean canModerate = clubContentModerationPolicy.canModerate(
+            viewerOauthUserId, post.getAuthorOauthUserId(), club, authentication);
+        if (!canModerate) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You do not have access to delete this post");
         }
 

--- a/backend/src/main/java/com/example/demo/club/mapper/ClubPostMapper.java
+++ b/backend/src/main/java/com/example/demo/club/mapper/ClubPostMapper.java
@@ -3,6 +3,7 @@ package com.example.demo.club.mapper;
 import com.example.demo.club.model.ClubPost;
 import com.example.demo.club.model.ClubPostComment;
 import com.example.demo.club.model.PublicClubPost;
+import com.example.demo.club.model.PublicClubPostComment;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -30,9 +31,12 @@ public interface ClubPostMapper {
     // by-ID lookup in this codebase.
     PublicClubPost findPublicPostByIdAndClubId(@Param("id") Long id, @Param("clubId") Long clubId);
 
-    // Scoped lookup for the pin/unpin path (ClubPostService#pin/#unpin): a post ID that exists
-    // but under a different club must read back null, exactly like every other by-ID lookup in
-    // this mapper, so cross-club pinning 404s instead of silently touching someone else's post.
+    // Scoped lookup shared by the pin/unpin path (ClubPostService#pin/#unpin) and the delete
+    // endpoint's own author/president/platform-owner authorization: a post ID that exists but
+    // under a different club must read back null, exactly like every other by-ID lookup in this
+    // mapper, so cross-club pinning/deletion 404s instead of silently touching someone else's
+    // post. Exposes author_oauth_user_id and image_url, so it must never be serialized directly
+    // as a controller response body.
     ClubPost findByIdAndClubId(@Param("id") Long id, @Param("clubId") Long clubId);
 
     int insert(ClubPost post);
@@ -45,7 +49,26 @@ public interface ClubPostMapper {
 
     int countPinnedByClubId(@Param("clubId") Long clubId);
 
+    // The pessimistic lock the comment cap needs: SELECT ... FOR UPDATE, scoped to clubId as the
+    // same defense-in-depth guard every other by-ID lookup in this mapper applies. Returns the
+    // locked row's id, or null if no row matched -- a FOR UPDATE matching zero rows takes no
+    // lock, so a null here means "missing post", not "lock acquired on nothing".
+    Long lockPostIdForUpdate(@Param("id") Long id, @Param("clubId") Long clubId);
+
     List<ClubPostComment> findCommentsByPostId(@Param("postId") Long postId);
+
+    // Raw (non-public) read-back scoped to its post, for the delete endpoint's own author/
+    // president/platform-owner authorization: exposes author_oauth_user_id, so it must never be
+    // serialized directly as a controller response body.
+    ClubPostComment findCommentByIdAndPostId(@Param("id") Long id, @Param("postId") Long postId);
+
+    // Public projection for the anonymous comments endpoint: comment columns plus the author's
+    // display name/avatar only, reusing the same no-PII rule as findPublicFeedByClubId.
+    List<PublicClubPostComment> findPublicCommentsByPostId(@Param("postId") Long postId);
+
+    // Read-back for ClubPostCommentWriter#lockCountAndInsert, so a just-posted comment can be
+    // returned in the exact same safe shape the public list has.
+    PublicClubPostComment findPublicCommentByIdAndPostId(@Param("id") Long id, @Param("postId") Long postId);
 
     int insertComment(ClubPostComment comment);
 

--- a/backend/src/main/java/com/example/demo/club/model/PublicClubPostComment.java
+++ b/backend/src/main/java/com/example/demo/club/model/PublicClubPostComment.java
@@ -1,0 +1,69 @@
+package com.example.demo.club.model;
+
+import java.time.LocalDateTime;
+
+/**
+ * Public projection of a {@link ClubPostComment} for the anonymous, unauthenticated comments
+ * endpoint. Reuses the same no-PII rule as {@link PublicClubPost}: exposes only the comment's
+ * own columns plus the author's display name and avatar, never {@code email},
+ * {@code author_oauth_user_id}, {@code provider}, {@code provider_user_id}, {@code role},
+ * {@code accepted_terms_at}, the user's {@code created_at}/{@code last_login_at}, or
+ * {@code graduation_year}.
+ */
+public class PublicClubPostComment {
+
+    private Long id;
+    private Long postId;
+    private String body;
+    private LocalDateTime createdAt;
+    private String authorDisplayName;
+    private String authorAvatarUrl;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getPostId() {
+        return postId;
+    }
+
+    public void setPostId(Long postId) {
+        this.postId = postId;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getAuthorDisplayName() {
+        return authorDisplayName;
+    }
+
+    public void setAuthorDisplayName(String authorDisplayName) {
+        this.authorDisplayName = authorDisplayName;
+    }
+
+    public String getAuthorAvatarUrl() {
+        return authorAvatarUrl;
+    }
+
+    public void setAuthorAvatarUrl(String authorAvatarUrl) {
+        this.authorAvatarUrl = authorAvatarUrl;
+    }
+}

--- a/backend/src/main/java/com/example/demo/club/service/ClubContentModerationPolicy.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubContentModerationPolicy.java
@@ -1,0 +1,30 @@
+package com.example.demo.club.service;
+
+import com.example.demo.club.model.Club;
+import com.example.demo.security.AuthenticatedUserResolver;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+/**
+ * Whether a viewer may delete a piece of club content (a post or a comment): its own author,
+ * the club president, or a platform owner -- the only moderation matrix this feature defines.
+ * Shared by {@code ClubPostController#deletePost} and {@code ClubPostCommentController#delete}
+ * so the two deletion endpoints can never silently drift apart on who is allowed to moderate.
+ */
+@Component
+public class ClubContentModerationPolicy {
+
+    private final AuthenticatedUserResolver authenticatedUserResolver;
+
+    public ClubContentModerationPolicy(AuthenticatedUserResolver authenticatedUserResolver) {
+        this.authenticatedUserResolver = authenticatedUserResolver;
+    }
+
+    public boolean canModerate(Long viewerOauthUserId, Long contentAuthorOauthUserId, Club club,
+                                Authentication authentication) {
+        boolean isAuthor = viewerOauthUserId != null && viewerOauthUserId.equals(contentAuthorOauthUserId);
+        return isAuthor
+            || Boolean.TRUE.equals(club.getCanManage())
+            || authenticatedUserResolver.isPlatformOwner(authentication);
+    }
+}

--- a/backend/src/main/java/com/example/demo/club/service/ClubPostCommentService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubPostCommentService.java
@@ -1,0 +1,57 @@
+package com.example.demo.club.service;
+
+import com.example.demo.club.mapper.ClubPostMapper;
+import com.example.demo.club.model.ClubPostComment;
+import com.example.demo.club.model.PublicClubPostComment;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+/**
+ * Posting a comment, reading a post's public comments, and deleting a comment (see #79). Posting
+ * validates the body here, then delegates the concurrency-sensitive lock-count-insert to
+ * {@link ClubPostCommentWriter}, exactly like {@link ClubPostService#publish} delegates to
+ * {@link ClubPostWriter}.
+ */
+@Service
+public class ClubPostCommentService {
+
+    private static final int MAX_BODY_LENGTH = 300;
+
+    private final ClubPostMapper clubPostMapper;
+    private final ClubPostCommentWriter clubPostCommentWriter;
+
+    public ClubPostCommentService(ClubPostMapper clubPostMapper, ClubPostCommentWriter clubPostCommentWriter) {
+        this.clubPostMapper = clubPostMapper;
+        this.clubPostCommentWriter = clubPostCommentWriter;
+    }
+
+    public PublicClubPostComment create(Long clubId, Long postId, Long authorOauthUserId, String body) {
+        String trimmedBody = validateBody(body);
+        return clubPostCommentWriter.lockCountAndInsert(clubId, postId, authorOauthUserId, trimmedBody);
+    }
+
+    public List<PublicClubPostComment> findPublicComments(Long postId) {
+        return clubPostMapper.findPublicCommentsByPostId(postId);
+    }
+
+    public ClubPostComment findByIdAndPostId(Long commentId, Long postId) {
+        return clubPostMapper.findCommentByIdAndPostId(commentId, postId);
+    }
+
+    public void delete(Long commentId) {
+        clubPostMapper.deleteComment(commentId);
+    }
+
+    private static String validateBody(String body) {
+        if (!StringUtils.hasText(body)) {
+            throw new IllegalArgumentException("Comment body is required");
+        }
+        String trimmed = body.trim();
+        if (trimmed.length() > MAX_BODY_LENGTH) {
+            throw new IllegalArgumentException("Comment body must be " + MAX_BODY_LENGTH + " characters or fewer");
+        }
+        return trimmed;
+    }
+}

--- a/backend/src/main/java/com/example/demo/club/service/ClubPostCommentWriter.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubPostCommentWriter.java
@@ -1,0 +1,64 @@
+package com.example.demo.club.service;
+
+import com.example.demo.club.mapper.ClubPostMapper;
+import com.example.demo.club.model.ClubPostComment;
+import com.example.demo.club.model.PublicClubPostComment;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The concurrency-safe half of posting a comment (see #79): lock the parent post row, count its
+ * existing comments, and insert the new one, all inside one real transaction. Split into its own
+ * Spring bean for the same reason as {@link ClubPostWriter}: a same-class {@code @Transactional}
+ * method called via {@code this} bypasses Spring's proxy and runs with no transaction at all --
+ * which here would mean the {@code FOR UPDATE} lock is released the instant it is taken (mybatis-
+ * spring gives every mapper call outside an active Spring transaction its own {@code SqlSession},
+ * whose connection returns to the pool as soon as the statement completes), leaving the count
+ * that follows completely unguarded and the whole cap meaningless.
+ * <p>
+ * Order matters: the lock must be acquired before the count, and the count must happen before
+ * the insert, all without releasing the lock in between -- otherwise two concurrent callers can
+ * each observe 49 existing comments and both insert, producing 51 (see the issue's own
+ * description of the race under REPEATABLE READ).
+ */
+@Service
+class ClubPostCommentWriter {
+
+    // The issue's own bound: the 51st comment on a post must be rejected.
+    private static final int MAX_COMMENTS_PER_POST = 50;
+
+    private final ClubPostMapper clubPostMapper;
+
+    ClubPostCommentWriter(ClubPostMapper clubPostMapper) {
+        this.clubPostMapper = clubPostMapper;
+    }
+
+    @Transactional
+    PublicClubPostComment lockCountAndInsert(Long clubId, Long postId, Long authorOauthUserId, String body) {
+        // A FOR UPDATE matching zero rows takes no lock; null here means the post does not
+        // exist (or belongs to a different club), and must not fall through to an unguarded
+        // count-then-insert.
+        Long lockedPostId = clubPostMapper.lockPostIdForUpdate(postId, clubId);
+        if (lockedPostId == null) {
+            throw new ClubPostNotFoundException(postId);
+        }
+
+        int existingCommentCount = clubPostMapper.countCommentsByPostId(postId);
+        if (existingCommentCount >= MAX_COMMENTS_PER_POST) {
+            throw new CommentLimitExceededException(postId);
+        }
+
+        ClubPostComment comment = new ClubPostComment();
+        comment.setPostId(postId);
+        comment.setAuthorOauthUserId(authorOauthUserId);
+        comment.setBody(body);
+        clubPostMapper.insertComment(comment);
+
+        PublicClubPostComment created = clubPostMapper.findPublicCommentByIdAndPostId(comment.getId(), postId);
+        if (created == null) {
+            throw new IllegalStateException(
+                "Comment " + comment.getId() + " was not found immediately after being inserted");
+        }
+        return created;
+    }
+}

--- a/backend/src/main/java/com/example/demo/club/service/ClubPostNotFoundException.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubPostNotFoundException.java
@@ -1,0 +1,9 @@
+package com.example.demo.club.service;
+
+/** Thrown when a club post id does not exist, or does not belong to the expected club. */
+public class ClubPostNotFoundException extends RuntimeException {
+
+    public ClubPostNotFoundException(Long postId) {
+        super("Post " + postId + " was not found");
+    }
+}

--- a/backend/src/main/java/com/example/demo/club/service/ClubPostService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubPostService.java
@@ -105,6 +105,15 @@ public class ClubPostService {
         clubPostMapper.unpin(postId);
     }
 
+    /** Raw (author-identifying) read-back for the delete endpoint's own authorization check. */
+    public ClubPost findByIdAndClubId(Long postId, Long clubId) {
+        return clubPostMapper.findByIdAndClubId(postId, clubId);
+    }
+
+    public void delete(ClubPost post) {
+        clubPostWriter.delete(post);
+    }
+
     private static String validateTitle(String title) {
         if (!StringUtils.hasText(title)) {
             throw new IllegalArgumentException("Title is required");

--- a/backend/src/main/java/com/example/demo/club/service/ClubPostWriter.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubPostWriter.java
@@ -5,6 +5,8 @@ import com.example.demo.club.model.ClubPost;
 import com.example.demo.club.model.PublicClubPost;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
  * The database half of {@link ClubPostService#publish}: insert the row and immediately read
@@ -14,14 +16,22 @@ import org.springframework.transaction.annotation.Transactional;
  * silently run without a transaction. Deliberately does not touch {@link ImageStorageService}:
  * the photo is validated and written by the caller before this runs, so this method never holds
  * a JDBC connection open during image decode/re-encode/write.
+ * <p>
+ * Also owns {@link ClubPostService#delete}'s database half: delete the row, then register the
+ * photo's removal to run only {@link TransactionSynchronization#afterCommit() after the
+ * transaction commits}. Registering it eagerly (or calling {@link ImageStorageService#delete}
+ * directly) would destroy a photo that still has a row on a rolled-back delete; registering it
+ * here, inside the same proxied transactional method, is what ties the two together correctly.
  */
 @Service
 class ClubPostWriter {
 
     private final ClubPostMapper clubPostMapper;
+    private final ImageStorageService imageStorageService;
 
-    ClubPostWriter(ClubPostMapper clubPostMapper) {
+    ClubPostWriter(ClubPostMapper clubPostMapper, ImageStorageService imageStorageService) {
         this.clubPostMapper = clubPostMapper;
+        this.imageStorageService = imageStorageService;
     }
 
     // @Transactional so the insert does not auto-commit before the read-back has succeeded:
@@ -42,5 +52,21 @@ class ClubPostWriter {
                 "Post " + post.getId() + " was not found immediately after being inserted");
         }
         return created;
+    }
+
+    @Transactional
+    void delete(ClubPost post) {
+        int deletedRows = clubPostMapper.delete(post.getId());
+        if (deletedRows == 0) {
+            throw new IllegalStateException("Post " + post.getId() + " was not found when deleting");
+        }
+
+        String imageUrl = post.getImageUrl();
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                imageStorageService.delete(imageUrl);
+            }
+        });
     }
 }

--- a/backend/src/main/java/com/example/demo/club/service/ClubVisibilityPolicy.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubVisibilityPolicy.java
@@ -1,0 +1,34 @@
+package com.example.demo.club.service;
+
+import com.example.demo.club.model.Club;
+import com.example.demo.security.AuthenticatedUserResolver;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+/**
+ * Whether a club's non-active-facing content (its post feed, its comments) is visible to a
+ * given viewer. Gated on {@code clubs.status = 'active'}, not {@code clubs.visibility} (that
+ * column has no semantics yet -- see #78/#83): a non-active club is visible only to a member,
+ * the club president, or a platform owner, so an unapproved club cannot publish to a public
+ * page. Shared by {@code ClubPostController#feed} and {@code ClubPostCommentController#list} so
+ * the two can never silently disagree about which clubs' content the public can see.
+ */
+@Component
+public class ClubVisibilityPolicy {
+
+    private final AuthenticatedUserResolver authenticatedUserResolver;
+
+    public ClubVisibilityPolicy(AuthenticatedUserResolver authenticatedUserResolver) {
+        this.authenticatedUserResolver = authenticatedUserResolver;
+    }
+
+    public boolean isVisibleTo(Club club, Authentication authentication) {
+        boolean isActive = "active".equalsIgnoreCase(club.getStatus());
+        if (isActive) {
+            return true;
+        }
+        return Boolean.TRUE.equals(club.getViewerIsMember())
+            || Boolean.TRUE.equals(club.getCanManage())
+            || authenticatedUserResolver.isPlatformOwner(authentication);
+    }
+}

--- a/backend/src/main/java/com/example/demo/club/service/CommentLimitExceededException.java
+++ b/backend/src/main/java/com/example/demo/club/service/CommentLimitExceededException.java
@@ -1,0 +1,9 @@
+package com.example.demo.club.service;
+
+/** Thrown when a post already carries the maximum of 50 comments (see #79). */
+public class CommentLimitExceededException extends RuntimeException {
+
+    public CommentLimitExceededException(Long postId) {
+        super("Post " + postId + " already has the maximum number of comments");
+    }
+}

--- a/backend/src/main/resources/mapper/ClubPostMapper.xml
+++ b/backend/src/main/resources/mapper/ClubPostMapper.xml
@@ -124,6 +124,14 @@
         SELECT COUNT(*) FROM club_post WHERE club_id = #{clubId} AND pinned_at IS NOT NULL
     </select>
 
+    <!-- Pessimistic lock for the comment cap (see #79): must sit inside the same @Transactional
+         method as the count and the insert that follow it, or the lock is released before the
+         count even runs (see ClubPostCommentWriter's Javadoc). Returns no row (so no lock is
+         taken) when the post does not exist or belongs to a different club. -->
+    <select id="lockPostIdForUpdate" resultType="long">
+        SELECT id FROM club_post WHERE id = #{id} AND club_id = #{clubId} FOR UPDATE
+    </select>
+
     <resultMap id="ClubPostCommentResultMap" type="com.example.demo.club.model.ClubPostComment">
         <id column="id" property="id" />
         <result column="post_id" property="postId" />
@@ -137,6 +145,46 @@
         FROM club_post_comment
         WHERE post_id = #{postId}
         ORDER BY created_at ASC, id ASC
+    </select>
+
+    <select id="findCommentByIdAndPostId" resultMap="ClubPostCommentResultMap">
+        SELECT id, post_id, author_oauth_user_id, body, created_at
+        FROM club_post_comment
+        WHERE id = #{id} AND post_id = #{postId}
+    </select>
+
+    <resultMap id="PublicClubPostCommentResultMap" type="com.example.demo.club.model.PublicClubPostComment">
+        <id column="id" property="id" />
+        <result column="post_id" property="postId" />
+        <result column="body" property="body" />
+        <result column="created_at" property="createdAt" />
+        <result column="author_display_name" property="authorDisplayName" />
+        <result column="author_avatar_url" property="authorAvatarUrl" />
+    </resultMap>
+
+    <!-- Shared by findPublicCommentsByPostId and findPublicCommentByIdAndPostId, mirroring
+         PublicPostColumnList: never author_oauth_user_id or any other oauth_users column. -->
+    <sql id="PublicCommentColumnList">
+        cpc.id, cpc.post_id, cpc.body, cpc.created_at,
+        ou.display_name AS author_display_name,
+        ou.avatar_url   AS author_avatar_url
+    </sql>
+
+    <!-- Oldest first, flat, uncapped by pagination (the 50-comment cap makes it unnecessary,
+         see #79). "id ASC" is the same same-second tiebreaker findFeedByClubId relies on. -->
+    <select id="findPublicCommentsByPostId" resultMap="PublicClubPostCommentResultMap">
+        SELECT <include refid="PublicCommentColumnList" />
+        FROM club_post_comment cpc
+            JOIN oauth_users ou ON ou.uid = cpc.author_oauth_user_id
+        WHERE cpc.post_id = #{postId}
+        ORDER BY cpc.created_at ASC, cpc.id ASC
+    </select>
+
+    <select id="findPublicCommentByIdAndPostId" resultMap="PublicClubPostCommentResultMap">
+        SELECT <include refid="PublicCommentColumnList" />
+        FROM club_post_comment cpc
+            JOIN oauth_users ou ON ou.uid = cpc.author_oauth_user_id
+        WHERE cpc.id = #{id} AND cpc.post_id = #{postId}
     </select>
 
     <insert id="insertComment" parameterType="com.example.demo.club.model.ClubPostComment"

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostCommentAndDeletionIntegrationTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostCommentAndDeletionIntegrationTest.java
@@ -1,0 +1,452 @@
+package com.example.demo.club.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.demo.club.mapper.ClubPostMapper;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Full-stack acceptance coverage for #79's post-deletion and comment endpoints: real DB, real
+ * security filter chain, real {@link com.example.demo.club.service.ImageStorageService}.
+ * Unit/mapper/service/controller tests elsewhere cover each layer and each authorization branch
+ * in isolation; this proves the whole request works end to end for the criteria that span
+ * layers, especially the file-removal-after-commit contract.
+ */
+@SpringBootTest(properties =
+    "spring.datasource.url=jdbc:h2:mem:club_post_comment_deletion_test;MODE=MySQL;"
+        + "DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE")
+@AutoConfigureMockMvc
+@Sql(scripts = "classpath:schema.sql")
+class ClubPostCommentAndDeletionIntegrationTest {
+
+    private static final String MEMBER_EMAIL = "member@example.com";
+    private static final String PRESIDENT_EMAIL = "president@example.com";
+    private static final String OUTSIDER_EMAIL = "outsider@example.com";
+    private static final String OWNER_EMAIL = "test-owner@example.com";
+
+    @TempDir
+    static Path uploadDir;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    // A spy, not a mock: every test except the rollback one must keep going through the real
+    // mapper against the real H2 database.
+    @MockitoSpyBean
+    private ClubPostMapper clubPostMapperSpy;
+
+    @DynamicPropertySource
+    static void uploadDir(DynamicPropertyRegistry registry) {
+        registry.add("app.upload.dir", () -> uploadDir.toString());
+    }
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update("DELETE FROM clubs");
+        jdbcTemplate.update("DELETE FROM oauth_users");
+    }
+
+    private long createClub() {
+        jdbcTemplate.update("MERGE INTO club_category (cate_name) KEY (cate_name) VALUES ('STEM & Innovation')");
+        return insertClub("Chess Club", "active");
+    }
+
+    private long insertClub(String name, String status) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO clubs (name, category, status, visibility) VALUES (?, 'STEM & Innovation', ?, 'public')",
+                Statement.RETURN_GENERATED_KEYS);
+            statement.setString(1, name);
+            statement.setString(2, status);
+            return statement;
+        }, keyHolder);
+        return extractId(keyHolder);
+    }
+
+    private long insertOauthUser(String email, String displayName) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO oauth_users (provider, provider_user_id, email, display_name) VALUES ('google', ?, ?, ?)",
+                Statement.RETURN_GENERATED_KEYS);
+            statement.setString(1, email);
+            statement.setString(2, email);
+            statement.setString(3, displayName);
+            return statement;
+        }, keyHolder);
+        return extractId(keyHolder, "uid");
+    }
+
+    private void addMember(long clubId, long uid, String role) {
+        jdbcTemplate.update(
+            "INSERT INTO club_member (club_id, oauth_user_id, role_name) VALUES (?, ?, ?)", clubId, uid, role);
+    }
+
+    private String writeStoredPhoto() throws Exception {
+        Path clubPostsDir = uploadDir.resolve("club-posts");
+        Files.createDirectories(clubPostsDir);
+        String filename = UUID.randomUUID() + ".jpg";
+        Files.write(clubPostsDir.resolve(filename), new byte[] {1, 2, 3});
+        return "/uploads/club-posts/" + filename;
+    }
+
+    private long insertPost(long clubId, long authorUid, String imageUrl) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO club_post (club_id, author_oauth_user_id, title, image_url) "
+                    + "VALUES (?, ?, 'Meeting recap', ?)",
+                Statement.RETURN_GENERATED_KEYS);
+            statement.setLong(1, clubId);
+            statement.setLong(2, authorUid);
+            statement.setString(3, imageUrl);
+            return statement;
+        }, keyHolder);
+        return extractId(keyHolder);
+    }
+
+    private long insertComment(long postId, long authorUid, String body) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO club_post_comment (post_id, author_oauth_user_id, body) VALUES (?, ?, ?)",
+                Statement.RETURN_GENERATED_KEYS);
+            statement.setLong(1, postId);
+            statement.setLong(2, authorUid);
+            statement.setString(3, body);
+            return statement;
+        }, keyHolder);
+        return extractId(keyHolder);
+    }
+
+    private static long extractId(KeyHolder keyHolder) {
+        return extractId(keyHolder, "id");
+    }
+
+    private static long extractId(KeyHolder keyHolder, String columnName) {
+        Map<String, Object> keys = keyHolder.getKeys();
+        Object idValue = keys.containsKey(columnName) ? keys.get(columnName) : keys.get(columnName.toUpperCase(Locale.ROOT));
+        return ((Number) idValue).longValue();
+    }
+
+    private int countPostRows(long postId) {
+        return jdbcTemplate.queryForObject("SELECT COUNT(*) FROM club_post WHERE id = ?", Integer.class, postId);
+    }
+
+    private int countCommentRows(long postId) {
+        return jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM club_post_comment WHERE post_id = ?", Integer.class, postId);
+    }
+
+    private OAuth2AuthenticationToken oauthToken(String email) {
+        OAuth2User principal = new DefaultOAuth2User(
+            List.of(() -> "ROLE_USER"),
+            Map.of("email", email, "sub", email),
+            "sub");
+        return new OAuth2AuthenticationToken(principal, principal.getAuthorities(), "google");
+    }
+
+    // ---- Post deletion ----
+
+    @Test
+    void authorCanDeleteOwnPostWhichCascadesItsCommentsAndRemovesTheFileOnlyAfterCommit() throws Exception {
+        long clubId = createClub();
+        long authorUid = insertOauthUser(MEMBER_EMAIL, "Ada Lovelace");
+        addMember(clubId, authorUid, "member");
+        String imageUrl = writeStoredPhoto();
+        long postId = insertPost(clubId, authorUid, imageUrl);
+        insertComment(postId, authorUid, "Nice!");
+        Path storedFile = uploadDir.resolve(imageUrl.substring("/uploads/".length()));
+        assertThat(Files.exists(storedFile)).isTrue();
+
+        mockMvc.perform(delete("/api/clubs/" + clubId + "/posts/" + postId)
+                .with(authentication(oauthToken(MEMBER_EMAIL))))
+            .andExpect(status().isNoContent());
+
+        assertThat(countPostRows(postId)).isZero();
+        assertThat(countCommentRows(postId)).isZero();
+        assertThat(Files.exists(storedFile)).isFalse();
+    }
+
+    @Test
+    void presidentCanDeleteAnotherMembersPost() throws Exception {
+        long clubId = createClub();
+        long authorUid = insertOauthUser(MEMBER_EMAIL, "Ada Lovelace");
+        long presidentUid = insertOauthUser(PRESIDENT_EMAIL, "President");
+        addMember(clubId, authorUid, "member");
+        addMember(clubId, presidentUid, "president");
+        long postId = insertPost(clubId, authorUid, writeStoredPhoto());
+
+        mockMvc.perform(delete("/api/clubs/" + clubId + "/posts/" + postId)
+                .with(authentication(oauthToken(PRESIDENT_EMAIL))))
+            .andExpect(status().isNoContent());
+
+        assertThat(countPostRows(postId)).isZero();
+    }
+
+    @Test
+    void platformOwnerCanDeleteAnyonesPost() throws Exception {
+        long clubId = createClub();
+        long authorUid = insertOauthUser(MEMBER_EMAIL, "Ada Lovelace");
+        insertOauthUser(OWNER_EMAIL, "Owner");
+        addMember(clubId, authorUid, "member");
+        long postId = insertPost(clubId, authorUid, writeStoredPhoto());
+
+        mockMvc.perform(delete("/api/clubs/" + clubId + "/posts/" + postId)
+                .with(authentication(oauthToken(OWNER_EMAIL))))
+            .andExpect(status().isNoContent());
+
+        assertThat(countPostRows(postId)).isZero();
+    }
+
+    @Test
+    void nonAuthorNonPresidentCannotDeleteAPost() throws Exception {
+        long clubId = createClub();
+        long authorUid = insertOauthUser(MEMBER_EMAIL, "Ada Lovelace");
+        insertOauthUser(OUTSIDER_EMAIL, "Outsider");
+        addMember(clubId, authorUid, "member");
+        String imageUrl = writeStoredPhoto();
+        long postId = insertPost(clubId, authorUid, imageUrl);
+        Path storedFile = uploadDir.resolve(imageUrl.substring("/uploads/".length()));
+
+        mockMvc.perform(delete("/api/clubs/" + clubId + "/posts/" + postId)
+                .with(authentication(oauthToken(OUTSIDER_EMAIL))))
+            .andExpect(status().isForbidden());
+
+        assertThat(countPostRows(postId)).isEqualTo(1);
+        assertThat(Files.exists(storedFile)).isTrue();
+    }
+
+    // The transaction-boundary contract this exists for: if the delete's own transaction rolls
+    // back for any reason, the row must still exist and the file must still be on disk --
+    // afterCommit must never have run.
+    @Test
+    void aRolledBackDeleteLeavesBothTheRowAndTheFileIntact() throws Exception {
+        long clubId = createClub();
+        long authorUid = insertOauthUser(MEMBER_EMAIL, "Ada Lovelace");
+        addMember(clubId, authorUid, "member");
+        String imageUrl = writeStoredPhoto();
+        long postId = insertPost(clubId, authorUid, imageUrl);
+        Path storedFile = uploadDir.resolve(imageUrl.substring("/uploads/".length()));
+
+        // Simulates a bug elsewhere in the same transactional method surfacing after the DELETE
+        // statement itself has already run: physically deletes the row (the exact statement
+        // ClubPostMapper.xml's delete defines) on the same transactional connection, then
+        // reports zero rows affected, which ClubPostWriter#delete treats as a failure and
+        // throws -- rolling back everything, including the DELETE that already ran.
+        doAnswer(invocation -> {
+            Long id = invocation.getArgument(0);
+            jdbcTemplate.update("DELETE FROM club_post WHERE id = ?", id);
+            return 0;
+        }).when(clubPostMapperSpy).delete(anyLong());
+
+        mockMvc.perform(delete("/api/clubs/" + clubId + "/posts/" + postId)
+                .with(authentication(oauthToken(MEMBER_EMAIL))))
+            .andExpect(status().is5xxServerError());
+
+        assertThat(countPostRows(postId)).isEqualTo(1);
+        assertThat(Files.exists(storedFile)).isTrue();
+    }
+
+    @Test
+    void deletingAnUnknownPostReturnsNotFound() throws Exception {
+        long clubId = createClub();
+        long authorUid = insertOauthUser(MEMBER_EMAIL, "Ada Lovelace");
+        addMember(clubId, authorUid, "member");
+
+        mockMvc.perform(delete("/api/clubs/" + clubId + "/posts/999999")
+                .with(authentication(oauthToken(MEMBER_EMAIL))))
+            .andExpect(status().isNotFound());
+    }
+
+    // ---- Comments ----
+
+    @Test
+    void memberCanPostACommentAndAnyoneCanReadItBackWithNoPii() throws Exception {
+        long clubId = createClub();
+        long authorUid = insertOauthUser(MEMBER_EMAIL, "Ada Lovelace");
+        addMember(clubId, authorUid, "member");
+        long postId = insertPost(clubId, authorUid, writeStoredPhoto());
+
+        mockMvc.perform(post("/api/clubs/" + clubId + "/posts/" + postId + "/comments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"body\":\"  Great meeting!  \"}")
+                .with(authentication(oauthToken(MEMBER_EMAIL))))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.body").value("Great meeting!"));
+
+        String responseBody = mockMvc.perform(get("/api/clubs/" + clubId + "/posts/" + postId + "/comments"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(1)))
+            .andExpect(jsonPath("$[0].body").value("Great meeting!"))
+            .andExpect(jsonPath("$[0].authorDisplayName").value("Ada Lovelace"))
+            .andReturn().getResponse().getContentAsString();
+
+        assertThat(responseBody).doesNotContain("\"email\"");
+        assertThat(responseBody).doesNotContain("@");
+    }
+
+    @Test
+    void nonMemberCannotPostAComment() throws Exception {
+        long clubId = createClub();
+        long authorUid = insertOauthUser(MEMBER_EMAIL, "Ada Lovelace");
+        insertOauthUser(OUTSIDER_EMAIL, "Outsider");
+        addMember(clubId, authorUid, "member");
+        long postId = insertPost(clubId, authorUid, writeStoredPhoto());
+
+        mockMvc.perform(post("/api/clubs/" + clubId + "/posts/" + postId + "/comments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"body\":\"Nice!\"}")
+                .with(authentication(oauthToken(OUTSIDER_EMAIL))))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void loggedOutVisitorCanReadCommentsButCannotPost() throws Exception {
+        long clubId = createClub();
+        long authorUid = insertOauthUser(MEMBER_EMAIL, "Ada Lovelace");
+        addMember(clubId, authorUid, "member");
+        long postId = insertPost(clubId, authorUid, writeStoredPhoto());
+        insertComment(postId, authorUid, "Nice!");
+
+        mockMvc.perform(get("/api/clubs/" + clubId + "/posts/" + postId + "/comments"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].body").value("Nice!"));
+
+        mockMvc.perform(post("/api/clubs/" + clubId + "/posts/" + postId + "/comments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"body\":\"Nice!\"}"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void aCommentOverThreeHundredCharactersReturnsBadRequest() throws Exception {
+        long clubId = createClub();
+        long authorUid = insertOauthUser(MEMBER_EMAIL, "Ada Lovelace");
+        addMember(clubId, authorUid, "member");
+        long postId = insertPost(clubId, authorUid, writeStoredPhoto());
+        String tooLong = "x".repeat(301);
+
+        mockMvc.perform(post("/api/clubs/" + clubId + "/posts/" + postId + "/comments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"body\":\"" + tooLong + "\"}")
+                .with(authentication(oauthToken(MEMBER_EMAIL))))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void commentingOnANonExistentPostReturnsNotFound() throws Exception {
+        long clubId = createClub();
+        long authorUid = insertOauthUser(MEMBER_EMAIL, "Ada Lovelace");
+        addMember(clubId, authorUid, "member");
+
+        mockMvc.perform(post("/api/clubs/" + clubId + "/posts/999999/comments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"body\":\"Nice!\"}")
+                .with(authentication(oauthToken(MEMBER_EMAIL))))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void commentAuthorCanDeleteTheirOwnComment() throws Exception {
+        long clubId = createClub();
+        long authorUid = insertOauthUser(MEMBER_EMAIL, "Ada Lovelace");
+        addMember(clubId, authorUid, "member");
+        long postId = insertPost(clubId, authorUid, writeStoredPhoto());
+        long commentId = insertComment(postId, authorUid, "Nice!");
+
+        mockMvc.perform(delete("/api/clubs/" + clubId + "/posts/" + postId + "/comments/" + commentId)
+                .with(authentication(oauthToken(MEMBER_EMAIL))))
+            .andExpect(status().isNoContent());
+
+        assertThat(countCommentRows(postId)).isZero();
+    }
+
+    @Test
+    void presidentCanDeleteAnotherMembersComment() throws Exception {
+        long clubId = createClub();
+        long authorUid = insertOauthUser(MEMBER_EMAIL, "Ada Lovelace");
+        long presidentUid = insertOauthUser(PRESIDENT_EMAIL, "President");
+        addMember(clubId, authorUid, "member");
+        addMember(clubId, presidentUid, "president");
+        long postId = insertPost(clubId, authorUid, writeStoredPhoto());
+        long commentId = insertComment(postId, authorUid, "Nice!");
+
+        mockMvc.perform(delete("/api/clubs/" + clubId + "/posts/" + postId + "/comments/" + commentId)
+                .with(authentication(oauthToken(PRESIDENT_EMAIL))))
+            .andExpect(status().isNoContent());
+
+        assertThat(countCommentRows(postId)).isZero();
+    }
+
+    @Test
+    void platformOwnerCanDeleteAnyonesComment() throws Exception {
+        long clubId = createClub();
+        long authorUid = insertOauthUser(MEMBER_EMAIL, "Ada Lovelace");
+        insertOauthUser(OWNER_EMAIL, "Owner");
+        addMember(clubId, authorUid, "member");
+        long postId = insertPost(clubId, authorUid, writeStoredPhoto());
+        long commentId = insertComment(postId, authorUid, "Nice!");
+
+        mockMvc.perform(delete("/api/clubs/" + clubId + "/posts/" + postId + "/comments/" + commentId)
+                .with(authentication(oauthToken(OWNER_EMAIL))))
+            .andExpect(status().isNoContent());
+
+        assertThat(countCommentRows(postId)).isZero();
+    }
+
+    @Test
+    void nonAuthorNonPresidentCannotDeleteAComment() throws Exception {
+        long clubId = createClub();
+        long authorUid = insertOauthUser(MEMBER_EMAIL, "Ada Lovelace");
+        insertOauthUser(OUTSIDER_EMAIL, "Outsider");
+        addMember(clubId, authorUid, "member");
+        long postId = insertPost(clubId, authorUid, writeStoredPhoto());
+        long commentId = insertComment(postId, authorUid, "Nice!");
+
+        mockMvc.perform(delete("/api/clubs/" + clubId + "/posts/" + postId + "/comments/" + commentId)
+                .with(authentication(oauthToken(OUTSIDER_EMAIL))))
+            .andExpect(status().isForbidden());
+
+        assertThat(countCommentRows(postId)).isEqualTo(1);
+    }
+}

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostCommentControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostCommentControllerTest.java
@@ -1,0 +1,418 @@
+package com.example.demo.club.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.demo.auth.config.SecurityProperties;
+import com.example.demo.auth.mapper.OAuthUserMapper;
+import com.example.demo.club.model.Club;
+import com.example.demo.club.model.ClubPost;
+import com.example.demo.club.model.ClubPostComment;
+import com.example.demo.club.model.PublicClubPostComment;
+import com.example.demo.club.service.ClubPostCommentService;
+import com.example.demo.club.service.ClubPostNotFoundException;
+import com.example.demo.club.service.ClubPostService;
+import com.example.demo.club.service.ClubService;
+import com.example.demo.club.service.CommentLimitExceededException;
+import com.example.demo.security.AuthenticatedUserResolver;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.security.oauth2.client.autoconfigure.servlet.OAuth2ClientWebSecurityAutoConfiguration;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    controllers = ClubPostCommentController.class,
+    excludeAutoConfiguration = {
+        OAuth2ClientAutoConfiguration.class,
+        OAuth2ClientWebSecurityAutoConfiguration.class
+    })
+@AutoConfigureMockMvc(addFilters = false)
+class ClubPostCommentControllerTest {
+
+    private static final String MEMBER_EMAIL = "member@example.com";
+    private static final String NON_MEMBER_EMAIL = "outsider@example.com";
+    private static final String OWNER_EMAIL = "test-owner@example.com";
+    private static final String PRESIDENT_EMAIL = "president@example.com";
+    private static final String AUTHOR_EMAIL = "author@example.com";
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        SecurityProperties securityProperties() {
+            return new SecurityProperties();
+        }
+
+        @Bean
+        AuthenticatedUserResolver authenticatedUserResolver(SecurityProperties securityProperties) {
+            return new AuthenticatedUserResolver(securityProperties);
+        }
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ClubService clubService;
+
+    @MockitoBean
+    private ClubPostService clubPostService;
+
+    @MockitoBean
+    private ClubPostCommentService clubPostCommentService;
+
+    @MockitoBean
+    private OAuthUserMapper oAuthUserMapper;
+
+    private static Club activeClub() {
+        Club club = new Club();
+        club.setId(1L);
+        club.setViewerIsMember(true);
+        return club;
+    }
+
+    // ---- GET ----
+
+    @Test
+    void listIsReachableByALoggedOutVisitor() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setStatus("active");
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        ClubPost post = new ClubPost();
+        post.setId(9L);
+        when(clubPostService.findByIdAndClubId(9L, 1L)).thenReturn(post);
+        PublicClubPostComment comment = new PublicClubPostComment();
+        comment.setBody("Nice!");
+        when(clubPostCommentService.findPublicComments(9L)).thenReturn(List.of(comment));
+
+        mockMvc.perform(get("/api/clubs/1/posts/9/comments"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].body").value("Nice!"));
+    }
+
+    @Test
+    void listReturnsNotFoundForAnUnknownClub() throws Exception {
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(null);
+
+        mockMvc.perform(get("/api/clubs/1/posts/9/comments"))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void listReturnsNotFoundWhenThePostDoesNotBelongToTheClub() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setStatus("active");
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(clubPostService.findByIdAndClubId(9L, 1L)).thenReturn(null);
+
+        mockMvc.perform(get("/api/clubs/1/posts/9/comments"))
+            .andExpect(status().isNotFound());
+    }
+
+    // Same gating as ClubPostController#feed: a non-active club's comments 404 to anyone who
+    // is not a member, the club president, or a platform owner, matching the feed they belong to.
+    @Test
+    void listOfANonActiveClubReturnsNotFoundToALoggedOutVisitor() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setStatus("pending");
+        club.setViewerIsMember(false);
+        club.setCanManage(false);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+
+        mockMvc.perform(get("/api/clubs/1/posts/9/comments"))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void listOfANonActiveClubIsVisibleToAMember() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setStatus("pending");
+        club.setViewerIsMember(true);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        ClubPost post = new ClubPost();
+        post.setId(9L);
+        when(clubPostService.findByIdAndClubId(9L, 1L)).thenReturn(post);
+        when(clubPostCommentService.findPublicComments(9L)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/clubs/1/posts/9/comments").principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isOk());
+    }
+
+    // ---- POST ----
+
+    @Test
+    void createRequiresAuthentication() throws Exception {
+        mockMvc.perform(post("/api/clubs/1/posts/9/comments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"body\":\"Nice!\"}"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void createReturnsNotFoundForAnUnknownClub() throws Exception {
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(null);
+
+        mockMvc.perform(post("/api/clubs/1/posts/9/comments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"body\":\"Nice!\"}")
+                .principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void createRejectsANonMemberWithForbidden() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setViewerIsMember(false);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+
+        mockMvc.perform(post("/api/clubs/1/posts/9/comments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"body\":\"Nice!\"}")
+                .principal(oauthToken(NON_MEMBER_EMAIL)))
+            .andExpect(status().isForbidden());
+
+        verify(clubPostCommentService, never()).create(any(), any(), any(), any());
+    }
+
+    @Test
+    void createSucceedsForAMemberAndReturnsThePublicComment() throws Exception {
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(activeClub());
+        when(oAuthUserMapper.findIdByEmail(MEMBER_EMAIL)).thenReturn(42L);
+        PublicClubPostComment created = new PublicClubPostComment();
+        created.setId(5L);
+        created.setBody("Nice!");
+        created.setCreatedAt(LocalDateTime.of(2024, 1, 1, 10, 0));
+        created.setAuthorDisplayName("Ada Lovelace");
+        when(clubPostCommentService.create(1L, 9L, 42L, "Nice!")).thenReturn(created);
+
+        String responseBody = mockMvc.perform(post("/api/clubs/1/posts/9/comments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"body\":\"Nice!\"}")
+                .principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.id").value(5))
+            .andExpect(jsonPath("$.body").value("Nice!"))
+            .andExpect(jsonPath("$.authorDisplayName").value("Ada Lovelace"))
+            .andReturn().getResponse().getContentAsString();
+
+        assertThat(responseBody).doesNotContain("authorOauthUserId");
+    }
+
+    @Test
+    void createReturnsBadRequestWhenTheServiceRejectsTheBody() throws Exception {
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(activeClub());
+        when(oAuthUserMapper.findIdByEmail(MEMBER_EMAIL)).thenReturn(42L);
+        when(clubPostCommentService.create(any(), any(), any(), any()))
+            .thenThrow(new IllegalArgumentException("Comment body is required"));
+
+        mockMvc.perform(post("/api/clubs/1/posts/9/comments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"body\":\"   \"}")
+                .principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createReturnsNotFoundWhenTheServiceReportsAMissingPost() throws Exception {
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(activeClub());
+        when(oAuthUserMapper.findIdByEmail(MEMBER_EMAIL)).thenReturn(42L);
+        when(clubPostCommentService.create(any(), any(), any(), any()))
+            .thenThrow(new ClubPostNotFoundException(9L));
+
+        mockMvc.perform(post("/api/clubs/1/posts/9/comments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"body\":\"Nice!\"}")
+                .principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void createReturnsConflictWhenTheServiceReportsTheCommentLimitIsReached() throws Exception {
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(activeClub());
+        when(oAuthUserMapper.findIdByEmail(MEMBER_EMAIL)).thenReturn(42L);
+        when(clubPostCommentService.create(any(), any(), any(), any()))
+            .thenThrow(new CommentLimitExceededException(9L));
+
+        mockMvc.perform(post("/api/clubs/1/posts/9/comments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"body\":\"Nice!\"}")
+                .principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isConflict());
+    }
+
+    // The lock-timeout requirement: an H2/MySQL lock timeout, surfaced by the mapper as
+    // Spring's CannotAcquireLockException, must become a 409, not an unhandled 500.
+    @Test
+    void createReturnsConflictWhenTheServiceReportsALockTimeout() throws Exception {
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(activeClub());
+        when(oAuthUserMapper.findIdByEmail(MEMBER_EMAIL)).thenReturn(42L);
+        when(clubPostCommentService.create(any(), any(), any(), any()))
+            .thenThrow(new CannotAcquireLockException("Timeout trying to lock table"));
+
+        mockMvc.perform(post("/api/clubs/1/posts/9/comments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"body\":\"Nice!\"}")
+                .principal(oauthToken(MEMBER_EMAIL)))
+            .andExpect(status().isConflict());
+    }
+
+    // ---- DELETE ----
+
+    @Test
+    void deleteRequiresAuthentication() throws Exception {
+        mockMvc.perform(delete("/api/clubs/1/posts/9/comments/5"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void deleteReturnsNotFoundForAnUnknownClub() throws Exception {
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(null);
+
+        mockMvc.perform(delete("/api/clubs/1/posts/9/comments/5").principal(oauthToken(AUTHOR_EMAIL)))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void deleteReturnsNotFoundWhenThePostDoesNotBelongToTheClub() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(clubPostService.findByIdAndClubId(9L, 1L)).thenReturn(null);
+
+        mockMvc.perform(delete("/api/clubs/1/posts/9/comments/5").principal(oauthToken(AUTHOR_EMAIL)))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void deleteReturnsNotFoundWhenTheCommentDoesNotBelongToThePost() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        ClubPost post = new ClubPost();
+        post.setId(9L);
+        when(clubPostService.findByIdAndClubId(9L, 1L)).thenReturn(post);
+        when(clubPostCommentService.findByIdAndPostId(5L, 9L)).thenReturn(null);
+
+        mockMvc.perform(delete("/api/clubs/1/posts/9/comments/5").principal(oauthToken(AUTHOR_EMAIL)))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void deleteRejectsANonAuthorNonPresidentNonOwnerWithForbidden() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setCanManage(false);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(oAuthUserMapper.findIdByEmail(NON_MEMBER_EMAIL)).thenReturn(77L);
+        ClubPost post = new ClubPost();
+        post.setId(9L);
+        when(clubPostService.findByIdAndClubId(9L, 1L)).thenReturn(post);
+        ClubPostComment comment = new ClubPostComment();
+        comment.setId(5L);
+        comment.setAuthorOauthUserId(42L);
+        when(clubPostCommentService.findByIdAndPostId(5L, 9L)).thenReturn(comment);
+
+        mockMvc.perform(delete("/api/clubs/1/posts/9/comments/5").principal(oauthToken(NON_MEMBER_EMAIL)))
+            .andExpect(status().isForbidden());
+
+        verify(clubPostCommentService, never()).delete(any());
+    }
+
+    @Test
+    void deleteSucceedsForTheCommentsAuthor() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setCanManage(false);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(oAuthUserMapper.findIdByEmail(AUTHOR_EMAIL)).thenReturn(42L);
+        ClubPost post = new ClubPost();
+        post.setId(9L);
+        when(clubPostService.findByIdAndClubId(9L, 1L)).thenReturn(post);
+        ClubPostComment comment = new ClubPostComment();
+        comment.setId(5L);
+        comment.setAuthorOauthUserId(42L);
+        when(clubPostCommentService.findByIdAndPostId(5L, 9L)).thenReturn(comment);
+
+        mockMvc.perform(delete("/api/clubs/1/posts/9/comments/5").principal(oauthToken(AUTHOR_EMAIL)))
+            .andExpect(status().isNoContent());
+
+        verify(clubPostCommentService).delete(5L);
+    }
+
+    @Test
+    void deleteSucceedsForTheClubPresident() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setCanManage(true);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(oAuthUserMapper.findIdByEmail(PRESIDENT_EMAIL)).thenReturn(7L);
+        ClubPost post = new ClubPost();
+        post.setId(9L);
+        when(clubPostService.findByIdAndClubId(9L, 1L)).thenReturn(post);
+        ClubPostComment comment = new ClubPostComment();
+        comment.setId(5L);
+        comment.setAuthorOauthUserId(42L);
+        when(clubPostCommentService.findByIdAndPostId(5L, 9L)).thenReturn(comment);
+
+        mockMvc.perform(delete("/api/clubs/1/posts/9/comments/5").principal(oauthToken(PRESIDENT_EMAIL)))
+            .andExpect(status().isNoContent());
+
+        verify(clubPostCommentService).delete(5L);
+    }
+
+    @Test
+    void deleteSucceedsForAPlatformOwner() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setCanManage(false);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(oAuthUserMapper.findIdByEmail(OWNER_EMAIL)).thenReturn(99L);
+        ClubPost post = new ClubPost();
+        post.setId(9L);
+        when(clubPostService.findByIdAndClubId(9L, 1L)).thenReturn(post);
+        ClubPostComment comment = new ClubPostComment();
+        comment.setId(5L);
+        comment.setAuthorOauthUserId(42L);
+        when(clubPostCommentService.findByIdAndPostId(5L, 9L)).thenReturn(comment);
+
+        mockMvc.perform(delete("/api/clubs/1/posts/9/comments/5").principal(oauthToken(OWNER_EMAIL)))
+            .andExpect(status().isNoContent());
+
+        verify(clubPostCommentService).delete(5L);
+    }
+
+    private OAuth2AuthenticationToken oauthToken(String email) {
+        OAuth2User principal = new DefaultOAuth2User(
+            List.of(() -> "ROLE_USER"),
+            Map.of("email", email, "sub", email),
+            "sub");
+        return new OAuth2AuthenticationToken(principal, principal.getAuthorities(), "google");
+    }
+}

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostCommentControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostCommentControllerTest.java
@@ -18,10 +18,12 @@ import com.example.demo.club.model.Club;
 import com.example.demo.club.model.ClubPost;
 import com.example.demo.club.model.ClubPostComment;
 import com.example.demo.club.model.PublicClubPostComment;
+import com.example.demo.club.service.ClubContentModerationPolicy;
 import com.example.demo.club.service.ClubPostCommentService;
 import com.example.demo.club.service.ClubPostNotFoundException;
 import com.example.demo.club.service.ClubPostService;
 import com.example.demo.club.service.ClubService;
+import com.example.demo.club.service.ClubVisibilityPolicy;
 import com.example.demo.club.service.CommentLimitExceededException;
 import com.example.demo.security.AuthenticatedUserResolver;
 import java.time.LocalDateTime;
@@ -68,6 +70,16 @@ class ClubPostCommentControllerTest {
         @Bean
         AuthenticatedUserResolver authenticatedUserResolver(SecurityProperties securityProperties) {
             return new AuthenticatedUserResolver(securityProperties);
+        }
+
+        @Bean
+        ClubVisibilityPolicy clubVisibilityPolicy(AuthenticatedUserResolver authenticatedUserResolver) {
+            return new ClubVisibilityPolicy(authenticatedUserResolver);
+        }
+
+        @Bean
+        ClubContentModerationPolicy clubContentModerationPolicy(AuthenticatedUserResolver authenticatedUserResolver) {
+            return new ClubContentModerationPolicy(authenticatedUserResolver);
         }
     }
 

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostControllerTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -15,6 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.example.demo.auth.config.SecurityProperties;
 import com.example.demo.auth.mapper.OAuthUserMapper;
 import com.example.demo.club.model.Club;
+import com.example.demo.club.model.ClubPost;
 import com.example.demo.club.model.PublicClubPost;
 import com.example.demo.club.service.ClubPostService;
 import com.example.demo.club.service.ClubService;
@@ -50,6 +53,9 @@ class ClubPostControllerTest {
 
     private static final String MEMBER_EMAIL = "member@example.com";
     private static final String NON_MEMBER_EMAIL = "outsider@example.com";
+    private static final String OWNER_EMAIL = "test-owner@example.com";
+    private static final String PRESIDENT_EMAIL = "president@example.com";
+    private static final String AUTHOR_EMAIL = "author@example.com";
 
     @TestConfiguration
     static class TestConfig {
@@ -413,6 +419,137 @@ class ClubPostControllerTest {
 
     private static MockMultipartFile aPhoto() {
         return new MockMultipartFile("file", "photo.jpg", "image/jpeg", new byte[] {1, 2, 3});
+    }
+
+    @Test
+    void deletePostRequiresAuthentication() throws Exception {
+        mockMvc.perform(delete("/api/clubs/1/posts/9"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void deletePostReturnsNotFoundForAnUnknownClub() throws Exception {
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(null);
+
+        mockMvc.perform(delete("/api/clubs/1/posts/9").principal(oauthToken(AUTHOR_EMAIL)))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void deletePostReturnsNotFoundWhenThePostDoesNotBelongToTheClub() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(clubPostService.findByIdAndClubId(9L, 1L)).thenReturn(null);
+
+        mockMvc.perform(delete("/api/clubs/1/posts/9").principal(oauthToken(AUTHOR_EMAIL)))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void deletePostRejectsANonAuthorNonPresidentNonOwnerWithForbidden() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setCanManage(false);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(oAuthUserMapper.findIdByEmail(NON_MEMBER_EMAIL)).thenReturn(77L);
+        ClubPost post = new ClubPost();
+        post.setId(9L);
+        post.setAuthorOauthUserId(42L);
+        when(clubPostService.findByIdAndClubId(9L, 1L)).thenReturn(post);
+
+        mockMvc.perform(delete("/api/clubs/1/posts/9").principal(oauthToken(NON_MEMBER_EMAIL)))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void deletePostSucceedsForThePostsAuthor() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setCanManage(false);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(oAuthUserMapper.findIdByEmail(AUTHOR_EMAIL)).thenReturn(42L);
+        ClubPost post = new ClubPost();
+        post.setId(9L);
+        post.setAuthorOauthUserId(42L);
+        when(clubPostService.findByIdAndClubId(9L, 1L)).thenReturn(post);
+
+        mockMvc.perform(delete("/api/clubs/1/posts/9").principal(oauthToken(AUTHOR_EMAIL)))
+            .andExpect(status().isNoContent());
+
+        verify(clubPostService).delete(post);
+    }
+
+    @Test
+    void deletePostSucceedsForTheClubPresident() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setCanManage(true);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(oAuthUserMapper.findIdByEmail(PRESIDENT_EMAIL)).thenReturn(7L);
+        ClubPost post = new ClubPost();
+        post.setId(9L);
+        post.setAuthorOauthUserId(42L);
+        when(clubPostService.findByIdAndClubId(9L, 1L)).thenReturn(post);
+
+        mockMvc.perform(delete("/api/clubs/1/posts/9").principal(oauthToken(PRESIDENT_EMAIL)))
+            .andExpect(status().isNoContent());
+
+        verify(clubPostService).delete(post);
+    }
+
+    @Test
+    void deletePostSucceedsForAPlatformOwner() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setCanManage(false);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(oAuthUserMapper.findIdByEmail(OWNER_EMAIL)).thenReturn(99L);
+        ClubPost post = new ClubPost();
+        post.setId(9L);
+        post.setAuthorOauthUserId(42L);
+        when(clubPostService.findByIdAndClubId(9L, 1L)).thenReturn(post);
+
+        mockMvc.perform(delete("/api/clubs/1/posts/9").principal(oauthToken(OWNER_EMAIL)))
+            .andExpect(status().isNoContent());
+
+        verify(clubPostService).delete(post);
+    }
+
+    @Test
+    void deletePostNeverDeletesWhenAuthorizationFails() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setCanManage(false);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(oAuthUserMapper.findIdByEmail(NON_MEMBER_EMAIL)).thenReturn(77L);
+        ClubPost post = new ClubPost();
+        post.setId(9L);
+        post.setAuthorOauthUserId(42L);
+        when(clubPostService.findByIdAndClubId(9L, 1L)).thenReturn(post);
+
+        mockMvc.perform(delete("/api/clubs/1/posts/9").principal(oauthToken(NON_MEMBER_EMAIL)))
+            .andExpect(status().isForbidden());
+
+        verify(clubPostService, never()).delete(any());
+    }
+
+    @Test
+    void deletePostReturnsServerErrorWhenTheServiceReportsAStaleRead() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setCanManage(false);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(oAuthUserMapper.findIdByEmail(AUTHOR_EMAIL)).thenReturn(42L);
+        ClubPost post = new ClubPost();
+        post.setId(9L);
+        post.setAuthorOauthUserId(42L);
+        when(clubPostService.findByIdAndClubId(9L, 1L)).thenReturn(post);
+        org.mockito.Mockito.doThrow(new IllegalStateException("Post 9 was not found when deleting"))
+            .when(clubPostService).delete(post);
+
+        mockMvc.perform(delete("/api/clubs/1/posts/9").principal(oauthToken(AUTHOR_EMAIL)))
+            .andExpect(status().isInternalServerError());
     }
 
     private OAuth2AuthenticationToken oauthToken(String email) {

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostControllerTest.java
@@ -19,8 +19,10 @@ import com.example.demo.auth.mapper.OAuthUserMapper;
 import com.example.demo.club.model.Club;
 import com.example.demo.club.model.ClubPost;
 import com.example.demo.club.model.PublicClubPost;
+import com.example.demo.club.service.ClubContentModerationPolicy;
 import com.example.demo.club.service.ClubPostService;
 import com.example.demo.club.service.ClubService;
+import com.example.demo.club.service.ClubVisibilityPolicy;
 import com.example.demo.security.AuthenticatedUserResolver;
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -67,6 +69,16 @@ class ClubPostControllerTest {
         @Bean
         AuthenticatedUserResolver authenticatedUserResolver(SecurityProperties securityProperties) {
             return new AuthenticatedUserResolver(securityProperties);
+        }
+
+        @Bean
+        ClubVisibilityPolicy clubVisibilityPolicy(AuthenticatedUserResolver authenticatedUserResolver) {
+            return new ClubVisibilityPolicy(authenticatedUserResolver);
+        }
+
+        @Bean
+        ClubContentModerationPolicy clubContentModerationPolicy(AuthenticatedUserResolver authenticatedUserResolver) {
+            return new ClubContentModerationPolicy(authenticatedUserResolver);
         }
     }
 

--- a/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
+++ b/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.example.demo.club.model.ClubPost;
 import com.example.demo.club.model.ClubPostComment;
 import com.example.demo.club.model.PublicClubPost;
+import com.example.demo.club.model.PublicClubPostComment;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -255,6 +256,111 @@ class ClubPostMapperTest {
     }
 
     @Test
+    void findByIdAndClubIdReturnsThePostWhenTheClubMatches() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+
+        ClubPost post = clubPostMapper.findByIdAndClubId(1L, 1L);
+
+        assertThat(post).isNotNull();
+        assertThat(post.getAuthorOauthUserId()).isEqualTo(1L);
+        assertThat(post.getImageUrl()).isEqualTo("/uploads/club-posts/1.jpg");
+    }
+
+    @Test
+    void findByIdAndClubIdReturnsNullForAMismatchedClubId() {
+        jdbcTemplate.update("INSERT INTO clubs (id, name) VALUES (2, 'Robotics')");
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+
+        assertThat(clubPostMapper.findByIdAndClubId(1L, 2L)).isNull();
+    }
+
+    // This only proves the query returns the right id/null; a FOR UPDATE assertion here would
+    // pass vacuously without a surrounding transaction (see the issue's own warning), so the
+    // actual pessimistic-locking behavior is covered by a service-level test instead.
+    @Test
+    void lockPostIdForUpdateReturnsTheIdWhenThePostExistsInThatClub() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+
+        assertThat(clubPostMapper.lockPostIdForUpdate(1L, 1L)).isEqualTo(1L);
+    }
+
+    @Test
+    void lockPostIdForUpdateReturnsNullForAMissingPostOrAMismatchedClubId() {
+        jdbcTemplate.update("INSERT INTO clubs (id, name) VALUES (2, 'Robotics')");
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+
+        assertThat(clubPostMapper.lockPostIdForUpdate(99L, 1L)).isNull();
+        assertThat(clubPostMapper.lockPostIdForUpdate(1L, 2L)).isNull();
+    }
+
+    @Test
+    void findCommentByIdAndPostIdReturnsTheCommentWhenThePostMatches() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        ClubPostComment comment = new ClubPostComment();
+        comment.setPostId(1L);
+        comment.setAuthorOauthUserId(1L);
+        comment.setBody("Great photo!");
+        clubPostMapper.insertComment(comment);
+
+        ClubPostComment found = clubPostMapper.findCommentByIdAndPostId(comment.getId(), 1L);
+
+        assertThat(found).isNotNull();
+        assertThat(found.getAuthorOauthUserId()).isEqualTo(1L);
+        assertThat(found.getBody()).isEqualTo("Great photo!");
+    }
+
+    @Test
+    void findCommentByIdAndPostIdReturnsNullForAMismatchedPostId() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        insertPost(2L, 1L, "2024-01-02 10:00:00", null);
+        ClubPostComment comment = new ClubPostComment();
+        comment.setPostId(1L);
+        comment.setAuthorOauthUserId(1L);
+        comment.setBody("Great photo!");
+        clubPostMapper.insertComment(comment);
+
+        assertThat(clubPostMapper.findCommentByIdAndPostId(comment.getId(), 2L)).isNull();
+    }
+
+    @Test
+    void findPublicCommentsByPostIdReturnsOldestFirstWithAuthorDisplayNameAndAvatarUrl() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        insertCommentAt(1L, 1L, "First comment", "2024-01-01 10:00:00");
+        insertCommentAt(2L, 1L, "Second comment", "2024-01-02 10:00:00");
+
+        List<PublicClubPostComment> comments = clubPostMapper.findPublicCommentsByPostId(1L);
+
+        assertThat(comments).extracting(PublicClubPostComment::getBody)
+            .containsExactly("First comment", "Second comment");
+        assertThat(comments).allSatisfy(comment -> {
+            assertThat(comment.getAuthorDisplayName()).isEqualTo("Ada Lovelace");
+            assertThat(comment.getAuthorAvatarUrl()).isEqualTo("/uploads/avatar-cache/ada.jpg");
+        });
+    }
+
+    @Test
+    void findPublicCommentByIdAndPostIdReturnsTheSameSafeShapeAsTheList() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        insertCommentAt(1L, 1L, "Great photo!", "2024-01-01 10:00:00");
+
+        PublicClubPostComment comment = clubPostMapper.findPublicCommentByIdAndPostId(1L, 1L);
+
+        assertThat(comment).isNotNull();
+        assertThat(comment.getBody()).isEqualTo("Great photo!");
+        assertThat(comment.getAuthorDisplayName()).isEqualTo("Ada Lovelace");
+        assertThat(comment.getAuthorAvatarUrl()).isEqualTo("/uploads/avatar-cache/ada.jpg");
+    }
+
+    @Test
+    void findPublicCommentByIdAndPostIdReturnsNullForAMismatchedPostId() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        insertPost(2L, 1L, "2024-01-02 10:00:00", null);
+        insertCommentAt(1L, 1L, "Great photo!", "2024-01-01 10:00:00");
+
+        assertThat(clubPostMapper.findPublicCommentByIdAndPostId(1L, 2L)).isNull();
+    }
+
+    @Test
     void findAllImageUrlsReturnsEveryPostsImageUrlAcrossClubs() {
         jdbcTemplate.update("INSERT INTO clubs (id, name) VALUES (2, 'Robotics')");
         insertPost(1L, 1L, "2024-01-01 10:00:00", null);
@@ -377,6 +483,13 @@ class ClubPostMapperTest {
             "INSERT INTO club_post (id, club_id, author_oauth_user_id, title, image_url, created_at, pinned_at) "
                 + "VALUES (?, ?, 1, 'Post ' || ?, '/uploads/club-posts/' || ? || '.jpg', ?, ?)",
             id, clubId, id, id, createdAt, pinnedAt);
+    }
+
+    private void insertCommentAt(long id, long postId, String body, String createdAt) {
+        jdbcTemplate.update(
+            "INSERT INTO club_post_comment (id, post_id, author_oauth_user_id, body, created_at) "
+                + "VALUES (?, ?, 1, ?, ?)",
+            id, postId, body, createdAt);
     }
 
     private static List<Long> idsOf(List<ClubPost> posts) {

--- a/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
+++ b/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
@@ -255,25 +255,6 @@ class ClubPostMapperTest {
             .satisfies(remaining -> assertThat(remaining.getBody()).isEqualTo("Second"));
     }
 
-    @Test
-    void findByIdAndClubIdReturnsThePostWhenTheClubMatches() {
-        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
-
-        ClubPost post = clubPostMapper.findByIdAndClubId(1L, 1L);
-
-        assertThat(post).isNotNull();
-        assertThat(post.getAuthorOauthUserId()).isEqualTo(1L);
-        assertThat(post.getImageUrl()).isEqualTo("/uploads/club-posts/1.jpg");
-    }
-
-    @Test
-    void findByIdAndClubIdReturnsNullForAMismatchedClubId() {
-        jdbcTemplate.update("INSERT INTO clubs (id, name) VALUES (2, 'Robotics')");
-        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
-
-        assertThat(clubPostMapper.findByIdAndClubId(1L, 2L)).isNull();
-    }
-
     // This only proves the query returns the right id/null; a FOR UPDATE assertion here would
     // pass vacuously without a surrounding transaction (see the issue's own warning), so the
     // actual pessimistic-locking behavior is covered by a service-level test instead.
@@ -457,6 +438,8 @@ class ClubPostMapperTest {
         assertThat(post).isNotNull();
         assertThat(post.getId()).isEqualTo(1L);
         assertThat(post.getClubId()).isEqualTo(1L);
+        assertThat(post.getAuthorOauthUserId()).isEqualTo(1L);
+        assertThat(post.getImageUrl()).isEqualTo("/uploads/club-posts/1.jpg");
     }
 
     // Scoped the same way findPublicPostByIdAndClubId is: cross-club pinning must 404, not

--- a/backend/src/test/java/com/example/demo/club/model/PublicClubPostCommentTest.java
+++ b/backend/src/test/java/com/example/demo/club/model/PublicClubPostCommentTest.java
@@ -1,0 +1,37 @@
+package com.example.demo.club.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression guard for the DTO's own contract, independent of the mapper: same rule as
+ * {@link PublicClubPostTest}, since #79 reuses the no-PII author projection for comments.
+ */
+class PublicClubPostCommentTest {
+
+    private static final String[] FORBIDDEN_SUBSTRINGS = {
+        "email", "uid", "provider", "role", "acceptedterms", "graduationyear", "lastlogin"
+    };
+
+    @Test
+    void hasNoFieldOrAccessorNamedAfterAForbiddenOauthUserColumn() {
+        Stream.concat(
+                Stream.of(PublicClubPostComment.class.getDeclaredFields()).map(Field::getName),
+                Stream.of(PublicClubPostComment.class.getDeclaredMethods()).map(Method::getName))
+            .forEach(name -> {
+                String normalized = name.toLowerCase(Locale.ROOT).replace("_", "");
+                for (String forbidden : FORBIDDEN_SUBSTRINGS) {
+                    assertThat(normalized)
+                        .withFailMessage("PublicClubPostComment member '%s' looks like it exposes "
+                            + "the forbidden oauth_users column pattern '%s'", name, forbidden)
+                        .doesNotContain(forbidden);
+                }
+            });
+    }
+}

--- a/backend/src/test/java/com/example/demo/club/service/ClubContentModerationPolicyTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubContentModerationPolicyTest.java
@@ -1,0 +1,84 @@
+package com.example.demo.club.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.example.demo.club.model.Club;
+import com.example.demo.security.AuthenticatedUserResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.Authentication;
+
+class ClubContentModerationPolicyTest {
+
+    private static final Long AUTHOR_OAUTH_USER_ID = 42L;
+
+    private AuthenticatedUserResolver authenticatedUserResolver;
+    private ClubContentModerationPolicy clubContentModerationPolicy;
+    private Authentication authentication;
+
+    @BeforeEach
+    void setUp() {
+        authenticatedUserResolver = mock(AuthenticatedUserResolver.class);
+        clubContentModerationPolicy = new ClubContentModerationPolicy(authenticatedUserResolver);
+        authentication = mock(Authentication.class);
+    }
+
+    private static Club clubWithCanManage(boolean canManage) {
+        Club club = new Club();
+        club.setCanManage(canManage);
+        return club;
+    }
+
+    @Test
+    void canModerateIsTrueForTheContentsOwnAuthor() {
+        Club club = clubWithCanManage(false);
+
+        boolean result = clubContentModerationPolicy.canModerate(
+            AUTHOR_OAUTH_USER_ID, AUTHOR_OAUTH_USER_ID, club, authentication);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void canModerateIsTrueForTheClubPresident() {
+        Club club = clubWithCanManage(true);
+
+        boolean result = clubContentModerationPolicy.canModerate(99L, AUTHOR_OAUTH_USER_ID, club, authentication);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void canModerateIsTrueForAPlatformOwner() {
+        Club club = clubWithCanManage(false);
+        when(authenticatedUserResolver.isPlatformOwner(authentication)).thenReturn(true);
+
+        boolean result = clubContentModerationPolicy.canModerate(99L, AUTHOR_OAUTH_USER_ID, club, authentication);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void canModerateIsFalseForANonAuthorNonPresidentNonOwner() {
+        Club club = clubWithCanManage(false);
+        when(authenticatedUserResolver.isPlatformOwner(authentication)).thenReturn(false);
+
+        boolean result = clubContentModerationPolicy.canModerate(99L, AUTHOR_OAUTH_USER_ID, club, authentication);
+
+        assertThat(result).isFalse();
+    }
+
+    // A viewer the caller could not resolve to an oauth_users row at all (e.g. findIdByEmail
+    // returned null) must never accidentally match a null-authored row by coincidence.
+    @Test
+    void canModerateIsFalseWhenTheViewersOauthUserIdIsNull() {
+        Club club = clubWithCanManage(false);
+        when(authenticatedUserResolver.isPlatformOwner(authentication)).thenReturn(false);
+
+        boolean result = clubContentModerationPolicy.canModerate(null, AUTHOR_OAUTH_USER_ID, club, authentication);
+
+        assertThat(result).isFalse();
+    }
+}

--- a/backend/src/test/java/com/example/demo/club/service/ClubPostCommentConcurrencyIntegrationTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubPostCommentConcurrencyIntegrationTest.java
@@ -1,0 +1,161 @@
+package com.example.demo.club.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+
+import com.example.demo.club.mapper.ClubPostMapper;
+import com.example.demo.club.model.PublicClubPostComment;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.context.jdbc.Sql;
+
+/**
+ * Real-transaction, real-H2 coverage for #79's concurrency race: two genuinely overlapping
+ * requests for the same post's 51st comment, which a mocked-mapper unit test cannot exercise
+ * (see ClubPostCommentWriterTest for the ordering guarantee that makes this race safe).
+ */
+@SpringBootTest(properties =
+    "spring.datasource.url=jdbc:h2:mem:club_post_comment_concurrency_test;MODE=MySQL;"
+        + "DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE")
+@Sql(scripts = "classpath:schema.sql")
+class ClubPostCommentConcurrencyIntegrationTest {
+
+    @Autowired
+    private ClubPostCommentService clubPostCommentService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    // A spy, not a mock: every test must keep going through the real mapper against the real H2
+    // database; the delay it injects below only widens the race window, it never fakes a result.
+    @MockitoSpyBean
+    private ClubPostMapper clubPostMapperSpy;
+
+    private ExecutorService executor;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.update("DELETE FROM clubs");
+        jdbcTemplate.update("DELETE FROM oauth_users");
+        executor = Executors.newFixedThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() {
+        executor.shutdownNow();
+    }
+
+    private long createClubWithAuthor() {
+        jdbcTemplate.update("MERGE INTO club_category (cate_name) KEY (cate_name) VALUES ('STEM & Innovation')");
+        KeyHolder clubKeyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> connection.prepareStatement(
+            "INSERT INTO clubs (name, category, status, visibility) "
+                + "VALUES ('Chess Club', 'STEM & Innovation', 'active', 'public')",
+            Statement.RETURN_GENERATED_KEYS), clubKeyHolder);
+
+        jdbcTemplate.update(
+            "INSERT INTO oauth_users (provider, provider_user_id, email, display_name) "
+                + "VALUES ('google', 'g-1', 'author@example.com', 'Ada Lovelace')");
+
+        return extractId(clubKeyHolder, "id");
+    }
+
+    private long insertPost(long clubId, long authorUid) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO club_post (club_id, author_oauth_user_id, title, image_url) "
+                    + "VALUES (?, ?, 'Meeting recap', '/uploads/club-posts/seed.jpg')",
+                Statement.RETURN_GENERATED_KEYS);
+            statement.setLong(1, clubId);
+            statement.setLong(2, authorUid);
+            return statement;
+        }, keyHolder);
+        return extractId(keyHolder, "id");
+    }
+
+    private void insertComments(long postId, long authorUid, int count) {
+        for (int i = 0; i < count; i++) {
+            jdbcTemplate.update(
+                "INSERT INTO club_post_comment (post_id, author_oauth_user_id, body) VALUES (?, ?, ?)",
+                postId, authorUid, "Existing comment " + i);
+        }
+    }
+
+    private static long extractId(KeyHolder keyHolder, String columnName) {
+        Object idValue = keyHolder.getKeys().containsKey(columnName)
+            ? keyHolder.getKeys().get(columnName)
+            : keyHolder.getKeys().get(columnName.toUpperCase(Locale.ROOT));
+        return ((Number) idValue).longValue();
+    }
+
+    // The issue's own race: without the FOR UPDATE lock serializing the two requests, both
+    // could observe 49 existing comments and both insert, producing 51. With it, the second
+    // caller must observe the first caller's committed 50th comment and be rejected.
+    @Test
+    void onlyOneOfTwoConcurrentRequestsForThe51stCommentSucceeds() throws Exception {
+        long clubId = createClubWithAuthor();
+        long authorUid = jdbcTemplate.queryForObject("SELECT uid FROM oauth_users LIMIT 1", Long.class);
+        long postId = insertPost(clubId, authorUid);
+        insertComments(postId, authorUid, 49);
+
+        // Widens the race window deterministically: whichever caller is first to acquire the
+        // FOR UPDATE lock now has time to also finish its count before the second caller's own
+        // lock attempt can even begin, instead of leaving the outcome to incidental thread
+        // scheduling. Re-runs the exact query countCommentsByPostId's mapper XML defines (see
+        // ClubPostMapper.xml) rather than invocation.callRealMethod(), which Mockito does not
+        // support for interface spies backed by a MyBatis mapper proxy.
+        doAnswer(invocation -> {
+            Thread.sleep(300);
+            Long queriedPostId = invocation.getArgument(0);
+            return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM club_post_comment WHERE post_id = ?", Integer.class, queriedPostId);
+        }).when(clubPostMapperSpy).countCommentsByPostId(anyLong());
+
+        CyclicBarrier barrier = new CyclicBarrier(2);
+        Callable<PublicClubPostComment> attempt = () -> {
+            barrier.await(5, TimeUnit.SECONDS);
+            return clubPostCommentService.create(clubId, postId, authorUid, "Racing comment");
+        };
+
+        Future<PublicClubPostComment> first = executor.submit(attempt);
+        Future<PublicClubPostComment> second = executor.submit(attempt);
+
+        int succeeded = 0;
+        int rejected = 0;
+        for (Future<PublicClubPostComment> future : List.of(first, second)) {
+            try {
+                future.get(10, TimeUnit.SECONDS);
+                succeeded++;
+            } catch (ExecutionException e) {
+                assertThat(e.getCause()).isInstanceOf(CommentLimitExceededException.class);
+                rejected++;
+            }
+        }
+
+        assertThat(succeeded).isEqualTo(1);
+        assertThat(rejected).isEqualTo(1);
+        Integer finalCount = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM club_post_comment WHERE post_id = ?", Integer.class, postId);
+        assertThat(finalCount).isEqualTo(50);
+    }
+}

--- a/backend/src/test/java/com/example/demo/club/service/ClubPostCommentLockTimeoutIntegrationTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubPostCommentLockTimeoutIntegrationTest.java
@@ -1,0 +1,105 @@
+package com.example.demo.club.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.util.Locale;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.test.context.jdbc.Sql;
+
+/**
+ * Real-transaction, real-H2 coverage for #79's other concurrency requirement: a lock timeout
+ * must surface as {@link CannotAcquireLockException} (which {@code ClubPostCommentController}
+ * maps to 409), never an unhandled 500. Runs in its own {@code @SpringBootTest} context, with
+ * its own H2 database and a short {@code LOCK_TIMEOUT}, so this test does not have to wait out
+ * H2's ~2s default and does not affect other tests' lock behavior.
+ */
+@SpringBootTest(properties =
+    "spring.datasource.url=jdbc:h2:mem:club_post_comment_lock_timeout_test;MODE=MySQL;"
+        + "DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE;INIT=SET LOCK_TIMEOUT 300")
+@Sql(scripts = "classpath:schema.sql")
+class ClubPostCommentLockTimeoutIntegrationTest {
+
+    @Autowired
+    private ClubPostCommentService clubPostCommentService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.update("DELETE FROM clubs");
+        jdbcTemplate.update("DELETE FROM oauth_users");
+    }
+
+    private long createClubWithAuthor() {
+        jdbcTemplate.update("MERGE INTO club_category (cate_name) KEY (cate_name) VALUES ('STEM & Innovation')");
+        KeyHolder clubKeyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> connection.prepareStatement(
+            "INSERT INTO clubs (name, category, status, visibility) "
+                + "VALUES ('Chess Club', 'STEM & Innovation', 'active', 'public')",
+            Statement.RETURN_GENERATED_KEYS), clubKeyHolder);
+
+        jdbcTemplate.update(
+            "INSERT INTO oauth_users (provider, provider_user_id, email, display_name) "
+                + "VALUES ('google', 'g-1', 'author@example.com', 'Ada Lovelace')");
+
+        return extractId(clubKeyHolder, "id");
+    }
+
+    private long insertPost(long clubId, long authorUid) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO club_post (club_id, author_oauth_user_id, title, image_url) "
+                    + "VALUES (?, ?, 'Meeting recap', '/uploads/club-posts/seed.jpg')",
+                Statement.RETURN_GENERATED_KEYS);
+            statement.setLong(1, clubId);
+            statement.setLong(2, authorUid);
+            return statement;
+        }, keyHolder);
+        return extractId(keyHolder, "id");
+    }
+
+    private static long extractId(KeyHolder keyHolder, String columnName) {
+        Object idValue = keyHolder.getKeys().containsKey(columnName)
+            ? keyHolder.getKeys().get(columnName)
+            : keyHolder.getKeys().get(columnName.toUpperCase(Locale.ROOT));
+        return ((Number) idValue).longValue();
+    }
+
+    @Test
+    void aRowLockedByAnotherConnectionSurfacesAsCannotAcquireLockException() throws Exception {
+        long clubId = createClubWithAuthor();
+        long authorUid = jdbcTemplate.queryForObject("SELECT uid FROM oauth_users LIMIT 1", Long.class);
+        long postId = insertPost(clubId, authorUid);
+
+        try (Connection lockHolder = dataSource.getConnection()) {
+            lockHolder.setAutoCommit(false);
+            try (PreparedStatement statement =
+                     lockHolder.prepareStatement("SELECT id FROM club_post WHERE id = ? FOR UPDATE")) {
+                statement.setLong(1, postId);
+                statement.execute();
+            }
+
+            assertThatThrownBy(() ->
+                clubPostCommentService.create(clubId, postId, authorUid, "Blocked comment"))
+                .isInstanceOf(CannotAcquireLockException.class);
+
+            lockHolder.rollback();
+        }
+    }
+}

--- a/backend/src/test/java/com/example/demo/club/service/ClubPostCommentServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubPostCommentServiceTest.java
@@ -1,0 +1,93 @@
+package com.example.demo.club.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.demo.club.mapper.ClubPostMapper;
+import com.example.demo.club.model.PublicClubPostComment;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ClubPostCommentServiceTest {
+
+    private ClubPostMapper clubPostMapper;
+    private ClubPostCommentWriter clubPostCommentWriter;
+    private ClubPostCommentService clubPostCommentService;
+
+    @BeforeEach
+    void setUp() {
+        clubPostMapper = mock(ClubPostMapper.class);
+        clubPostCommentWriter = mock(ClubPostCommentWriter.class);
+        clubPostCommentService = new ClubPostCommentService(clubPostMapper, clubPostCommentWriter);
+    }
+
+    @Test
+    void createRejectsANullBody() {
+        assertThatThrownBy(() -> clubPostCommentService.create(1L, 10L, 5L, null))
+            .isInstanceOf(IllegalArgumentException.class);
+
+        verify(clubPostCommentWriter, never()).lockCountAndInsert(eq(1L), eq(10L), eq(5L), org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void createRejectsABodyThatIsBlankAfterTrimming() {
+        assertThatThrownBy(() -> clubPostCommentService.create(1L, 10L, 5L, "   "))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void createRejectsABodyOverThreeHundredCharacters() {
+        String tooLong = "x".repeat(301);
+
+        assertThatThrownBy(() -> clubPostCommentService.create(1L, 10L, 5L, tooLong))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void createAcceptsABodyOfExactlyThreeHundredCharacters() {
+        String exactlyMax = "x".repeat(300);
+        when(clubPostCommentWriter.lockCountAndInsert(1L, 10L, 5L, exactlyMax))
+            .thenReturn(new PublicClubPostComment());
+
+        clubPostCommentService.create(1L, 10L, 5L, exactlyMax);
+
+        verify(clubPostCommentWriter).lockCountAndInsert(1L, 10L, 5L, exactlyMax);
+    }
+
+    @Test
+    void createTrimsTheBodyBeforeDelegatingToTheWriter() {
+        when(clubPostCommentWriter.lockCountAndInsert(1L, 10L, 5L, "Nice!"))
+            .thenReturn(new PublicClubPostComment());
+
+        clubPostCommentService.create(1L, 10L, 5L, "  Nice!  ");
+
+        verify(clubPostCommentWriter).lockCountAndInsert(1L, 10L, 5L, "Nice!");
+    }
+
+    @Test
+    void createReturnsExactlyWhatTheWriterProduces() {
+        PublicClubPostComment created = new PublicClubPostComment();
+        created.setId(99L);
+        when(clubPostCommentWriter.lockCountAndInsert(1L, 10L, 5L, "Nice!")).thenReturn(created);
+
+        PublicClubPostComment result = clubPostCommentService.create(1L, 10L, 5L, "Nice!");
+
+        assertThat(result).isSameAs(created);
+    }
+
+    @Test
+    void findPublicCommentsDelegatesToTheMapper() {
+        PublicClubPostComment comment = new PublicClubPostComment();
+        when(clubPostMapper.findPublicCommentsByPostId(10L)).thenReturn(List.of(comment));
+
+        List<PublicClubPostComment> comments = clubPostCommentService.findPublicComments(10L);
+
+        assertThat(comments).containsExactly(comment);
+    }
+}

--- a/backend/src/test/java/com/example/demo/club/service/ClubPostCommentWriterTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubPostCommentWriterTest.java
@@ -1,0 +1,121 @@
+package com.example.demo.club.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.demo.club.mapper.ClubPostMapper;
+import com.example.demo.club.model.ClubPostComment;
+import com.example.demo.club.model.PublicClubPostComment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+
+class ClubPostCommentWriterTest {
+
+    private ClubPostMapper clubPostMapper;
+    private ClubPostCommentWriter clubPostCommentWriter;
+
+    @BeforeEach
+    void setUp() {
+        clubPostMapper = mock(ClubPostMapper.class);
+        clubPostCommentWriter = new ClubPostCommentWriter(clubPostMapper);
+        // Mirrors MyBatis's useGeneratedKeys behavior: insertComment() sets the generated id
+        // onto the same ClubPostComment instance it was given, which the read-back then looks
+        // up by.
+        doAnswer(invocation -> {
+            ClubPostComment comment = invocation.getArgument(0);
+            comment.setId(99L);
+            return 1;
+        }).when(clubPostMapper).insertComment(any());
+    }
+
+    // The issue's own "must not fall through to an unguarded insert" requirement: a missing
+    // post (or one belonging to a different club) means lockPostIdForUpdate finds no row and
+    // took no lock, so the count and insert must never run.
+    @Test
+    void lockCountAndInsertThrowsClubPostNotFoundWhenTheLockFindsNoRowAndNeverInserts() {
+        when(clubPostMapper.lockPostIdForUpdate(1L, 10L)).thenReturn(null);
+
+        assertThatThrownBy(() -> clubPostCommentWriter.lockCountAndInsert(10L, 1L, 5L, "Nice!"))
+            .isInstanceOf(ClubPostNotFoundException.class);
+
+        verify(clubPostMapper, never()).insertComment(any());
+    }
+
+    // The concurrency-cap requirement: the 51st comment must be rejected, never inserted.
+    @Test
+    void lockCountAndInsertThrowsCommentLimitExceededWhenTheCountIsAlreadyFiftyAndNeverInserts() {
+        when(clubPostMapper.lockPostIdForUpdate(1L, 10L)).thenReturn(1L);
+        when(clubPostMapper.countCommentsByPostId(1L)).thenReturn(50);
+
+        assertThatThrownBy(() -> clubPostCommentWriter.lockCountAndInsert(10L, 1L, 5L, "Nice!"))
+            .isInstanceOf(CommentLimitExceededException.class);
+
+        verify(clubPostMapper, never()).insertComment(any());
+    }
+
+    @Test
+    void lockCountAndInsertInsertsWhenTheCountIsBelowFifty() {
+        when(clubPostMapper.lockPostIdForUpdate(1L, 10L)).thenReturn(1L);
+        when(clubPostMapper.countCommentsByPostId(1L)).thenReturn(49);
+        PublicClubPostComment readBack = new PublicClubPostComment();
+        readBack.setBody("Nice!");
+        when(clubPostMapper.findPublicCommentByIdAndPostId(99L, 1L)).thenReturn(readBack);
+
+        clubPostCommentWriter.lockCountAndInsert(10L, 1L, 5L, "Nice!");
+
+        ArgumentCaptor<ClubPostComment> insertedComment = ArgumentCaptor.forClass(ClubPostComment.class);
+        verify(clubPostMapper).insertComment(insertedComment.capture());
+        assertThat(insertedComment.getValue().getPostId()).isEqualTo(1L);
+        assertThat(insertedComment.getValue().getAuthorOauthUserId()).isEqualTo(5L);
+        assertThat(insertedComment.getValue().getBody()).isEqualTo("Nice!");
+    }
+
+    @Test
+    void lockCountAndInsertReturnsExactlyWhatTheReadBackProduces() {
+        when(clubPostMapper.lockPostIdForUpdate(1L, 10L)).thenReturn(1L);
+        when(clubPostMapper.countCommentsByPostId(1L)).thenReturn(0);
+        PublicClubPostComment readBack = new PublicClubPostComment();
+        readBack.setId(99L);
+        readBack.setAuthorDisplayName("Ada Lovelace");
+        when(clubPostMapper.findPublicCommentByIdAndPostId(99L, 1L)).thenReturn(readBack);
+
+        PublicClubPostComment result = clubPostCommentWriter.lockCountAndInsert(10L, 1L, 5L, "Nice!");
+
+        assertThat(result).isSameAs(readBack);
+    }
+
+    @Test
+    void lockCountAndInsertThrowsWhenTheReadBackFindsNoRow() {
+        when(clubPostMapper.lockPostIdForUpdate(1L, 10L)).thenReturn(1L);
+        when(clubPostMapper.countCommentsByPostId(1L)).thenReturn(0);
+        when(clubPostMapper.findPublicCommentByIdAndPostId(99L, 1L)).thenReturn(null);
+
+        assertThatThrownBy(() -> clubPostCommentWriter.lockCountAndInsert(10L, 1L, 5L, "Nice!"))
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    // The exact ordering the issue's concurrency section demands: lock, then count, then insert,
+    // all as calls the mock can observe happening in that order.
+    @Test
+    void lockCountAndInsertLocksBeforeCountingBeforeInserting() {
+        when(clubPostMapper.lockPostIdForUpdate(1L, 10L)).thenReturn(1L);
+        when(clubPostMapper.countCommentsByPostId(1L)).thenReturn(0);
+        when(clubPostMapper.findPublicCommentByIdAndPostId(any(), any())).thenReturn(new PublicClubPostComment());
+
+        clubPostCommentWriter.lockCountAndInsert(10L, 1L, 5L, "Nice!");
+
+        InOrder order = inOrder(clubPostMapper);
+        order.verify(clubPostMapper).lockPostIdForUpdate(1L, 10L);
+        order.verify(clubPostMapper).countCommentsByPostId(1L);
+        order.verify(clubPostMapper).insertComment(any());
+    }
+}

--- a/backend/src/test/java/com/example/demo/club/service/ClubPostServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubPostServiceTest.java
@@ -11,8 +11,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.example.demo.club.mapper.ClubPostMapper;
 import com.example.demo.club.mapper.ClubMapper;
+import com.example.demo.club.mapper.ClubPostMapper;
 import com.example.demo.club.model.ClubPost;
 import com.example.demo.club.model.PublicClubPost;
 import java.io.IOException;
@@ -320,5 +320,26 @@ class ClubPostServiceTest {
             .isInstanceOf(IllegalArgumentException.class);
 
         verify(clubPostMapper, never()).unpin(any());
+    }
+
+    @Test
+    void findByIdAndClubIdDelegatesToTheMapper() {
+        ClubPost post = new ClubPost();
+        post.setId(9L);
+        when(clubPostMapper.findByIdAndClubId(9L, 1L)).thenReturn(post);
+
+        ClubPost result = clubPostService.findByIdAndClubId(9L, 1L);
+
+        assertThat(result).isSameAs(post);
+    }
+
+    @Test
+    void deleteDelegatesToTheWriter() {
+        ClubPost post = new ClubPost();
+        post.setId(9L);
+
+        clubPostService.delete(post);
+
+        verify(clubPostWriter).delete(post);
     }
 }

--- a/backend/src/test/java/com/example/demo/club/service/ClubPostWriterTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubPostWriterTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -14,16 +15,20 @@ import com.example.demo.club.model.PublicClubPost;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 class ClubPostWriterTest {
 
     private ClubPostMapper clubPostMapper;
+    private ImageStorageService imageStorageService;
     private ClubPostWriter clubPostWriter;
 
     @BeforeEach
     void setUp() {
         clubPostMapper = mock(ClubPostMapper.class);
-        clubPostWriter = new ClubPostWriter(clubPostMapper);
+        imageStorageService = mock(ImageStorageService.class);
+        clubPostWriter = new ClubPostWriter(clubPostMapper, imageStorageService);
         // Mirrors MyBatis's useGeneratedKeys behavior: insert() sets the generated id onto the
         // same ClubPost instance it was given, which the read-back then looks up by.
         doAnswer(invocation -> {
@@ -72,6 +77,73 @@ class ClubPostWriterTest {
 
         assertThatThrownBy(() ->
             clubPostWriter.insertAndReadBack(1L, 10L, "Meeting recap", "/uploads/club-posts/uuid.jpg"))
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    // TransactionSynchronizationManager only tracks synchronizations while a transaction is
+    // actually active; running the delete inside one here (rather than mocking Spring's
+    // transaction manager) is what proves delete() really does register the file removal
+    // against the surrounding transaction, not just call ImageStorageService directly.
+    private static void runInATestTransaction(Runnable action) {
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            action.run();
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
+    @Test
+    void deleteRemovesTheRowThroughTheMapper() {
+        when(clubPostMapper.delete(99L)).thenReturn(1);
+        ClubPost post = new ClubPost();
+        post.setId(99L);
+        post.setImageUrl("/uploads/club-posts/uuid.jpg");
+
+        runInATestTransaction(() -> clubPostWriter.delete(post));
+
+        verify(clubPostMapper).delete(99L);
+    }
+
+    @Test
+    void deleteDoesNotRemoveTheFileBeforeTheSynchronizationsAreTriggered() {
+        when(clubPostMapper.delete(99L)).thenReturn(1);
+        ClubPost post = new ClubPost();
+        post.setId(99L);
+        post.setImageUrl("/uploads/club-posts/uuid.jpg");
+
+        runInATestTransaction(() -> clubPostWriter.delete(post));
+
+        verify(imageStorageService, never()).delete(any());
+    }
+
+    // The transaction-boundary contract this exists for: a rolled-back delete must leave the
+    // file on disk, so the removal can only run from an afterCommit callback, never eagerly.
+    @Test
+    void deleteRemovesTheFileOnlyAfterTheTransactionCommits() {
+        when(clubPostMapper.delete(99L)).thenReturn(1);
+        ClubPost post = new ClubPost();
+        post.setId(99L);
+        post.setImageUrl("/uploads/club-posts/uuid.jpg");
+
+        runInATestTransaction(() -> {
+            clubPostWriter.delete(post);
+            for (TransactionSynchronization synchronization : TransactionSynchronizationManager.getSynchronizations()) {
+                synchronization.afterCommit();
+            }
+        });
+
+        verify(imageStorageService).delete("/uploads/club-posts/uuid.jpg");
+    }
+
+    @Test
+    void deleteThrowsWhenTheRowWasAlreadyGone() {
+        when(clubPostMapper.delete(99L)).thenReturn(0);
+        ClubPost post = new ClubPost();
+        post.setId(99L);
+        post.setImageUrl("/uploads/club-posts/uuid.jpg");
+
+        assertThatThrownBy(() -> runInATestTransaction(() -> clubPostWriter.delete(post)))
             .isInstanceOf(IllegalStateException.class);
     }
 }

--- a/backend/src/test/java/com/example/demo/club/service/ClubVisibilityPolicyTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubVisibilityPolicyTest.java
@@ -1,0 +1,85 @@
+package com.example.demo.club.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.example.demo.club.model.Club;
+import com.example.demo.security.AuthenticatedUserResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.Authentication;
+
+class ClubVisibilityPolicyTest {
+
+    private AuthenticatedUserResolver authenticatedUserResolver;
+    private ClubVisibilityPolicy clubVisibilityPolicy;
+    private Authentication authentication;
+
+    @BeforeEach
+    void setUp() {
+        authenticatedUserResolver = mock(AuthenticatedUserResolver.class);
+        clubVisibilityPolicy = new ClubVisibilityPolicy(authenticatedUserResolver);
+        authentication = mock(Authentication.class);
+    }
+
+    private static Club aClub(String status, Boolean viewerIsMember, Boolean canManage) {
+        Club club = new Club();
+        club.setStatus(status);
+        club.setViewerIsMember(viewerIsMember);
+        club.setCanManage(canManage);
+        return club;
+    }
+
+    @Test
+    void isVisibleToIsTrueForAnActiveClubRegardlessOfTheViewer() {
+        Club club = aClub("active", false, false);
+
+        assertThat(clubVisibilityPolicy.isVisibleTo(club, authentication)).isTrue();
+    }
+
+    @Test
+    void isVisibleToTreatsTheActiveStatusCaseInsensitively() {
+        Club club = aClub("ACTIVE", false, false);
+
+        assertThat(clubVisibilityPolicy.isVisibleTo(club, authentication)).isTrue();
+    }
+
+    @Test
+    void isVisibleToIsFalseForANonActiveClubToAnAnonymousOrUnrelatedViewer() {
+        Club club = aClub("pending", false, false);
+        when(authenticatedUserResolver.isPlatformOwner(authentication)).thenReturn(false);
+
+        assertThat(clubVisibilityPolicy.isVisibleTo(club, authentication)).isFalse();
+    }
+
+    @Test
+    void isVisibleToIsTrueForANonActiveClubToAMember() {
+        Club club = aClub("pending", true, false);
+
+        assertThat(clubVisibilityPolicy.isVisibleTo(club, authentication)).isTrue();
+    }
+
+    @Test
+    void isVisibleToIsTrueForANonActiveClubToThePresident() {
+        Club club = aClub("pending", false, true);
+
+        assertThat(clubVisibilityPolicy.isVisibleTo(club, authentication)).isTrue();
+    }
+
+    @Test
+    void isVisibleToIsTrueForANonActiveClubToAPlatformOwner() {
+        Club club = aClub("pending", false, false);
+        when(authenticatedUserResolver.isPlatformOwner(authentication)).thenReturn(true);
+
+        assertThat(clubVisibilityPolicy.isVisibleTo(club, authentication)).isTrue();
+    }
+
+    @Test
+    void isVisibleToTreatsANullStatusAsNotActive() {
+        Club club = aClub(null, false, false);
+        when(authenticatedUserResolver.isPlatformOwner(authentication)).thenReturn(false);
+
+        assertThat(clubVisibilityPolicy.isVisibleTo(club, authentication)).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Add public PII-safe comment reads and member-only comment publishing with a concurrency-safe 50-comment cap.
- Add author, president, and platform-owner deletion for comments and posts.
- Remove post images only after a successful database commit while preserving rollback safety.
- Centralize club visibility and content moderation decisions across post and comment endpoints.

## Verification

- `./mvnw test` (333 tests passed)
- Real H2 concurrency, lock-timeout, cascade, commit, and rollback tests passed
- Two independent review rounds completed; final verdict: patch is correct

Closes bangxiao0927/HSclubs#79

---
Generated by Codet
