### PR TITLE
Club media: add the public read-only media page

### DIFF
--- a/backend/src/main/java/com/example/demo/club/mapper/EpochSecondsInstantTypeHandler.java
+++ b/backend/src/main/java/com/example/demo/club/mapper/EpochSecondsInstantTypeHandler.java
@@ -1,0 +1,56 @@
+package com.example.demo.club.mapper;
+
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedTypes;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+
+/**
+ * Binds a {@code UNIX_TIMESTAMP(...)} SQL expression (whole seconds since the epoch) to an
+ * {@link Instant}, deliberately bypassing the JDBC driver's own TIMESTAMP-to-LocalDateTime
+ * conversion machinery. That conversion is what made {@code PublicClubPost#createdAt} ambiguous
+ * (see ClubPostMapper.xml's {@code PublicPostColumnList}): MySQL's TIMESTAMP columns are always
+ * stored as a true UTC instant internally, and {@code UNIX_TIMESTAMP(...)} is the exact inverse
+ * of whatever {@code CURRENT_TIMESTAMP} wrote, regardless of the connection's session
+ * {@code time_zone} or the JDBC URL's {@code serverTimezone} parameter (documented in
+ * application.yaml as {@code Asia/Shanghai}) -- neither has to be known, correct, or even
+ * consistent with the other for this value to come out right. H2 (used by the test suite)
+ * round-trips the same way using the JVM's own default zone for both {@code CURRENT_TIMESTAMP}
+ * and {@code UNIX_TIMESTAMP}, so this is correct there too without any test-only special-casing.
+ *
+ * <p>Only bound explicitly on {@code PublicClubPost#createdAt} (see the {@code typeHandler}
+ * attribute on that one {@code <result>} mapping) rather than registered globally, so every
+ * other {@code LocalDateTime}-mapped timestamp in this codebase is untouched.
+ */
+@MappedTypes(Instant.class)
+public class EpochSecondsInstantTypeHandler extends BaseTypeHandler<Instant> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, Instant parameter, JdbcType jdbcType)
+            throws SQLException {
+        ps.setLong(i, parameter.getEpochSecond());
+    }
+
+    @Override
+    public Instant getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        long epochSeconds = rs.getLong(columnName);
+        return rs.wasNull() ? null : Instant.ofEpochSecond(epochSeconds);
+    }
+
+    @Override
+    public Instant getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        long epochSeconds = rs.getLong(columnIndex);
+        return rs.wasNull() ? null : Instant.ofEpochSecond(epochSeconds);
+    }
+
+    @Override
+    public Instant getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        long epochSeconds = cs.getLong(columnIndex);
+        return cs.wasNull() ? null : Instant.ofEpochSecond(epochSeconds);
+    }
+}

--- a/backend/src/main/java/com/example/demo/club/mapper/EpochSecondsInstantTypeHandler.java
+++ b/backend/src/main/java/com/example/demo/club/mapper/EpochSecondsInstantTypeHandler.java
@@ -23,9 +23,11 @@ import java.time.Instant;
  * round-trips the same way using the JVM's own default zone for both {@code CURRENT_TIMESTAMP}
  * and {@code UNIX_TIMESTAMP}, so this is correct there too without any test-only special-casing.
  *
- * <p>Only bound explicitly on {@code PublicClubPost#createdAt} (see the {@code typeHandler}
- * attribute on that one {@code <result>} mapping) rather than registered globally, so every
- * other {@code LocalDateTime}-mapped timestamp in this codebase is untouched.
+ * <p>Only bound explicitly on {@code PublicClubPost#createdAt} and
+ * {@code PublicClubPostComment#createdAt} (see the {@code typeHandler} attribute on those two
+ * {@code <result>} mappings) rather than registered globally, so every other
+ * {@code LocalDateTime}-mapped timestamp in this codebase -- including the internal
+ * {@code ClubPost}/{@code ClubPostComment} models these two DTOs project from -- is untouched.
  */
 @MappedTypes(Instant.class)
 public class EpochSecondsInstantTypeHandler extends BaseTypeHandler<Instant> {

--- a/backend/src/main/java/com/example/demo/club/model/PublicClubPost.java
+++ b/backend/src/main/java/com/example/demo/club/model/PublicClubPost.java
@@ -1,5 +1,6 @@
 package com.example.demo.club.model;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 /**
@@ -9,6 +10,14 @@ import java.time.LocalDateTime;
  * {@code role}, {@code accepted_terms_at}, the user's {@code created_at}/{@code last_login_at},
  * or {@code graduation_year}. See ClubPostMapperTest for the regression test that a wildcard
  * select or a copied result map cannot silently reintroduce one of those columns here.
+ *
+ * <p>{@code createdAt} is an {@link Instant}, not a {@link LocalDateTime} like every other
+ * timestamp in this codebase: it is the one timestamp this API exposes to anonymous, possibly
+ * cross-timezone callers, so it is serialized as an unambiguous, offset-bearing instant (Jackson
+ * writes {@code Instant} as ISO-8601 with a trailing {@code Z}) rather than a timezone-naive
+ * wall-clock string a browser could misinterpret as its own local time. See
+ * {@code EpochSecondsInstantTypeHandler} for how the mapper populates it correctly regardless of
+ * the JDBC driver's own timezone conversion.
  */
 public class PublicClubPost {
 
@@ -17,7 +26,7 @@ public class PublicClubPost {
     private String title;
     private String imageUrl;
     private LocalDateTime pinnedAt;
-    private LocalDateTime createdAt;
+    private Instant createdAt;
     private String authorDisplayName;
     private String authorAvatarUrl;
 
@@ -66,11 +75,11 @@ public class PublicClubPost {
         this.pinnedAt = pinnedAt;
     }
 
-    public LocalDateTime getCreatedAt() {
+    public Instant getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(LocalDateTime createdAt) {
+    public void setCreatedAt(Instant createdAt) {
         this.createdAt = createdAt;
     }
 

--- a/backend/src/main/java/com/example/demo/club/model/PublicClubPost.java
+++ b/backend/src/main/java/com/example/demo/club/model/PublicClubPost.java
@@ -21,6 +21,11 @@ public class PublicClubPost {
     private String authorDisplayName;
     private String authorAvatarUrl;
 
+    // A correlated COUNT(*) against club_post_comment (see ClubPostMapper.xml's
+    // PublicPostColumnList), never a join: a join against club_post_comment would multiply
+    // this row once per comment instead of contributing a single count.
+    private int commentCount;
+
     public Long getId() {
         return id;
     }
@@ -83,5 +88,13 @@ public class PublicClubPost {
 
     public void setAuthorAvatarUrl(String authorAvatarUrl) {
         this.authorAvatarUrl = authorAvatarUrl;
+    }
+
+    public int getCommentCount() {
+        return commentCount;
+    }
+
+    public void setCommentCount(int commentCount) {
+        this.commentCount = commentCount;
     }
 }

--- a/backend/src/main/java/com/example/demo/club/model/PublicClubPostComment.java
+++ b/backend/src/main/java/com/example/demo/club/model/PublicClubPostComment.java
@@ -1,6 +1,6 @@
 package com.example.demo.club.model;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 /**
  * Public projection of a {@link ClubPostComment} for the anonymous, unauthenticated comments
@@ -9,13 +9,20 @@ import java.time.LocalDateTime;
  * {@code author_oauth_user_id}, {@code provider}, {@code provider_user_id}, {@code role},
  * {@code accepted_terms_at}, the user's {@code created_at}/{@code last_login_at}, or
  * {@code graduation_year}.
+ *
+ * <p>{@code createdAt} is an {@link Instant}, mirroring {@link PublicClubPost#getCreatedAt()}:
+ * this is the other timestamp this API exposes to anonymous, possibly cross-timezone callers,
+ * so it is serialized as an unambiguous, offset-bearing instant rather than the timezone-naive
+ * {@link java.time.LocalDateTime} {@link ClubPostComment#getCreatedAt()} still uses internally.
+ * See {@code EpochSecondsInstantTypeHandler} for how the mapper populates it correctly
+ * regardless of the JDBC driver's own timezone conversion.
  */
 public class PublicClubPostComment {
 
     private Long id;
     private Long postId;
     private String body;
-    private LocalDateTime createdAt;
+    private Instant createdAt;
     private String authorDisplayName;
     private String authorAvatarUrl;
 
@@ -43,11 +50,11 @@ public class PublicClubPostComment {
         this.body = body;
     }
 
-    public LocalDateTime getCreatedAt() {
+    public Instant getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(LocalDateTime createdAt) {
+    public void setCreatedAt(Instant createdAt) {
         this.createdAt = createdAt;
     }
 

--- a/backend/src/main/resources/mapper/ClubPostMapper.xml
+++ b/backend/src/main/resources/mapper/ClubPostMapper.xml
@@ -55,6 +55,7 @@
         <result column="created_at" property="createdAt" />
         <result column="author_display_name" property="authorDisplayName" />
         <result column="author_avatar_url" property="authorAvatarUrl" />
+        <result column="comment_count" property="commentCount" />
     </resultMap>
 
     <!-- Shared by findPublicFeedByClubId and findPublicPostByIdAndClubId so a freshly published
@@ -63,7 +64,8 @@
     <sql id="PublicPostColumnList">
         cp.id, cp.club_id, cp.title, cp.image_url, cp.pinned_at, cp.created_at,
         ou.display_name AS author_display_name,
-        ou.avatar_url   AS author_avatar_url
+        ou.avatar_url   AS author_avatar_url,
+        (SELECT COUNT(*) FROM club_post_comment cpc WHERE cpc.post_id = cp.id) AS comment_count
     </sql>
 
     <!-- Deliberately not a wildcard select and not a reuse of ClubMemberView's/

--- a/backend/src/main/resources/mapper/ClubPostMapper.xml
+++ b/backend/src/main/resources/mapper/ClubPostMapper.xml
@@ -52,7 +52,8 @@
         <result column="title" property="title" />
         <result column="image_url" property="imageUrl" />
         <result column="pinned_at" property="pinnedAt" />
-        <result column="created_at" property="createdAt" />
+        <result column="created_at" property="createdAt"
+                typeHandler="com.example.demo.club.mapper.EpochSecondsInstantTypeHandler" />
         <result column="author_display_name" property="authorDisplayName" />
         <result column="author_avatar_url" property="authorAvatarUrl" />
         <result column="comment_count" property="commentCount" />
@@ -60,9 +61,16 @@
 
     <!-- Shared by findPublicFeedByClubId and findPublicPostByIdAndClubId so a freshly published
          post reads back in exactly the same safe shape a feed item has: never author_oauth_
-         user_id or any other oauth_users column. -->
+         user_id or any other oauth_users column.
+
+         cp.created_at is deliberately read through UNIX_TIMESTAMP(...) rather than passed
+         through as-is: see EpochSecondsInstantTypeHandler's Javadoc for why that (not the raw
+         column) is what makes PublicClubPost#createdAt an unambiguous instant instead of a
+         wall-clock reading a browser in a different timezone could misread as its own local
+         time. -->
     <sql id="PublicPostColumnList">
-        cp.id, cp.club_id, cp.title, cp.image_url, cp.pinned_at, cp.created_at,
+        cp.id, cp.club_id, cp.title, cp.image_url, cp.pinned_at,
+        UNIX_TIMESTAMP(cp.created_at) AS created_at,
         ou.display_name AS author_display_name,
         ou.avatar_url   AS author_avatar_url,
         (SELECT COUNT(*) FROM club_post_comment cpc WHERE cpc.post_id = cp.id) AS comment_count

--- a/backend/src/main/resources/mapper/ClubPostMapper.xml
+++ b/backend/src/main/resources/mapper/ClubPostMapper.xml
@@ -167,15 +167,23 @@
         <id column="id" property="id" />
         <result column="post_id" property="postId" />
         <result column="body" property="body" />
-        <result column="created_at" property="createdAt" />
+        <result column="created_at" property="createdAt"
+                typeHandler="com.example.demo.club.mapper.EpochSecondsInstantTypeHandler" />
         <result column="author_display_name" property="authorDisplayName" />
         <result column="author_avatar_url" property="authorAvatarUrl" />
     </resultMap>
 
     <!-- Shared by findPublicCommentsByPostId and findPublicCommentByIdAndPostId, mirroring
-         PublicPostColumnList: never author_oauth_user_id or any other oauth_users column. -->
+         PublicPostColumnList: never author_oauth_user_id or any other oauth_users column.
+
+         cpc.created_at is deliberately read through UNIX_TIMESTAMP(...), exactly like
+         PublicPostColumnList's cp.created_at: see EpochSecondsInstantTypeHandler's Javadoc for
+         why that is what makes PublicClubPostComment#createdAt an unambiguous instant instead
+         of a wall-clock reading a browser in a different timezone could misread as its own
+         local time. -->
     <sql id="PublicCommentColumnList">
-        cpc.id, cpc.post_id, cpc.body, cpc.created_at,
+        cpc.id, cpc.post_id, cpc.body,
+        UNIX_TIMESTAMP(cpc.created_at) AS created_at,
         ou.display_name AS author_display_name,
         ou.avatar_url   AS author_avatar_url
     </sql>

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostCommentAndDeletionIntegrationTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostCommentAndDeletionIntegrationTest.java
@@ -22,7 +22,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.TimeZone;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -338,29 +337,29 @@ class ClubPostCommentAndDeletionIntegrationTest {
 
     // Mirrors ClubPostFeedIntegrationTest's equivalent post-level test: a comment posted "just
     // now" (DB default CURRENT_TIMESTAMP, no literal override) must serialize as an instant
-    // close to the real Instant.now(), never shifted hours away, even when the JVM's own
-    // default timezone is a real, non-UTC one.
+    // close to the real Instant.now(), never shifted hours away.
+    //
+    // No TimeZone.setDefault() here: this property holds regardless of timezone by
+    // construction (UNIX_TIMESTAMP inverts CURRENT_TIMESTAMP within the same session no matter
+    // which zone is actually in effect), and see ClubPostMapperTest's literal round-trip tests
+    // for why an in-test override would not reliably change H2's already-established session
+    // zone anyway. Running this suite under both this repo's normal non-UTC local/dev
+    // environment and an explicit `TZ=UTC` (CI-like) process both exercise this meaningfully.
     @Test
-    void justPostedCommentsCreatedAtIsCloseToNowRegardlessOfTheJvmDefaultTimeZone() throws Exception {
-        TimeZone originalDefault = TimeZone.getDefault();
-        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Shanghai"));
-        try {
-            long clubId = createClub();
-            long authorUid = insertOauthUser(MEMBER_EMAIL, "Ada Lovelace");
-            addMember(clubId, authorUid, "member");
-            long postId = insertPost(clubId, authorUid, writeStoredPhoto());
-            insertComment(postId, authorUid, "Fresh comment");
+    void justPostedCommentsCreatedAtIsCloseToNow() throws Exception {
+        long clubId = createClub();
+        long authorUid = insertOauthUser(MEMBER_EMAIL, "Ada Lovelace");
+        addMember(clubId, authorUid, "member");
+        long postId = insertPost(clubId, authorUid, writeStoredPhoto());
+        insertComment(postId, authorUid, "Fresh comment");
 
-            String responseBody = mockMvc.perform(get("/api/clubs/" + clubId + "/posts/" + postId + "/comments"))
-                .andExpect(status().isOk())
-                .andReturn().getResponse().getContentAsString();
+        String responseBody = mockMvc.perform(get("/api/clubs/" + clubId + "/posts/" + postId + "/comments"))
+            .andExpect(status().isOk())
+            .andReturn().getResponse().getContentAsString();
 
-            String createdAt = extractJsonStringField(responseBody, "createdAt");
-            assertThat(createdAt).endsWith("Z");
-            assertThat(Instant.parse(createdAt)).isCloseTo(Instant.now(), within(5, ChronoUnit.SECONDS));
-        } finally {
-            TimeZone.setDefault(originalDefault);
-        }
+        String createdAt = extractJsonStringField(responseBody, "createdAt");
+        assertThat(createdAt).endsWith("Z");
+        assertThat(Instant.parse(createdAt)).isCloseTo(Instant.now(), within(5, ChronoUnit.SECONDS));
     }
 
     @Test

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostCommentAndDeletionIntegrationTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostCommentAndDeletionIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.example.demo.club.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
@@ -16,9 +17,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.PreparedStatement;
 import java.sql.Statement;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -166,6 +170,13 @@ class ClubPostCommentAndDeletionIntegrationTest {
         Map<String, Object> keys = keyHolder.getKeys();
         Object idValue = keys.containsKey(columnName) ? keys.get(columnName) : keys.get(columnName.toUpperCase(Locale.ROOT));
         return ((Number) idValue).longValue();
+    }
+
+    private static String extractJsonStringField(String json, String field) {
+        String needle = "\"" + field + "\":\"";
+        int start = json.indexOf(needle) + needle.length();
+        int end = json.indexOf('"', start);
+        return json.substring(start, end);
     }
 
     private int countPostRows(long postId) {
@@ -323,6 +334,33 @@ class ClubPostCommentAndDeletionIntegrationTest {
 
         assertThat(responseBody).doesNotContain("\"email\"");
         assertThat(responseBody).doesNotContain("@");
+    }
+
+    // Mirrors ClubPostFeedIntegrationTest's equivalent post-level test: a comment posted "just
+    // now" (DB default CURRENT_TIMESTAMP, no literal override) must serialize as an instant
+    // close to the real Instant.now(), never shifted hours away, even when the JVM's own
+    // default timezone is a real, non-UTC one.
+    @Test
+    void justPostedCommentsCreatedAtIsCloseToNowRegardlessOfTheJvmDefaultTimeZone() throws Exception {
+        TimeZone originalDefault = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Shanghai"));
+        try {
+            long clubId = createClub();
+            long authorUid = insertOauthUser(MEMBER_EMAIL, "Ada Lovelace");
+            addMember(clubId, authorUid, "member");
+            long postId = insertPost(clubId, authorUid, writeStoredPhoto());
+            insertComment(postId, authorUid, "Fresh comment");
+
+            String responseBody = mockMvc.perform(get("/api/clubs/" + clubId + "/posts/" + postId + "/comments"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+            String createdAt = extractJsonStringField(responseBody, "createdAt");
+            assertThat(createdAt).endsWith("Z");
+            assertThat(Instant.parse(createdAt)).isCloseTo(Instant.now(), within(5, ChronoUnit.SECONDS));
+        } finally {
+            TimeZone.setDefault(originalDefault);
+        }
     }
 
     @Test

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostCommentControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostCommentControllerTest.java
@@ -26,7 +26,7 @@ import com.example.demo.club.service.ClubService;
 import com.example.demo.club.service.ClubVisibilityPolicy;
 import com.example.demo.club.service.CommentLimitExceededException;
 import com.example.demo.security.AuthenticatedUserResolver;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -220,7 +220,7 @@ class ClubPostCommentControllerTest {
         PublicClubPostComment created = new PublicClubPostComment();
         created.setId(5L);
         created.setBody("Nice!");
-        created.setCreatedAt(LocalDateTime.of(2024, 1, 1, 10, 0));
+        created.setCreatedAt(Instant.parse("2024-01-01T10:00:00Z"));
         created.setAuthorDisplayName("Ada Lovelace");
         when(clubPostCommentService.create(1L, 9L, 42L, "Nice!")).thenReturn(created);
 
@@ -231,6 +231,7 @@ class ClubPostCommentControllerTest {
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.id").value(5))
             .andExpect(jsonPath("$.body").value("Nice!"))
+            .andExpect(jsonPath("$.createdAt").value("2024-01-01T10:00:00Z"))
             .andExpect(jsonPath("$.authorDisplayName").value("Ada Lovelace"))
             .andReturn().getResponse().getContentAsString();
 

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostControllerTest.java
@@ -25,7 +25,7 @@ import com.example.demo.club.service.ClubService;
 import com.example.demo.club.service.ClubVisibilityPolicy;
 import com.example.demo.security.AuthenticatedUserResolver;
 import java.io.IOException;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -139,7 +139,7 @@ class ClubPostControllerTest {
         created.setClubId(1L);
         created.setTitle("Meeting recap");
         created.setImageUrl("/uploads/club-posts/uuid.jpg");
-        created.setCreatedAt(LocalDateTime.of(2024, 1, 1, 10, 0));
+        created.setCreatedAt(Instant.parse("2024-01-01T10:00:00Z"));
         created.setAuthorDisplayName("Ada Lovelace");
         created.setAuthorAvatarUrl("/uploads/avatar-cache/ada.jpg");
         when(clubPostService.publish(eq(1L), eq(42L), eq("Meeting recap"), any())).thenReturn(created);
@@ -152,7 +152,7 @@ class ClubPostControllerTest {
             .andExpect(jsonPath("$.id").value(9))
             .andExpect(jsonPath("$.title").value("Meeting recap"))
             .andExpect(jsonPath("$.imageUrl").value("/uploads/club-posts/uuid.jpg"))
-            .andExpect(jsonPath("$.createdAt").exists())
+            .andExpect(jsonPath("$.createdAt").value("2024-01-01T10:00:00Z"))
             .andExpect(jsonPath("$.authorDisplayName").value("Ada Lovelace"))
             .andExpect(jsonPath("$.authorAvatarUrl").value("/uploads/avatar-cache/ada.jpg"))
             .andReturn().getResponse().getContentAsString();

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostControllerTest.java
@@ -258,6 +258,23 @@ class ClubPostControllerTest {
     }
 
     @Test
+    void feedItemsCarryTheirCommentCount() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setStatus("active");
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        PublicClubPost post = new PublicClubPost();
+        post.setId(9L);
+        post.setCommentCount(3);
+        when(clubPostService.findPublicFeed(eq(1L), anyInt(), anyInt()))
+            .thenReturn(new ClubPostService.PostFeedPage(List.of(post), 0, 12, 1));
+
+        mockMvc.perform(get("/api/clubs/1/posts"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.items[0].commentCount").value(3));
+    }
+
+    @Test
     void feedReturnsNotFoundForAnUnknownClub() throws Exception {
         when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(null);
 

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostFeedIntegrationTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostFeedIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.example.demo.club.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -23,11 +24,14 @@ import java.nio.file.Path;
 import java.sql.PreparedStatement;
 import java.sql.Statement;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
+import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.imageio.IIOImage;
@@ -295,6 +299,31 @@ class ClubPostFeedIntegrationTest {
 
         assertThat(responseBody).contains("\"commentCount\":2");
         assertThat(responseBody).contains("\"commentCount\":0");
+    }
+
+    // Full-stack regression for the same bug ClubPostMapperTest guards at the mapper layer: a
+    // post created "just now" (DB default CURRENT_TIMESTAMP, no literal override) must serialize
+    // as an instant close to the real Instant.now(), never shifted hours away, even when the
+    // JVM's own default timezone is a real, non-UTC one -- proving the whole mapper-to-JSON
+    // pipeline, not just the mapper in isolation.
+    @Test
+    void justCreatedPostsCreatedAtIsCloseToNowRegardlessOfTheJvmDefaultTimeZone() throws Exception {
+        TimeZone originalDefault = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Shanghai"));
+        try {
+            long clubId = createActiveClubWithAMember();
+            insertPost(clubId, "Fresh post", null);
+
+            String responseBody = mockMvc.perform(get("/api/clubs/" + clubId + "/posts"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+            String createdAt = extractJsonStringField(responseBody, "createdAt");
+            assertThat(createdAt).endsWith("Z");
+            assertThat(Instant.parse(createdAt)).isCloseTo(Instant.now(), within(5, ChronoUnit.SECONDS));
+        } finally {
+            TimeZone.setDefault(originalDefault);
+        }
     }
 
     @Test

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostFeedIntegrationTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostFeedIntegrationTest.java
@@ -279,6 +279,24 @@ class ClubPostFeedIntegrationTest {
             .andExpect(jsonPath("$.items[0].authorAvatarUrl").value("/uploads/avatar-cache/ada.jpg"));
     }
 
+    // Real DB, real join: proves the correlated subquery in ClubPostMapper.xml's
+    // PublicPostColumnList counts only that post's own comments, not every comment on the club.
+    @Test
+    void feedItemCommentCountReflectsOnlyThatPostsOwnComments() throws Exception {
+        long clubId = createActiveClubWithAMember();
+        long firstPostId = insertPost(clubId, "Post with comments", null);
+        insertPost(clubId, "Post with no comments", null);
+        insertComment(firstPostId, "First comment");
+        insertComment(firstPostId, "Second comment");
+
+        String responseBody = mockMvc.perform(get("/api/clubs/" + clubId + "/posts"))
+            .andExpect(status().isOk())
+            .andReturn().getResponse().getContentAsString();
+
+        assertThat(responseBody).contains("\"commentCount\":2");
+        assertThat(responseBody).contains("\"commentCount\":0");
+    }
+
     @Test
     void pinnedPostsSortToTheFrontExactlyOnce() throws Exception {
         long clubId = createActiveClubWithAMember();
@@ -383,6 +401,14 @@ class ClubPostFeedIntegrationTest {
             return statement;
         }, keyHolder);
         return extractId(keyHolder);
+    }
+
+    private void insertComment(long postId, String body) {
+        long authorUid = jdbcTemplate.queryForObject(
+            "SELECT author_oauth_user_id FROM club_post WHERE id = ?", Long.class, postId);
+        jdbcTemplate.update(
+            "INSERT INTO club_post_comment (post_id, author_oauth_user_id, body) VALUES (?, ?, ?)",
+            postId, authorUid, body);
     }
 
     // H2 reports every column with a default (id, created_at, updated_at) as "generated" here,

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostFeedIntegrationTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostFeedIntegrationTest.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
-import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.imageio.IIOImage;
@@ -303,27 +302,28 @@ class ClubPostFeedIntegrationTest {
 
     // Full-stack regression for the same bug ClubPostMapperTest guards at the mapper layer: a
     // post created "just now" (DB default CURRENT_TIMESTAMP, no literal override) must serialize
-    // as an instant close to the real Instant.now(), never shifted hours away, even when the
-    // JVM's own default timezone is a real, non-UTC one -- proving the whole mapper-to-JSON
-    // pipeline, not just the mapper in isolation.
+    // as an instant close to the real Instant.now(), never shifted hours away -- proving the
+    // whole mapper-to-JSON pipeline, not just the mapper in isolation.
+    //
+    // This asserts a property that holds regardless of timezone by construction: UNIX_TIMESTAMP
+    // and CURRENT_TIMESTAMP are session-consistent inverses of each other no matter which zone
+    // is actually in effect, so there is nothing to force here (see ClubPostMapperTest's literal
+    // round-trip tests for why TimeZone.setDefault() would not reliably change H2's already-
+    // established session zone anyway). Running this suite under both this repo's normal
+    // non-UTC local/dev environment and an explicit `TZ=UTC` (CI-like) process both exercise
+    // this test meaningfully, without needing an in-test override.
     @Test
-    void justCreatedPostsCreatedAtIsCloseToNowRegardlessOfTheJvmDefaultTimeZone() throws Exception {
-        TimeZone originalDefault = TimeZone.getDefault();
-        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Shanghai"));
-        try {
-            long clubId = createActiveClubWithAMember();
-            insertPost(clubId, "Fresh post", null);
+    void justCreatedPostsCreatedAtIsCloseToNow() throws Exception {
+        long clubId = createActiveClubWithAMember();
+        insertPost(clubId, "Fresh post", null);
 
-            String responseBody = mockMvc.perform(get("/api/clubs/" + clubId + "/posts"))
-                .andExpect(status().isOk())
-                .andReturn().getResponse().getContentAsString();
+        String responseBody = mockMvc.perform(get("/api/clubs/" + clubId + "/posts"))
+            .andExpect(status().isOk())
+            .andReturn().getResponse().getContentAsString();
 
-            String createdAt = extractJsonStringField(responseBody, "createdAt");
-            assertThat(createdAt).endsWith("Z");
-            assertThat(Instant.parse(createdAt)).isCloseTo(Instant.now(), within(5, ChronoUnit.SECONDS));
-        } finally {
-            TimeZone.setDefault(originalDefault);
-        }
+        String createdAt = extractJsonStringField(responseBody, "createdAt");
+        assertThat(createdAt).endsWith("Z");
+        assertThat(Instant.parse(createdAt)).isCloseTo(Instant.now(), within(5, ChronoUnit.SECONDS));
     }
 
     @Test

--- a/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
+++ b/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
@@ -6,7 +6,11 @@ import com.example.demo.club.model.ClubPost;
 import com.example.demo.club.model.ClubPostComment;
 import com.example.demo.club.model.PublicClubPost;
 import com.example.demo.club.model.PublicClubPostComment;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
+import java.util.TimeZone;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -464,6 +468,31 @@ class ClubPostMapperTest {
         PublicClubPost post = clubPostMapper.findPublicPostByIdAndClubId(1L, 2L);
 
         assertThat(post).isNull();
+    }
+
+    // The regression this guards: PublicClubPost#createdAt used to be a bare LocalDateTime, a
+    // timezone-naive wall-clock reading a browser could misparse as its own local time, making a
+    // just-created post appear hours in the future. Forcing a real, non-UTC JVM default zone here
+    // (rather than relying on whichever zone happens to run this suite) proves the mapper's
+    // UNIX_TIMESTAMP round-trip produces the correct instant regardless of that zone: the DB
+    // write is a literal wall-clock string, so the only zone-dependent step is the read, and
+    // EpochSecondsInstantTypeHandler must invert it correctly.
+    @Test
+    void findPublicPostByIdAndClubIdReturnsAnUnambiguousInstantRegardlessOfTheJvmDefaultTimeZone() {
+        TimeZone originalDefault = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+        try {
+            insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+
+            PublicClubPost post = clubPostMapper.findPublicPostByIdAndClubId(1L, 1L);
+
+            Instant expected = LocalDateTime.of(2024, 1, 1, 10, 0)
+                .atZone(ZoneId.of("America/Los_Angeles"))
+                .toInstant();
+            assertThat(post.getCreatedAt()).isEqualTo(expected);
+        } finally {
+            TimeZone.setDefault(originalDefault);
+        }
     }
 
     @Test

--- a/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
+++ b/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
@@ -10,7 +10,6 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
-import java.util.TimeZone;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -345,27 +344,22 @@ class ClubPostMapperTest {
         assertThat(clubPostMapper.findPublicCommentByIdAndPostId(1L, 2L)).isNull();
     }
 
-    // Mirrors findPublicPostByIdAndClubIdReturnsAnUnambiguousInstantRegardlessOfTheJvmDefaultTimeZone:
+    // Mirrors findPublicPostByIdAndClubIdConvertsALiteralCreatedAtUsingTheEffectiveSystemZone:
     // PublicClubPostComment#createdAt is on the same UNIX_TIMESTAMP/EpochSecondsInstantTypeHandler
-    // contract as PublicClubPost#createdAt, so it must round-trip to the correct instant under a
-    // forced, non-UTC JVM default zone too.
+    // contract as PublicClubPost#createdAt, so it must round-trip to the correct instant too --
+    // see that test's comment for why this derives the expected value from
+    // ZoneId.systemDefault() rather than attempting to force one with TimeZone.setDefault().
     @Test
-    void findPublicCommentByIdAndPostIdReturnsAnUnambiguousInstantRegardlessOfTheJvmDefaultTimeZone() {
-        TimeZone originalDefault = TimeZone.getDefault();
-        TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
-        try {
-            insertPost(1L, 1L, "2024-01-01 10:00:00", null);
-            insertCommentAt(1L, 1L, "Great photo!", "2024-01-01 11:30:00");
+    void findPublicCommentByIdAndPostIdConvertsALiteralCreatedAtUsingTheEffectiveSystemZone() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        insertCommentAt(1L, 1L, "Great photo!", "2024-01-01 11:30:00");
 
-            PublicClubPostComment comment = clubPostMapper.findPublicCommentByIdAndPostId(1L, 1L);
+        PublicClubPostComment comment = clubPostMapper.findPublicCommentByIdAndPostId(1L, 1L);
 
-            Instant expected = LocalDateTime.of(2024, 1, 1, 11, 30)
-                .atZone(ZoneId.of("America/Los_Angeles"))
-                .toInstant();
-            assertThat(comment.getCreatedAt()).isEqualTo(expected);
-        } finally {
-            TimeZone.setDefault(originalDefault);
-        }
+        Instant expected = LocalDateTime.of(2024, 1, 1, 11, 30)
+            .atZone(ZoneId.systemDefault())
+            .toInstant();
+        assertThat(comment.getCreatedAt()).isEqualTo(expected);
     }
 
     @Test
@@ -495,27 +489,28 @@ class ClubPostMapperTest {
 
     // The regression this guards: PublicClubPost#createdAt used to be a bare LocalDateTime, a
     // timezone-naive wall-clock reading a browser could misparse as its own local time, making a
-    // just-created post appear hours in the future. Forcing a real, non-UTC JVM default zone here
-    // (rather than relying on whichever zone happens to run this suite) proves the mapper's
-    // UNIX_TIMESTAMP round-trip produces the correct instant regardless of that zone: the DB
-    // write is a literal wall-clock string, so the only zone-dependent step is the read, and
-    // EpochSecondsInstantTypeHandler must invert it correctly.
+    // just-created post appear hours in the future.
+    //
+    // This does NOT force a specific zone with TimeZone.setDefault(): H2 resolves its own
+    // date/time functions against the JVM's default zone at (or before) connection setup, so a
+    // TimeZone.setDefault() call from inside a @Test method that runs after the connection
+    // pool/DataSource already exists has no effect on H2's CURRENT_TIMESTAMP/UNIX_TIMESTAMP --
+    // provably so: with that override in place, running this suite under an actual `TZ=UTC`
+    // process still produced UTC-derived instants, not America/Los_Angeles-derived ones. Instead
+    // this derives the expected instant from ZoneId.systemDefault(), the zone that is actually
+    // in effect, so the assertion is correct under whatever real zone the process runs with --
+    // exercised as both a genuinely non-UTC zone (this suite's normal local/dev environment) and
+    // UTC (this suite run with `TZ=UTC`, matching CI).
     @Test
-    void findPublicPostByIdAndClubIdReturnsAnUnambiguousInstantRegardlessOfTheJvmDefaultTimeZone() {
-        TimeZone originalDefault = TimeZone.getDefault();
-        TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
-        try {
-            insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+    void findPublicPostByIdAndClubIdConvertsALiteralCreatedAtUsingTheEffectiveSystemZone() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
 
-            PublicClubPost post = clubPostMapper.findPublicPostByIdAndClubId(1L, 1L);
+        PublicClubPost post = clubPostMapper.findPublicPostByIdAndClubId(1L, 1L);
 
-            Instant expected = LocalDateTime.of(2024, 1, 1, 10, 0)
-                .atZone(ZoneId.of("America/Los_Angeles"))
-                .toInstant();
-            assertThat(post.getCreatedAt()).isEqualTo(expected);
-        } finally {
-            TimeZone.setDefault(originalDefault);
-        }
+        Instant expected = LocalDateTime.of(2024, 1, 1, 10, 0)
+            .atZone(ZoneId.systemDefault())
+            .toInstant();
+        assertThat(post.getCreatedAt()).isEqualTo(expected);
     }
 
     @Test

--- a/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
+++ b/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
@@ -345,6 +345,29 @@ class ClubPostMapperTest {
         assertThat(clubPostMapper.findPublicCommentByIdAndPostId(1L, 2L)).isNull();
     }
 
+    // Mirrors findPublicPostByIdAndClubIdReturnsAnUnambiguousInstantRegardlessOfTheJvmDefaultTimeZone:
+    // PublicClubPostComment#createdAt is on the same UNIX_TIMESTAMP/EpochSecondsInstantTypeHandler
+    // contract as PublicClubPost#createdAt, so it must round-trip to the correct instant under a
+    // forced, non-UTC JVM default zone too.
+    @Test
+    void findPublicCommentByIdAndPostIdReturnsAnUnambiguousInstantRegardlessOfTheJvmDefaultTimeZone() {
+        TimeZone originalDefault = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+        try {
+            insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+            insertCommentAt(1L, 1L, "Great photo!", "2024-01-01 11:30:00");
+
+            PublicClubPostComment comment = clubPostMapper.findPublicCommentByIdAndPostId(1L, 1L);
+
+            Instant expected = LocalDateTime.of(2024, 1, 1, 11, 30)
+                .atZone(ZoneId.of("America/Los_Angeles"))
+                .toInstant();
+            assertThat(comment.getCreatedAt()).isEqualTo(expected);
+        } finally {
+            TimeZone.setDefault(originalDefault);
+        }
+    }
+
     @Test
     void findAllImageUrlsReturnsEveryPostsImageUrlAcrossClubs() {
         jdbcTemplate.update("INSERT INTO clubs (id, name) VALUES (2, 'Robotics')");

--- a/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
+++ b/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
@@ -366,6 +366,43 @@ class ClubPostMapperTest {
         });
     }
 
+    // The public feed card shows a comment count without the caller ever fetching the
+    // (separate, public) comments endpoint, so the count has to travel with the feed item
+    // itself: a correlated count against club_post_comment, never a join that could multiply
+    // the post row per comment.
+    @Test
+    void findPublicFeedByClubIdIncludesCommentCountCorrelatedToEachPost() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        insertPost(2L, 1L, "2024-01-02 10:00:00", null);
+        insertComment(1L, "First");
+        insertComment(1L, "Second");
+
+        List<PublicClubPost> feed = clubPostMapper.findPublicFeedByClubId(1L, 0, 10);
+
+        assertThat(feed).extracting(PublicClubPost::getId, PublicClubPost::getCommentCount)
+            .containsExactlyInAnyOrder(
+                org.assertj.core.groups.Tuple.tuple(1L, 2),
+                org.assertj.core.groups.Tuple.tuple(2L, 0));
+    }
+
+    @Test
+    void findPublicPostByIdAndClubIdIncludesCommentCount() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        insertComment(1L, "Nice!");
+
+        PublicClubPost post = clubPostMapper.findPublicPostByIdAndClubId(1L, 1L);
+
+        assertThat(post.getCommentCount()).isEqualTo(1);
+    }
+
+    private void insertComment(long postId, String body) {
+        ClubPostComment comment = new ClubPostComment();
+        comment.setPostId(postId);
+        comment.setAuthorOauthUserId(1L);
+        comment.setBody(body);
+        clubPostMapper.insertComment(comment);
+    }
+
     // Same ordering contract as findFeedByClubId: pinned posts first (by pinned_at DESC), then
     // created_at DESC, with id DESC as the same-created_at tiebreaker. Exercised here too
     // because the public projection is a separate SQL statement, not a reuse of the internal one.

--- a/frontend/src/router/index.spec.ts
+++ b/frontend/src/router/index.spec.ts
@@ -84,6 +84,15 @@ describe('authentication gate', () => {
 
     expect(router.currentRoute.value.name).toBe('club-search')
   })
+
+  it('leaves the club media route reachable for an unauthenticated visitor', async () => {
+    await primeSession(null)
+
+    await router.push('/clubs/3/media')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('club-media')
+  })
 })
 
 describe('already-authenticated user landing on the sign-in page', () => {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -32,6 +32,11 @@ const router = createRouter({
       component: () => import('../views/ClubDetailView.vue'),
     },
     {
+      path: '/clubs/:id/media',
+      name: 'club-media',
+      component: () => import('../views/ClubMediaView.vue'),
+    },
+    {
       path: '/clubs/:id/admin',
       name: 'club-admin',
       component: () => import('../views/ClubAdminView.vue'),

--- a/frontend/src/services/clubPostService.ts
+++ b/frontend/src/services/clubPostService.ts
@@ -1,0 +1,34 @@
+import type { ClubPostComment, ClubPostFeedPage } from '../types/clubPost'
+import { buildApiUrl } from './httpClient'
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const url = buildApiUrl(path)
+  const response = await fetch(url, {
+    ...init,
+    credentials: init?.credentials ?? 'include',
+  })
+  if (!response.ok) {
+    const message = await response.text()
+    throw new Error(message || `Request failed with status ${response.status}`)
+  }
+  const raw = await response.text()
+  if (!raw) return undefined as T
+  return JSON.parse(raw) as T
+}
+
+export const fetchClubMediaFeed = (
+  clubIdOrSlug: number | string,
+  page: number,
+  size: number,
+) =>
+  request<ClubPostFeedPage>(
+    `/api/clubs/${clubIdOrSlug}/posts?page=${page}&size=${size}`,
+  )
+
+export const fetchClubPostComments = (
+  clubIdOrSlug: number | string,
+  postId: number | string,
+) =>
+  request<ClubPostComment[]>(
+    `/api/clubs/${clubIdOrSlug}/posts/${postId}/comments`,
+  )

--- a/frontend/src/types/clubPost.ts
+++ b/frontend/src/types/clubPost.ts
@@ -22,9 +22,9 @@ export interface ClubPostComment {
   authorAvatarUrl: string | null
   body: string
   /**
-   * A timezone-naive ISO-8601 string (the backend's PublicClubPostComment#createdAt is a plain
-   * java.time.LocalDateTime, not an Instant like ClubPost#createdAt), so formatRelativeTime
-   * assumes UTC when no offset is present rather than parsing this straight into `new Date(...)`.
+   * An unambiguous, offset-bearing ISO-8601 instant, matching ClubPost#createdAt's contract
+   * (the backend's PublicClubPostComment#createdAt is a java.time.Instant, always ending in
+   * "Z") -- safe to hand straight to `new Date(...)`.
    */
   createdAt: string
 }

--- a/frontend/src/types/clubPost.ts
+++ b/frontend/src/types/clubPost.ts
@@ -1,0 +1,27 @@
+export interface ClubPost {
+  id: number
+  clubId: number
+  title: string
+  imageUrl: string
+  pinnedAt: string | null
+  createdAt: string
+  authorDisplayName: string
+  authorAvatarUrl: string | null
+  commentCount?: number
+}
+
+export interface ClubPostComment {
+  id: number
+  postId: number
+  authorDisplayName: string
+  authorAvatarUrl: string | null
+  body: string
+  createdAt: string
+}
+
+export interface ClubPostFeedPage {
+  items: ClubPost[]
+  page: number
+  size: number
+  total: number
+}

--- a/frontend/src/types/clubPost.ts
+++ b/frontend/src/types/clubPost.ts
@@ -7,7 +7,7 @@ export interface ClubPost {
   createdAt: string
   authorDisplayName: string
   authorAvatarUrl: string | null
-  commentCount?: number
+  commentCount: number
 }
 
 export interface ClubPostComment {

--- a/frontend/src/types/clubPost.ts
+++ b/frontend/src/types/clubPost.ts
@@ -21,6 +21,11 @@ export interface ClubPostComment {
   authorDisplayName: string
   authorAvatarUrl: string | null
   body: string
+  /**
+   * A timezone-naive ISO-8601 string (the backend's PublicClubPostComment#createdAt is a plain
+   * java.time.LocalDateTime, not an Instant like ClubPost#createdAt), so formatRelativeTime
+   * assumes UTC when no offset is present rather than parsing this straight into `new Date(...)`.
+   */
   createdAt: string
 }
 

--- a/frontend/src/types/clubPost.ts
+++ b/frontend/src/types/clubPost.ts
@@ -4,6 +4,11 @@ export interface ClubPost {
   title: string
   imageUrl: string
   pinnedAt: string | null
+  /**
+   * An unambiguous, offset-bearing ISO-8601 instant (the backend serializes this as a
+   * java.time.Instant, always ending in "Z"), not a timezone-naive wall-clock string --
+   * safe to hand straight to `new Date(...)`.
+   */
   createdAt: string
   authorDisplayName: string
   authorAvatarUrl: string | null

--- a/frontend/src/utils/clubImages.ts
+++ b/frontend/src/utils/clubImages.ts
@@ -1,4 +1,5 @@
 import type { Club } from '../types/club'
+import type { ClubPost } from '../types/clubPost'
 import { buildApiUrl } from '../services/httpClient'
 import { localAvatar } from './avatarImages'
 
@@ -63,3 +64,8 @@ export const clubImage = (club: ClubImageSource): string => {
   }
   return cachedInstagramAvatar(club) ?? localAvatar(club.name)
 }
+
+// club_post.image_url is always server-relative (see ClubPostService's Javadoc); routing it
+// through buildApiUrl keeps photos loading when VITE_API_BASE_URL is an absolute, different
+// origin than the SPA itself.
+export const clubPostImage = (post: Pick<ClubPost, 'imageUrl'>): string => buildApiUrl(post.imageUrl)

--- a/frontend/src/views/ClubDetailView.vue
+++ b/frontend/src/views/ClubDetailView.vue
@@ -587,6 +587,11 @@ watch(
     align-items: flex-start;
   }
 
+  .media-link {
+    width: 100%;
+    text-align: center;
+  }
+
   .admin-link {
     width: 100%;
     text-align: center;

--- a/frontend/src/views/ClubDetailView.vue
+++ b/frontend/src/views/ClubDetailView.vue
@@ -163,6 +163,7 @@ watch(
           </div>
         </div>
         <div class="hero-side">
+          <RouterLink :to="`/clubs/${club.id}/media`" class="media-link"> View club media </RouterLink>
           <RouterLink
             v-if="club.canManage || isOwner"
             :to="`/clubs/${club.id}/admin`"
@@ -368,6 +369,16 @@ watch(
   color: var(--mv-gold);
   font-weight: 600;
   background: var(--mv-surface-muted);
+}
+
+.media-link {
+  border: 1px solid var(--mv-border);
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  text-decoration: none;
+  color: var(--mv-text-soft);
+  font-weight: 600;
+  background: var(--mv-surface-card);
 }
 
 .club-hero h1 {

--- a/frontend/src/views/ClubMediaView.spec.ts
+++ b/frontend/src/views/ClubMediaView.spec.ts
@@ -428,13 +428,12 @@ describe('ClubMediaView robots meta', () => {
 declare const process: { env: Record<string, string | undefined> }
 
 describe('ClubMediaView relative time under a non-UTC browser timezone', () => {
-  // post.createdAt is a java.time.Instant on the backend, always serialized with an explicit
-  // "Z" (see PublicClubPost's Javadoc and EpochSecondsInstantTypeHandler); comment.createdAt is
-  // not (#79's PublicClubPostComment still carries a plain, timezone-naive LocalDateTime).
-  // Forcing a real, non-UTC host timezone here proves both cases render a just-created
-  // item as recent, never in the future: the guaranteed-offset post value parses correctly
-  // as-is, and the offset-less comment value falls back to the same "assume UTC" rule
-  // formatRelativeTime still carries for exactly this reason.
+  // Both post.createdAt and comment.createdAt are java.time.Instant on the backend, always
+  // serialized with an explicit "Z" (see PublicClubPost's, PublicClubPostComment's, and
+  // EpochSecondsInstantTypeHandler's Javadoc). Forcing a real, non-UTC host timezone here
+  // proves formatRelativeTime's plain `new Date(iso)` -- no "guess the offset" workaround --
+  // still can't misread a just-created post or a just-posted comment as being in the future
+  // purely because of the viewer's own timezone.
   const originalTz = process.env.TZ
 
   beforeAll(() => {
@@ -461,12 +460,13 @@ describe('ClubMediaView relative time under a non-UTC browser timezone', () => {
     expect(relativeTimeText).not.toMatch(/^in /)
   })
 
-  it('renders a just-posted comment as recent, never as being in the future, given the backend\'s offset-less LocalDateTime', async () => {
-    const justPostedTimestamp = new Date().toISOString().replace(/Z$/, '')
+  it('renders a just-posted comment as recent, never as being in the future, given the backend\'s offset-bearing instant', async () => {
+    const justPostedInstant = new Date().toISOString()
+    expect(justPostedInstant).toMatch(/Z$/)
 
     fetchClubByIdMock.mockResolvedValue(buildClub())
     fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 7 })], total: 1 }))
-    fetchClubPostCommentsMock.mockResolvedValue([buildComment({ createdAt: justPostedTimestamp })])
+    fetchClubPostCommentsMock.mockResolvedValue([buildComment({ createdAt: justPostedInstant })])
 
     const wrapper = await mountAtMediaRoute()
     await flushPromises()

--- a/frontend/src/views/ClubMediaView.spec.ts
+++ b/frontend/src/views/ClubMediaView.spec.ts
@@ -302,6 +302,28 @@ describe('ClubMediaView comments', () => {
     expect(wrapper.find('.mv-comment-list').exists()).toBe(false)
   })
 
+  it('retries the comments fetch when a post is collapsed and re-expanded after a failed load', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 7 })], total: 1 }))
+    fetchClubPostCommentsMock.mockRejectedValueOnce(new Error('Network error'))
+    fetchClubPostCommentsMock.mockResolvedValueOnce([buildComment({ body: 'Loaded on retry' })])
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).toContain('Network error')
+
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    await flushPromises()
+
+    expect(fetchClubPostCommentsMock).toHaveBeenCalledTimes(2)
+    expect(wrapper.text()).toContain('Loaded on retry')
+    expect(wrapper.text()).not.toContain('Network error')
+  })
+
   it('shows a comments empty state when a post has no comments', async () => {
     fetchClubByIdMock.mockResolvedValue(buildClub())
     fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 7 })], total: 1 }))
@@ -405,12 +427,12 @@ describe('ClubMediaView robots meta', () => {
 // locally here rather than pulling in @types/node project-wide for one test's TZ override.
 declare const process: { env: Record<string, string | undefined> }
 
-describe('ClubMediaView relative time for offset-less timestamps', () => {
-  // Jackson serializes java.time.LocalDateTime with no zone/offset suffix (e.g.
-  // "2024-06-01T12:00:00"). Forcing a real, non-UTC host timezone here reproduces the actual
-  // bug regardless of what timezone happens to run this suite: parsed naively, that string is
-  // read as *local* wall-clock time, not UTC, so a post created seconds ago can render as
-  // hours in the future purely because of the viewer's timezone.
+describe('ClubMediaView relative time for the backend\'s offset-bearing instant', () => {
+  // post.createdAt is now a java.time.Instant on the backend, always serialized with an
+  // explicit "Z" (see PublicClubPost's Javadoc and EpochSecondsInstantTypeHandler). Forcing a
+  // real, non-UTC host timezone here proves the frontend's plain `new Date(iso)` -- no more
+  // "guess the offset" workaround -- still can't misread a just-created post as being in the
+  // future purely because of the viewer's own timezone.
   const originalTz = process.env.TZ
 
   beforeAll(() => {
@@ -421,13 +443,13 @@ describe('ClubMediaView relative time for offset-less timestamps', () => {
     process.env.TZ = originalTz
   })
 
-  it('renders a just-created post as recent, never as being in the future, when createdAt has no timezone offset', async () => {
-    const nowUtcIso = new Date().toISOString()
-    const offsetLessRecentTimestamp = nowUtcIso.replace(/Z$/, '')
+  it('renders a just-created post as recent, never as being in the future, given the backend\'s offset-bearing instant', async () => {
+    const justCreatedInstant = new Date().toISOString()
+    expect(justCreatedInstant).toMatch(/Z$/)
 
     fetchClubByIdMock.mockResolvedValue(buildClub())
     fetchClubMediaFeedMock.mockResolvedValue(
-      buildFeed({ items: [buildPost({ createdAt: offsetLessRecentTimestamp })], total: 1 }),
+      buildFeed({ items: [buildPost({ createdAt: justCreatedInstant })], total: 1 }),
     )
 
     const wrapper = await mountAtMediaRoute()

--- a/frontend/src/views/ClubMediaView.spec.ts
+++ b/frontend/src/views/ClubMediaView.spec.ts
@@ -1,0 +1,355 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { createMemoryHistory, createRouter, type Router } from 'vue-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../services/clubService', () => ({
+  fetchClubById: vi.fn(),
+}))
+
+vi.mock('../services/clubPostService', () => ({
+  fetchClubMediaFeed: vi.fn(),
+  fetchClubPostComments: vi.fn(),
+}))
+
+import { fetchClubById } from '../services/clubService'
+import { fetchClubMediaFeed, fetchClubPostComments } from '../services/clubPostService'
+import type { Club } from '../types/club'
+import type { ClubPost, ClubPostComment, ClubPostFeedPage } from '../types/clubPost'
+import ClubMediaView from './ClubMediaView.vue'
+
+const fetchClubByIdMock = vi.mocked(fetchClubById)
+const fetchClubMediaFeedMock = vi.mocked(fetchClubMediaFeed)
+const fetchClubPostCommentsMock = vi.mocked(fetchClubPostComments)
+
+const buildClub = (overrides: Partial<Club> = {}): Club => ({
+  id: 1,
+  name: 'Chess Club',
+  slug: null,
+  aliasName: null,
+  description: 'Play chess on Fridays',
+  category: 'General',
+  meetingSchedule: 'Fridays 3pm',
+  location: null,
+  contactEmail: null,
+  advisor: null,
+  imageUrl: null,
+  memberCount: 42,
+  achievements: [],
+  canManage: false,
+  ...overrides,
+})
+
+const buildPost = (overrides: Partial<ClubPost> = {}): ClubPost => ({
+  id: 1,
+  clubId: 1,
+  title: 'Weekly meeting recap',
+  imageUrl: '/uploads/club-posts/a.jpg',
+  pinnedAt: null,
+  createdAt: new Date().toISOString(),
+  authorDisplayName: 'Ada Lovelace',
+  authorAvatarUrl: '/uploads/avatar-cache/ada.jpg',
+  commentCount: 0,
+  ...overrides,
+})
+
+const buildFeed = (overrides: Partial<ClubPostFeedPage> = {}): ClubPostFeedPage => ({
+  items: [],
+  page: 0,
+  size: 12,
+  total: 0,
+  ...overrides,
+})
+
+const buildComment = (overrides: Partial<ClubPostComment> = {}): ClubPostComment => ({
+  id: 1,
+  postId: 1,
+  authorDisplayName: 'Grace Hopper',
+  authorAvatarUrl: null,
+  body: 'Great photo!',
+  createdAt: new Date().toISOString(),
+  ...overrides,
+})
+
+let router: Router
+
+const mountAtMediaRoute = async (path = '/clubs/1/media') => {
+  router = createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/clubs/:id/media', name: 'club-media', component: ClubMediaView }],
+  })
+  await router.push(path)
+  await router.isReady()
+  return mount(ClubMediaView, { global: { plugins: [router] } })
+}
+
+beforeEach(() => {
+  fetchClubByIdMock.mockReset()
+  fetchClubMediaFeedMock.mockReset()
+  fetchClubPostCommentsMock.mockReset()
+})
+
+afterEach(() => {
+  document.head.querySelectorAll('meta[name="robots"]').forEach((node) => node.remove())
+})
+
+describe('ClubMediaView loading, error and empty states', () => {
+  it('shows a loading state before the club and feed have resolved', async () => {
+    fetchClubByIdMock.mockReturnValue(new Promise(() => {}))
+    fetchClubMediaFeedMock.mockReturnValue(new Promise(() => {}))
+
+    const wrapper = await mountAtMediaRoute()
+
+    expect(wrapper.text()).toContain('Loading club media')
+  })
+
+  it('shows an error state and a retry action when the feed fails to load', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockRejectedValue(new Error('Club not found'))
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Club not found')
+    expect(wrapper.find('button.mv-retry-btn').exists()).toBe(true)
+  })
+
+  it('retries loading when the retry button is clicked', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockRejectedValueOnce(new Error('Network error'))
+    fetchClubMediaFeedMock.mockResolvedValueOnce(buildFeed())
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+    expect(wrapper.text()).toContain('Network error')
+
+    await wrapper.find('button.mv-retry-btn').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('No posts yet.')
+  })
+
+  it('shows an empty state when the club has no posts yet', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed())
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('No posts yet.')
+    expect(wrapper.findAll('li.mv-post-card')).toHaveLength(0)
+  })
+})
+
+describe('ClubMediaView populated feed', () => {
+  it('renders each post exactly once with its title, author, avatar, comment count, and a pinned badge only on the pinned post', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValue(
+      buildFeed({
+        items: [
+          buildPost({ id: 1, title: 'Pinned announcement', pinnedAt: '2024-06-01T00:00:00Z', commentCount: 3 }),
+          buildPost({ id: 2, title: 'Regular update', pinnedAt: null, commentCount: 0 }),
+        ],
+        total: 2,
+      }),
+    )
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    const cards = wrapper.findAll('li.mv-post-card')
+    expect(cards).toHaveLength(2)
+    expect(wrapper.text()).toContain('Pinned announcement')
+    expect(wrapper.text()).toContain('Regular update')
+    expect(wrapper.text()).toContain('Ada Lovelace')
+    expect(wrapper.text()).toContain('Show comments (3)')
+    expect(wrapper.text()).toContain('Show comments (0)')
+
+    const badges = wrapper.findAll('.mv-badge-pinned')
+    expect(badges).toHaveLength(1)
+    expect(cards[0]!.find('.mv-badge-pinned').exists()).toBe(true)
+    expect(cards[1]!.find('.mv-badge-pinned').exists()).toBe(false)
+  })
+
+  it('shows a relative time for each post', async () => {
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString()
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValue(
+      buildFeed({ items: [buildPost({ createdAt: fiveMinutesAgo })], total: 1 }),
+    )
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    expect(wrapper.find('.mv-post-time').text()).toContain('5 minutes ago')
+  })
+
+  it('routes the post image and author avatar through buildApiUrl for an absolute API origin, and lazy-loads them', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValue(
+      buildFeed({
+        items: [buildPost({ imageUrl: '/uploads/club-posts/a.jpg', authorAvatarUrl: '/uploads/avatar-cache/ada.jpg' })],
+        total: 1,
+      }),
+    )
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    const postImage = wrapper.find('.mv-post-image')
+    const avatarImage = wrapper.find('.mv-author-avatar')
+
+    expect(postImage.attributes('src')).toBe('http://localhost:8080/uploads/club-posts/a.jpg')
+    expect(postImage.attributes('loading')).toBe('lazy')
+    expect(avatarImage.attributes('src')).toBe('http://localhost:8080/uploads/avatar-cache/ada.jpg')
+    expect(avatarImage.attributes('loading')).toBe('lazy')
+  })
+})
+
+describe('ClubMediaView pagination', () => {
+  it('requests the next page using the page and size the envelope reported, not the values requested', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    // The request asks for size=999; the server clamps that to 100 and echoes the clamp back.
+    fetchClubMediaFeedMock.mockResolvedValueOnce(
+      buildFeed({ items: [buildPost({ id: 1 })], page: 0, size: 100, total: 250 }),
+    )
+    fetchClubMediaFeedMock.mockResolvedValueOnce(
+      buildFeed({ items: [buildPost({ id: 2 })], page: 1, size: 100, total: 250 }),
+    )
+
+    const wrapper = await mountAtMediaRoute('/clubs/1/media?page=0&size=999')
+    await flushPromises()
+
+    expect(fetchClubMediaFeedMock).toHaveBeenNthCalledWith(1, '1', 0, 999)
+    expect(wrapper.text()).toContain('Page 1 of 3')
+
+    await wrapper.find('.mv-pagination button:last-of-type').trigger('click')
+    await flushPromises()
+
+    expect(fetchClubMediaFeedMock).toHaveBeenNthCalledWith(2, '1', 1, 100)
+    expect(wrapper.text()).toContain('Page 2 of 3')
+  })
+
+  it('disables the previous button on the first page and the next button on the last page', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValue(
+      buildFeed({ items: [buildPost()], page: 0, size: 12, total: 1 }),
+    )
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    const [previousButton, nextButton] = wrapper.findAll('.mv-pagination button')
+    expect(previousButton!.attributes('disabled')).toBeDefined()
+    expect(nextButton!.attributes('disabled')).toBeDefined()
+  })
+})
+
+describe('ClubMediaView comments', () => {
+  it('loads and shows escaped comments when a post is expanded', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 7 })], total: 1 }))
+    fetchClubPostCommentsMock.mockResolvedValue([
+      buildComment({ id: 1, body: '<script>alert(1)</script>' }),
+    ])
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    expect(wrapper.find('.mv-comment').exists()).toBe(false)
+
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    await flushPromises()
+
+    expect(fetchClubPostCommentsMock).toHaveBeenCalledWith('1', 7)
+    const commentBody = wrapper.find('.mv-comment-body')
+    expect(commentBody.text()).toBe('<script>alert(1)</script>')
+    expect(commentBody.find('script').exists()).toBe(false)
+    expect(wrapper.text()).toContain('Grace Hopper')
+  })
+
+  it('shows a comments error state and does not render a comment list', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 7 })], total: 1 }))
+    fetchClubPostCommentsMock.mockRejectedValue(new Error('Failed to load comments'))
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Failed to load comments')
+    expect(wrapper.find('.mv-comment-list').exists()).toBe(false)
+  })
+
+  it('shows a comments empty state when a post has no comments', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 7 })], total: 1 }))
+    fetchClubPostCommentsMock.mockResolvedValue([])
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('No comments yet.')
+  })
+
+  it('collapses the comments and hides the loaded list when toggled again', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 7 })], total: 1 }))
+    fetchClubPostCommentsMock.mockResolvedValue([buildComment()])
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('.mv-comment').exists()).toBe(true)
+
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    expect(wrapper.find('.mv-comment').exists()).toBe(false)
+
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    await flushPromises()
+
+    expect(fetchClubPostCommentsMock).toHaveBeenCalledTimes(1)
+    expect(wrapper.find('.mv-comment').exists()).toBe(true)
+  })
+})
+
+describe('ClubMediaView robots meta', () => {
+  it('sets a noindex robots meta tag while mounted and restores prior head state on unmount', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed())
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    const meta = document.head.querySelector('meta[name="robots"]')
+    expect(meta?.getAttribute('content')).toBe('noindex')
+
+    wrapper.unmount()
+
+    expect(document.head.querySelector('meta[name="robots"]')).toBeNull()
+  })
+
+  it('restores a pre-existing robots meta tag content on unmount instead of removing it', async () => {
+    const existing = document.createElement('meta')
+    existing.setAttribute('name', 'robots')
+    existing.setAttribute('content', 'index, follow')
+    document.head.appendChild(existing)
+
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed())
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+    expect(document.head.querySelector('meta[name="robots"]')?.getAttribute('content')).toBe('noindex')
+
+    wrapper.unmount()
+
+    expect(document.head.querySelector('meta[name="robots"]')?.getAttribute('content')).toBe('index, follow')
+  })
+})

--- a/frontend/src/views/ClubMediaView.spec.ts
+++ b/frontend/src/views/ClubMediaView.spec.ts
@@ -1,6 +1,6 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import { createMemoryHistory, createRouter, type Router } from 'vue-router'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../services/clubService', () => ({
   fetchClubById: vi.fn(),
@@ -242,6 +242,26 @@ describe('ClubMediaView pagination', () => {
     expect(previousButton!.attributes('disabled')).toBeDefined()
     expect(nextButton!.attributes('disabled')).toBeDefined()
   })
+
+  it('does not refetch the unchanged club detail when only the page changes', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValueOnce(
+      buildFeed({ items: [buildPost({ id: 1 })], page: 0, size: 12, total: 24 }),
+    )
+    fetchClubMediaFeedMock.mockResolvedValueOnce(
+      buildFeed({ items: [buildPost({ id: 2 })], page: 1, size: 12, total: 24 }),
+    )
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+    expect(fetchClubByIdMock).toHaveBeenCalledTimes(1)
+
+    await wrapper.find('.mv-pagination button:last-of-type').trigger('click')
+    await flushPromises()
+
+    expect(fetchClubMediaFeedMock).toHaveBeenCalledTimes(2)
+    expect(fetchClubByIdMock).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('ClubMediaView comments', () => {
@@ -304,18 +324,45 @@ describe('ClubMediaView comments', () => {
     const wrapper = await mountAtMediaRoute()
     await flushPromises()
 
-    await wrapper.find('.mv-comments-toggle').trigger('click')
-    await flushPromises()
-    expect(wrapper.find('.mv-comment').exists()).toBe(true)
+    const isCommentsRegionHidden = () =>
+      (wrapper.find('.mv-comments').attributes('style') ?? '').includes('display: none')
 
     await wrapper.find('.mv-comments-toggle').trigger('click')
-    expect(wrapper.find('.mv-comment').exists()).toBe(false)
+    await flushPromises()
+    expect(isCommentsRegionHidden()).toBe(false)
+
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    expect(isCommentsRegionHidden()).toBe(true)
 
     await wrapper.find('.mv-comments-toggle').trigger('click')
     await flushPromises()
 
     expect(fetchClubPostCommentsMock).toHaveBeenCalledTimes(1)
-    expect(wrapper.find('.mv-comment').exists()).toBe(true)
+    expect(isCommentsRegionHidden()).toBe(false)
+  })
+
+  it('exposes aria-expanded and aria-controls on the toggle, pointing at a stable comment region id', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 42 })], total: 1 }))
+    fetchClubPostCommentsMock.mockResolvedValue([buildComment()])
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    const toggle = wrapper.find('.mv-comments-toggle')
+    const regionId = toggle.attributes('aria-controls')
+    expect(regionId).toBeTruthy()
+    expect(toggle.attributes('aria-expanded')).toBe('false')
+
+    const region = wrapper.find(`#${regionId}`)
+    expect(region.exists()).toBe(true)
+    expect(region.classes()).toContain('mv-comments')
+
+    await toggle.trigger('click')
+    await flushPromises()
+
+    expect(toggle.attributes('aria-expanded')).toBe('true')
+    expect(toggle.attributes('aria-controls')).toBe(regionId)
   })
 })
 
@@ -351,5 +398,42 @@ describe('ClubMediaView robots meta', () => {
     wrapper.unmount()
 
     expect(document.head.querySelector('meta[name="robots"]')?.getAttribute('content')).toBe('index, follow')
+  })
+})
+
+// This file's tsconfig scope (tsconfig.app.json) has no "node" types, so `process` is declared
+// locally here rather than pulling in @types/node project-wide for one test's TZ override.
+declare const process: { env: Record<string, string | undefined> }
+
+describe('ClubMediaView relative time for offset-less timestamps', () => {
+  // Jackson serializes java.time.LocalDateTime with no zone/offset suffix (e.g.
+  // "2024-06-01T12:00:00"). Forcing a real, non-UTC host timezone here reproduces the actual
+  // bug regardless of what timezone happens to run this suite: parsed naively, that string is
+  // read as *local* wall-clock time, not UTC, so a post created seconds ago can render as
+  // hours in the future purely because of the viewer's timezone.
+  const originalTz = process.env.TZ
+
+  beforeAll(() => {
+    process.env.TZ = 'America/New_York'
+  })
+
+  afterAll(() => {
+    process.env.TZ = originalTz
+  })
+
+  it('renders a just-created post as recent, never as being in the future, when createdAt has no timezone offset', async () => {
+    const nowUtcIso = new Date().toISOString()
+    const offsetLessRecentTimestamp = nowUtcIso.replace(/Z$/, '')
+
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValue(
+      buildFeed({ items: [buildPost({ createdAt: offsetLessRecentTimestamp })], total: 1 }),
+    )
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    const relativeTimeText = wrapper.find('.mv-post-time').text()
+    expect(relativeTimeText).not.toMatch(/^in /)
   })
 })

--- a/frontend/src/views/ClubMediaView.spec.ts
+++ b/frontend/src/views/ClubMediaView.spec.ts
@@ -427,12 +427,14 @@ describe('ClubMediaView robots meta', () => {
 // locally here rather than pulling in @types/node project-wide for one test's TZ override.
 declare const process: { env: Record<string, string | undefined> }
 
-describe('ClubMediaView relative time for the backend\'s offset-bearing instant', () => {
-  // post.createdAt is now a java.time.Instant on the backend, always serialized with an
-  // explicit "Z" (see PublicClubPost's Javadoc and EpochSecondsInstantTypeHandler). Forcing a
-  // real, non-UTC host timezone here proves the frontend's plain `new Date(iso)` -- no more
-  // "guess the offset" workaround -- still can't misread a just-created post as being in the
-  // future purely because of the viewer's own timezone.
+describe('ClubMediaView relative time under a non-UTC browser timezone', () => {
+  // post.createdAt is a java.time.Instant on the backend, always serialized with an explicit
+  // "Z" (see PublicClubPost's Javadoc and EpochSecondsInstantTypeHandler); comment.createdAt is
+  // not (#79's PublicClubPostComment still carries a plain, timezone-naive LocalDateTime).
+  // Forcing a real, non-UTC host timezone here proves both cases render a just-created
+  // item as recent, never in the future: the guaranteed-offset post value parses correctly
+  // as-is, and the offset-less comment value falls back to the same "assume UTC" rule
+  // formatRelativeTime still carries for exactly this reason.
   const originalTz = process.env.TZ
 
   beforeAll(() => {
@@ -456,6 +458,23 @@ describe('ClubMediaView relative time for the backend\'s offset-bearing instant'
     await flushPromises()
 
     const relativeTimeText = wrapper.find('.mv-post-time').text()
+    expect(relativeTimeText).not.toMatch(/^in /)
+  })
+
+  it('renders a just-posted comment as recent, never as being in the future, given the backend\'s offset-less LocalDateTime', async () => {
+    const justPostedTimestamp = new Date().toISOString().replace(/Z$/, '')
+
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 7 })], total: 1 }))
+    fetchClubPostCommentsMock.mockResolvedValue([buildComment({ createdAt: justPostedTimestamp })])
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    await flushPromises()
+
+    const relativeTimeText = wrapper.find('.mv-comment-time').text()
     expect(relativeTimeText).not.toMatch(/^in /)
   })
 })

--- a/frontend/src/views/ClubMediaView.vue
+++ b/frontend/src/views/ClubMediaView.vue
@@ -154,17 +154,13 @@ const relativeTimeDivisions: Array<[Intl.RelativeTimeFormatUnit, number]> = [
   ['second', 1],
 ]
 
-// post.createdAt is a java.time.Instant on the backend (see PublicClubPost's Javadoc), always
-// serialized with an explicit UTC offset (a trailing "Z"). comment.createdAt is not: #79's
-// PublicClubPostComment still carries a plain LocalDateTime, the same timezone-naive shape
-// post.createdAt used to have before that fix. Until a future ticket gives comments the same
-// Instant contract, assume UTC for whatever string arrives without an explicit offset -- the
-// same fallback previously used for posts, kept only because comments still need it.
-const hasExplicitTimezoneOffset = /(Z|[+-]\d{2}:\d{2})$/i
-const toUtcDate = (iso: string) => new Date(hasExplicitTimezoneOffset.test(iso) ? iso : `${iso}Z`)
-
+// Both post.createdAt and comment.createdAt are java.time.Instant on the backend (see
+// PublicClubPost's and PublicClubPostComment's Javadoc), always serialized with an explicit
+// UTC offset (a trailing "Z"). That contract is what makes a plain `new Date(iso)` safe here:
+// there is no ambiguous, offset-less wall-clock string left for a browser to misparse as its
+// own local time.
 const formatRelativeTime = (iso: string) => {
-  const date = toUtcDate(iso)
+  const date = new Date(iso)
   if (Number.isNaN(date.getTime())) {
     return ''
   }

--- a/frontend/src/views/ClubMediaView.vue
+++ b/frontend/src/views/ClubMediaView.vue
@@ -1,0 +1,508 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { fetchClubById } from '../services/clubService'
+import { fetchClubMediaFeed, fetchClubPostComments } from '../services/clubPostService'
+import type { Club } from '../types/club'
+import type { ClubPost, ClubPostComment } from '../types/clubPost'
+import { clubPostImage } from '../utils/clubImages'
+import { userAvatar } from '../utils/avatarImages'
+import BackButton from '../components/BackButton.vue'
+
+const DEFAULT_PAGE_SIZE = 12
+
+interface CommentsEntry {
+  loading: boolean
+  error: string
+  comments: ClubPostComment[]
+}
+
+const route = useRoute()
+const router = useRouter()
+
+const club = ref<Club | null>(null)
+const posts = ref<ClubPost[]>([])
+const page = ref(0)
+const size = ref(DEFAULT_PAGE_SIZE)
+const total = ref(0)
+const loading = ref(true)
+const error = ref('')
+
+const expandedPostIds = ref<Set<number>>(new Set())
+const commentsByPost = ref<Record<number, CommentsEntry>>({})
+
+const routeClubId = computed(() => {
+  const raw = route.params.id
+  const value = Array.isArray(raw) ? raw[0] : raw
+  return value ?? ''
+})
+
+const backTarget = computed(() => (routeClubId.value ? `/clubs/${routeClubId.value}` : '/'))
+
+const totalPages = computed(() => Math.max(1, Math.ceil(total.value / Math.max(size.value, 1))))
+const hasNextPage = computed(() => (page.value + 1) * size.value < total.value)
+const hasPreviousPage = computed(() => page.value > 0)
+
+const parseQueryInt = (raw: unknown, fallback: number) => {
+  const value = Array.isArray(raw) ? raw[0] : raw
+  const parsed = value !== undefined && value !== null ? Number(value) : NaN
+  return Number.isFinite(parsed) ? Math.trunc(parsed) : fallback
+}
+
+const load = async () => {
+  const clubIdOrSlug = routeClubId.value
+  if (!clubIdOrSlug) {
+    return
+  }
+
+  loading.value = true
+  error.value = ''
+  expandedPostIds.value = new Set()
+  commentsByPost.value = {}
+
+  const requestedPage = Math.max(0, parseQueryInt(route.query.page, 0))
+  const requestedSize = Math.max(1, parseQueryInt(route.query.size, DEFAULT_PAGE_SIZE))
+
+  try {
+    const [clubResponse, feed] = await Promise.all([
+      fetchClubById(clubIdOrSlug),
+      fetchClubMediaFeed(clubIdOrSlug, requestedPage, requestedSize),
+    ])
+    club.value = clubResponse
+    posts.value = feed.items
+    page.value = feed.page
+    size.value = feed.size
+    total.value = feed.total
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to load club media'
+    club.value = null
+    posts.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+const retryLoad = () => {
+  void load()
+}
+
+const goToPage = (nextPage: number) => {
+  if (nextPage < 0) {
+    return
+  }
+  void router.push({ query: { ...route.query, page: String(nextPage), size: String(size.value) } })
+}
+
+const isExpanded = (postId: number) => expandedPostIds.value.has(postId)
+
+const emptyCommentsEntry: CommentsEntry = { loading: false, error: '', comments: [] }
+const commentsState = (postId: number) => commentsByPost.value[postId] ?? emptyCommentsEntry
+
+const loadComments = async (postId: number) => {
+  commentsByPost.value = {
+    ...commentsByPost.value,
+    [postId]: { loading: true, error: '', comments: [] },
+  }
+  try {
+    const comments = await fetchClubPostComments(routeClubId.value, postId)
+    commentsByPost.value = {
+      ...commentsByPost.value,
+      [postId]: { loading: false, error: '', comments },
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to load comments'
+    commentsByPost.value = {
+      ...commentsByPost.value,
+      [postId]: { loading: false, error: message, comments: [] },
+    }
+  }
+}
+
+const toggleComments = (postId: number) => {
+  const next = new Set(expandedPostIds.value)
+  if (next.has(postId)) {
+    next.delete(postId)
+    expandedPostIds.value = next
+    return
+  }
+  next.add(postId)
+  expandedPostIds.value = next
+  if (!commentsByPost.value[postId]) {
+    void loadComments(postId)
+  }
+}
+
+const relativeTimeFormatter = new Intl.RelativeTimeFormat('en', { numeric: 'auto' })
+const relativeTimeDivisions: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+  ['year', 60 * 60 * 24 * 365],
+  ['month', 60 * 60 * 24 * 30],
+  ['week', 60 * 60 * 24 * 7],
+  ['day', 60 * 60 * 24],
+  ['hour', 60 * 60],
+  ['minute', 60],
+  ['second', 1],
+]
+
+const formatRelativeTime = (iso: string) => {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) {
+    return ''
+  }
+  const diffSeconds = Math.round((date.getTime() - Date.now()) / 1000)
+  for (const [unit, secondsInUnit] of relativeTimeDivisions) {
+    if (Math.abs(diffSeconds) >= secondsInUnit || unit === 'second') {
+      return relativeTimeFormatter.format(Math.round(diffSeconds / secondsInUnit), unit)
+    }
+  }
+  return ''
+}
+
+let previousRobotsContent: string | null = null
+let createdRobotsMeta = false
+
+onMounted(() => {
+  const existing = document.head.querySelector('meta[name="robots"]')
+  if (existing) {
+    previousRobotsContent = existing.getAttribute('content')
+    existing.setAttribute('content', 'noindex')
+  } else {
+    const meta = document.createElement('meta')
+    meta.setAttribute('name', 'robots')
+    meta.setAttribute('content', 'noindex')
+    document.head.appendChild(meta)
+    createdRobotsMeta = true
+  }
+})
+
+onBeforeUnmount(() => {
+  const existing = document.head.querySelector('meta[name="robots"]')
+  if (!existing) {
+    return
+  }
+  if (createdRobotsMeta) {
+    existing.remove()
+  } else if (previousRobotsContent !== null) {
+    existing.setAttribute('content', previousRobotsContent)
+  }
+})
+
+watch(
+  () => [routeClubId.value, route.query.page, route.query.size],
+  () => {
+    void load()
+  },
+  { immediate: true },
+)
+</script>
+
+<template>
+  <section class="club-media page-shell">
+    <BackButton :fallback-to="backTarget">← Back to club</BackButton>
+
+    <div v-if="loading" class="mv-status">Loading club media…</div>
+
+    <div v-else-if="error" class="mv-status mv-status--error">
+      <p>{{ error }}</p>
+      <button type="button" class="mv-retry-btn" @click="retryLoad">Try again</button>
+    </div>
+
+    <template v-else>
+      <header class="mv-header">
+        <p class="section-label" v-if="club">Media · {{ club.name }}</p>
+        <h1>Club media</h1>
+        <p class="mv-subtitle">Activity photos and updates shared by club members.</p>
+      </header>
+
+      <p v-if="posts.length === 0" class="mv-empty">No posts yet. Check back soon.</p>
+
+      <ul v-else class="mv-post-list">
+        <li v-for="post in posts" :key="post.id" class="mv-post-card">
+          <div class="mv-post-media">
+            <img :src="clubPostImage(post)" :alt="post.title" loading="lazy" class="mv-post-image" />
+            <span v-if="post.pinnedAt" class="mv-badge-pinned">Pinned</span>
+          </div>
+          <div class="mv-post-body">
+            <h2 class="mv-post-title">{{ post.title }}</h2>
+            <div class="mv-post-author">
+              <img
+                :src="userAvatar(post.authorAvatarUrl, post.authorDisplayName)"
+                :alt="post.authorDisplayName"
+                loading="lazy"
+                class="mv-author-avatar"
+              />
+              <div>
+                <p class="mv-author-name">{{ post.authorDisplayName }}</p>
+                <p class="mv-post-time">{{ formatRelativeTime(post.createdAt) }}</p>
+              </div>
+            </div>
+            <button type="button" class="mv-comments-toggle" @click="toggleComments(post.id)">
+              {{ isExpanded(post.id) ? 'Hide comments' : `Show comments (${post.commentCount ?? 0})` }}
+            </button>
+            <div v-if="isExpanded(post.id)" class="mv-comments">
+              <p v-if="commentsState(post.id).loading" class="mv-status">Loading comments…</p>
+              <p v-else-if="commentsState(post.id).error" class="mv-status mv-status--error">
+                {{ commentsState(post.id).error }}
+              </p>
+              <p v-else-if="commentsState(post.id).comments.length === 0" class="mv-empty">
+                No comments yet.
+              </p>
+              <ul v-else class="mv-comment-list">
+                <li v-for="comment in commentsState(post.id).comments" :key="comment.id" class="mv-comment">
+                  <p class="mv-comment-author">{{ comment.authorDisplayName }}</p>
+                  <p class="mv-comment-body">{{ comment.body }}</p>
+                  <p class="mv-comment-time">{{ formatRelativeTime(comment.createdAt) }}</p>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </li>
+      </ul>
+
+      <nav v-if="posts.length" class="mv-pagination">
+        <button type="button" :disabled="!hasPreviousPage" @click="goToPage(page - 1)">Previous</button>
+        <span class="mv-pagination-status">Page {{ page + 1 }} of {{ totalPages }}</span>
+        <button type="button" :disabled="!hasNextPage" @click="goToPage(page + 1)">Next</button>
+      </nav>
+    </template>
+  </section>
+</template>
+
+<style scoped>
+.club-media {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding-block: clamp(2rem, 5vw, 3.5rem);
+}
+
+.mv-status {
+  border-radius: 20px;
+  border: 1px solid var(--mv-border);
+  padding: 1rem 1.25rem;
+  background: var(--mv-surface-card-strong);
+}
+
+.mv-status--error {
+  border-color: rgba(248, 113, 113, 0.35);
+  color: var(--mv-status-danger);
+}
+
+.mv-retry-btn {
+  border-radius: 999px;
+  border: 1px solid var(--mv-border-strong);
+  background: var(--mv-surface-accent);
+  color: var(--mv-gold);
+  font-weight: 600;
+  padding: 0.4rem 1.2rem;
+  cursor: pointer;
+  margin-top: 0.5rem;
+}
+
+.mv-header h1 {
+  margin: 0.25rem 0 0.35rem;
+  font-size: clamp(1.8rem, 3.5vw, 2.6rem);
+}
+
+.mv-subtitle {
+  margin: 0;
+  color: var(--mv-text-faint);
+}
+
+.mv-empty {
+  border-radius: 20px;
+  border: 1px dashed var(--mv-border);
+  padding: 1.5rem;
+  text-align: center;
+  color: var(--mv-text-faint);
+}
+
+.mv-post-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.mv-post-card {
+  border-radius: 24px;
+  border: 1px solid var(--mv-border);
+  background: var(--mv-surface-card);
+  overflow: hidden;
+  box-shadow: var(--mv-shadow-card);
+  display: flex;
+  flex-direction: column;
+}
+
+.mv-post-media {
+  position: relative;
+}
+
+.mv-post-image {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  display: block;
+}
+
+.mv-badge-pinned {
+  position: absolute;
+  top: 0.75rem;
+  left: 0.75rem;
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  background: var(--mv-gold);
+  color: var(--mv-primary-text);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.mv-post-body {
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.mv-post-title {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.mv-post-author {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.mv-author-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.mv-author-name {
+  margin: 0;
+  font-weight: 600;
+}
+
+.mv-post-time {
+  margin: 0;
+  color: var(--mv-text-dim);
+  font-size: 0.85rem;
+}
+
+.mv-comments-toggle {
+  align-self: flex-start;
+  border: 1px solid var(--mv-border);
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  background: var(--mv-surface-muted);
+  color: var(--mv-text-soft);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.mv-comments {
+  border-top: 1px solid var(--mv-border);
+  padding-top: 0.75rem;
+}
+
+.mv-comment-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.mv-comment {
+  border-radius: 14px;
+  background: var(--mv-surface-muted);
+  padding: 0.6rem 0.8rem;
+}
+
+.mv-comment-author {
+  margin: 0;
+  font-weight: 600;
+}
+
+.mv-comment-body {
+  margin: 0.15rem 0;
+}
+
+.mv-comment-time {
+  margin: 0;
+  color: var(--mv-text-dim);
+  font-size: 0.8rem;
+}
+
+.mv-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.mv-pagination button {
+  border-radius: 999px;
+  border: 1px solid var(--mv-border-strong);
+  background: var(--mv-surface-accent);
+  color: var(--mv-gold);
+  font-weight: 600;
+  padding: 0.45rem 1.2rem;
+  cursor: pointer;
+}
+
+.mv-pagination button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.mv-pagination-status {
+  color: var(--mv-text-faint);
+}
+
+@media (max-width: 900px) {
+  .mv-post-list {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .mv-post-card {
+    border-radius: 20px;
+  }
+
+  .mv-post-body {
+    padding: 1rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .mv-pagination {
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 480px) {
+  .mv-header h1 {
+    font-size: 1.5rem;
+  }
+
+  .mv-post-body {
+    padding: 0.85rem;
+  }
+
+  .mv-pagination button {
+    flex: 1 1 auto;
+    text-align: center;
+  }
+}
+</style>

--- a/frontend/src/views/ClubMediaView.vue
+++ b/frontend/src/views/ClubMediaView.vue
@@ -30,12 +30,15 @@ const error = ref('')
 
 const expandedPostIds = ref<Set<number>>(new Set())
 const commentsByPost = ref<Record<number, CommentsEntry>>({})
+let loadedClubId: string | null = null
 
 const routeClubId = computed(() => {
   const raw = route.params.id
   const value = Array.isArray(raw) ? raw[0] : raw
   return value ?? ''
 })
+
+const commentsRegionId = (postId: number) => `club-media-comments-${postId}`
 
 const backTarget = computed(() => (routeClubId.value ? `/clubs/${routeClubId.value}` : '/'))
 
@@ -62,13 +65,19 @@ const load = async () => {
 
   const requestedPage = Math.max(0, parseQueryInt(route.query.page, 0))
   const requestedSize = Math.max(1, parseQueryInt(route.query.size, DEFAULT_PAGE_SIZE))
+  // Pagination re-runs this on every page/size query change but must not re-fetch a club
+  // detail record that hasn't changed -- only the feed page itself is new.
+  const needsClub = loadedClubId !== clubIdOrSlug
 
   try {
     const [clubResponse, feed] = await Promise.all([
-      fetchClubById(clubIdOrSlug),
+      needsClub ? fetchClubById(clubIdOrSlug) : Promise.resolve(club.value),
       fetchClubMediaFeed(clubIdOrSlug, requestedPage, requestedSize),
     ])
-    club.value = clubResponse
+    if (needsClub) {
+      club.value = clubResponse
+      loadedClubId = clubIdOrSlug
+    }
     posts.value = feed.items
     page.value = feed.page
     size.value = feed.size
@@ -77,6 +86,7 @@ const load = async () => {
     error.value = err instanceof Error ? err.message : 'Failed to load club media'
     club.value = null
     posts.value = []
+    loadedClubId = null
   } finally {
     loading.value = false
   }
@@ -143,8 +153,16 @@ const relativeTimeDivisions: Array<[Intl.RelativeTimeFormatUnit, number]> = [
   ['second', 1],
 ]
 
+// Jackson serializes java.time.LocalDateTime without a zone/offset suffix (e.g.
+// "2024-01-01T10:00:00"), and the ES spec parses that exact shape as *local browser time*,
+// not UTC -- so a post created seconds ago can come back reading "in 8 hours" purely because
+// the viewer's timezone differs from the server's. The backend value is always meant to be
+// read as UTC, so append 'Z' whenever no offset is already present before parsing.
+const hasExplicitTimezoneOffset = /(Z|[+-]\d{2}:\d{2})$/i
+const toUtcDate = (iso: string) => new Date(hasExplicitTimezoneOffset.test(iso) ? iso : `${iso}Z`)
+
 const formatRelativeTime = (iso: string) => {
-  const date = new Date(iso)
+  const date = toUtcDate(iso)
   if (Number.isNaN(date.getTime())) {
     return ''
   }
@@ -235,10 +253,22 @@ watch(
                 <p class="mv-post-time">{{ formatRelativeTime(post.createdAt) }}</p>
               </div>
             </div>
-            <button type="button" class="mv-comments-toggle" @click="toggleComments(post.id)">
-              {{ isExpanded(post.id) ? 'Hide comments' : `Show comments (${post.commentCount ?? 0})` }}
+            <button
+              type="button"
+              class="mv-comments-toggle"
+              :aria-expanded="isExpanded(post.id)"
+              :aria-controls="commentsRegionId(post.id)"
+              @click="toggleComments(post.id)"
+            >
+              {{ isExpanded(post.id) ? 'Hide comments' : `Show comments (${post.commentCount})` }}
             </button>
-            <div v-if="isExpanded(post.id)" class="mv-comments">
+            <div
+              v-show="isExpanded(post.id)"
+              :id="commentsRegionId(post.id)"
+              class="mv-comments"
+              role="region"
+              :aria-label="`Comments on ${post.title}`"
+            >
               <p v-if="commentsState(post.id).loading" class="mv-status">Loading comments…</p>
               <p v-else-if="commentsState(post.id).error" class="mv-status mv-status--error">
                 {{ commentsState(post.id).error }}

--- a/frontend/src/views/ClubMediaView.vue
+++ b/frontend/src/views/ClubMediaView.vue
@@ -137,7 +137,8 @@ const toggleComments = (postId: number) => {
   }
   next.add(postId)
   expandedPostIds.value = next
-  if (!commentsByPost.value[postId]) {
+  const existing = commentsByPost.value[postId]
+  if (!existing || existing.error) {
     void loadComments(postId)
   }
 }
@@ -153,16 +154,12 @@ const relativeTimeDivisions: Array<[Intl.RelativeTimeFormatUnit, number]> = [
   ['second', 1],
 ]
 
-// Jackson serializes java.time.LocalDateTime without a zone/offset suffix (e.g.
-// "2024-01-01T10:00:00"), and the ES spec parses that exact shape as *local browser time*,
-// not UTC -- so a post created seconds ago can come back reading "in 8 hours" purely because
-// the viewer's timezone differs from the server's. The backend value is always meant to be
-// read as UTC, so append 'Z' whenever no offset is already present before parsing.
-const hasExplicitTimezoneOffset = /(Z|[+-]\d{2}:\d{2})$/i
-const toUtcDate = (iso: string) => new Date(hasExplicitTimezoneOffset.test(iso) ? iso : `${iso}Z`)
-
+// post.createdAt is a java.time.Instant on the backend (see PublicClubPost's Javadoc), which
+// Jackson always serializes with an explicit UTC offset (a trailing "Z"). That contract is what
+// makes a plain `new Date(iso)` safe here: there is no ambiguous, offset-less wall-clock string
+// left for a browser to misparse as its own local time.
 const formatRelativeTime = (iso: string) => {
-  const date = toUtcDate(iso)
+  const date = new Date(iso)
   if (Number.isNaN(date.getTime())) {
     return ''
   }

--- a/frontend/src/views/ClubMediaView.vue
+++ b/frontend/src/views/ClubMediaView.vue
@@ -154,12 +154,17 @@ const relativeTimeDivisions: Array<[Intl.RelativeTimeFormatUnit, number]> = [
   ['second', 1],
 ]
 
-// post.createdAt is a java.time.Instant on the backend (see PublicClubPost's Javadoc), which
-// Jackson always serializes with an explicit UTC offset (a trailing "Z"). That contract is what
-// makes a plain `new Date(iso)` safe here: there is no ambiguous, offset-less wall-clock string
-// left for a browser to misparse as its own local time.
+// post.createdAt is a java.time.Instant on the backend (see PublicClubPost's Javadoc), always
+// serialized with an explicit UTC offset (a trailing "Z"). comment.createdAt is not: #79's
+// PublicClubPostComment still carries a plain LocalDateTime, the same timezone-naive shape
+// post.createdAt used to have before that fix. Until a future ticket gives comments the same
+// Instant contract, assume UTC for whatever string arrives without an explicit offset -- the
+// same fallback previously used for posts, kept only because comments still need it.
+const hasExplicitTimezoneOffset = /(Z|[+-]\d{2}:\d{2})$/i
+const toUtcDate = (iso: string) => new Date(hasExplicitTimezoneOffset.test(iso) ? iso : `${iso}Z`)
+
 const formatRelativeTime = (iso: string) => {
-  const date = new Date(iso)
+  const date = toUtcDate(iso)
   if (Number.isNaN(date.getTime())) {
     return ''
   }


### PR DESCRIPTION
## Summary

- Add a public read-only club media route and link from club detail.
- Render backend-ordered post cards with pinned state, lazy cross-origin-safe images, comments, pagination, responsive layout, and noindex metadata.
- Add accurate per-post comment counts and unambiguous Instant timestamps for public posts and comments.
- Cover loading, empty, error, populated, retry, accessibility, timezone, and pagination behavior.

## Verification

- `./mvnw test` (341 tests passed)
- `TZ=UTC ./mvnw test` (341 tests passed)
- `npm run test:unit -- --run` (149 tests passed)
- `npm run build` passed
- Three independent review rounds completed; final production verdict sound, final CI portability finding fixed and verified in UTC

Closes bangxiao0927/HSclubs#81

---
Generated by Codet
