### PR TITLE
Club media: add publish, comment, delete, and pin interactions

### DIFF
--- a/backend/src/main/java/com/example/demo/club/controller/ClubPostCommentController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubPostCommentController.java
@@ -81,8 +81,7 @@ public class ClubPostCommentController {
         requirePostInClub(postId, club.getId());
 
         Long viewerOauthUserId = viewerEmail != null ? oAuthUserMapper.findIdByEmail(viewerEmail) : null;
-        boolean viewerCanModerateAnyPost = Boolean.TRUE.equals(club.getCanManage())
-            || authenticatedUserResolver.isPlatformOwner(authentication);
+        boolean viewerCanModerateAnyPost = clubContentModerationPolicy.canModerateAnyContent(club, authentication);
         return clubPostCommentService.findPublicComments(postId, viewerOauthUserId, viewerCanModerateAnyPost);
     }
 

--- a/backend/src/main/java/com/example/demo/club/controller/ClubPostCommentController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubPostCommentController.java
@@ -80,7 +80,10 @@ public class ClubPostCommentController {
 
         requirePostInClub(postId, club.getId());
 
-        return clubPostCommentService.findPublicComments(postId);
+        Long viewerOauthUserId = viewerEmail != null ? oAuthUserMapper.findIdByEmail(viewerEmail) : null;
+        boolean viewerCanModerateAnyPost = Boolean.TRUE.equals(club.getCanManage())
+            || authenticatedUserResolver.isPlatformOwner(authentication);
+        return clubPostCommentService.findPublicComments(postId, viewerOauthUserId, viewerCanModerateAnyPost);
     }
 
     @PostMapping("/{clubSlugOrId}/posts/{postId}/comments")

--- a/backend/src/main/java/com/example/demo/club/controller/ClubPostController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubPostController.java
@@ -105,8 +105,7 @@ public class ClubPostController {
         }
 
         Long viewerOauthUserId = viewerEmail != null ? oAuthUserMapper.findIdByEmail(viewerEmail) : null;
-        boolean viewerCanModerateAnyPost = Boolean.TRUE.equals(club.getCanManage())
-            || authenticatedUserResolver.isPlatformOwner(authentication);
+        boolean viewerCanModerateAnyPost = clubContentModerationPolicy.canModerateAnyContent(club, authentication);
         return clubPostService.findPublicFeed(club.getId(), page, size, viewerOauthUserId, viewerCanModerateAnyPost);
     }
 
@@ -183,17 +182,18 @@ public class ClubPostController {
         }
     }
 
-    // Same matrix as ClubController/ClubImageController's requireManageAccess: the club's own
-    // president, or a platform owner. Pinning is an editorial power, not a publishing one, so an
-    // ordinary member (even the post's own author) is not enough.
+    // Same matrix as ClubController/ClubImageController's requireManageAccess, delegated to
+    // ClubContentModerationPolicy#canModerateAnyContent so this branch can never silently drift
+    // from the one #feed uses for viewerCanModerateAnyPost or #deletePost uses for canModerate:
+    // the club's own president, or a platform owner. Pinning is an editorial power, not a
+    // publishing one, so an ordinary member (even the post's own author) is not enough.
     private Club requireManageAccess(String clubSlugOrId, Authentication authentication) {
         String viewerEmail = authenticatedUserResolver.requireEmail(authentication);
         Club club = clubService.resolveBySlugOrId(clubSlugOrId, viewerEmail);
         if (club == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
         }
-        boolean canManage = Boolean.TRUE.equals(club.getCanManage())
-            || authenticatedUserResolver.isPlatformOwner(authentication);
+        boolean canManage = clubContentModerationPolicy.canModerateAnyContent(club, authentication);
         if (!canManage) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN,
                 "Only the club president or a platform owner can pin posts");

--- a/backend/src/main/java/com/example/demo/club/controller/ClubPostController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubPostController.java
@@ -104,7 +104,10 @@ public class ClubPostController {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
         }
 
-        return clubPostService.findPublicFeed(club.getId(), page, size);
+        Long viewerOauthUserId = viewerEmail != null ? oAuthUserMapper.findIdByEmail(viewerEmail) : null;
+        boolean viewerCanModerateAnyPost = Boolean.TRUE.equals(club.getCanManage())
+            || authenticatedUserResolver.isPlatformOwner(authentication);
+        return clubPostService.findPublicFeed(club.getId(), page, size, viewerOauthUserId, viewerCanModerateAnyPost);
     }
 
     // ---- Pinning (president or platform owner only) ----

--- a/backend/src/main/java/com/example/demo/club/mapper/ClubPostMapper.java
+++ b/backend/src/main/java/com/example/demo/club/mapper/ClubPostMapper.java
@@ -21,15 +21,25 @@ public interface ClubPostMapper {
     // Public projection for the anonymous club feed: post columns plus the author's display
     // name/avatar only, never any oauth_users column that could identify or contact them (see
     // PublicClubPost's Javadoc for the exact forbidden list).
+    // viewerOauthUserId (nullable, for anonymous callers) and viewerCanModerateAnyPost feed only
+    // PublicClubPost#viewerCanDelete's own CASE WHEN, never anything serialized back to the
+    // caller.
     List<PublicClubPost> findPublicFeedByClubId(@Param("clubId") Long clubId,
                                                  @Param("offset") int offset,
-                                                 @Param("limit") int limit);
+                                                 @Param("limit") int limit,
+                                                 @Param("viewerOauthUserId") Long viewerOauthUserId,
+                                                 @Param("viewerCanModerateAnyPost") boolean viewerCanModerateAnyPost);
 
     // Read-back for ClubPostService#publish, so a just-published post can be returned with the
     // exact same safe shape a feed item has (author display name/avatar, never the internal
     // author_oauth_user_id). Scoped to clubId as a defense-in-depth guard, matching every other
     // by-ID lookup in this codebase.
-    PublicClubPost findPublicPostByIdAndClubId(@Param("id") Long id, @Param("clubId") Long clubId);
+    // ClubPostWriter#insertAndReadBack always passes the newly created post's own author as
+    // viewerOauthUserId, so the returned viewerCanDelete is always true -- the same authorship
+    // rule findPublicFeedByClubId applies to every other viewer.
+    PublicClubPost findPublicPostByIdAndClubId(@Param("id") Long id, @Param("clubId") Long clubId,
+                                                @Param("viewerOauthUserId") Long viewerOauthUserId,
+                                                @Param("viewerCanModerateAnyPost") boolean viewerCanModerateAnyPost);
 
     // Scoped lookup shared by the pin/unpin path (ClubPostService#pin/#unpin) and the delete
     // endpoint's own author/president/platform-owner authorization: a post ID that exists but
@@ -64,11 +74,19 @@ public interface ClubPostMapper {
 
     // Public projection for the anonymous comments endpoint: comment columns plus the author's
     // display name/avatar only, reusing the same no-PII rule as findPublicFeedByClubId.
-    List<PublicClubPostComment> findPublicCommentsByPostId(@Param("postId") Long postId);
+    List<PublicClubPostComment> findPublicCommentsByPostId(@Param("postId") Long postId,
+                                                            @Param("viewerOauthUserId") Long viewerOauthUserId,
+                                                            @Param("viewerCanModerateAnyPost")
+                                                            boolean viewerCanModerateAnyPost);
 
     // Read-back for ClubPostCommentWriter#lockCountAndInsert, so a just-posted comment can be
     // returned in the exact same safe shape the public list has.
-    PublicClubPostComment findPublicCommentByIdAndPostId(@Param("id") Long id, @Param("postId") Long postId);
+    // Always passed the new comment's own author as viewerOauthUserId, mirroring
+    // findPublicPostByIdAndClubId's contract for a freshly published post.
+    PublicClubPostComment findPublicCommentByIdAndPostId(@Param("id") Long id, @Param("postId") Long postId,
+                                                          @Param("viewerOauthUserId") Long viewerOauthUserId,
+                                                          @Param("viewerCanModerateAnyPost")
+                                                          boolean viewerCanModerateAnyPost);
 
     int insertComment(ClubPostComment comment);
 

--- a/backend/src/main/java/com/example/demo/club/model/PublicClubPost.java
+++ b/backend/src/main/java/com/example/demo/club/model/PublicClubPost.java
@@ -35,6 +35,13 @@ public class PublicClubPost {
     // this row once per comment instead of contributing a single count.
     private int commentCount;
 
+    // Computed server-side per request from the viewer's own oauth_user_id and the club's
+    // canManage/platform-owner status (see ClubPostMapper.xml's PublicPostColumnList) -- never
+    // the viewer's or the author's oauth_user_id itself. This is what lets the frontend show a
+    // delete control to the post's own author without either leaking author_oauth_user_id to
+    // every caller or having the frontend infer authorship by comparing display names.
+    private boolean viewerCanDelete;
+
     public Long getId() {
         return id;
     }
@@ -105,5 +112,13 @@ public class PublicClubPost {
 
     public void setCommentCount(int commentCount) {
         this.commentCount = commentCount;
+    }
+
+    public boolean isViewerCanDelete() {
+        return viewerCanDelete;
+    }
+
+    public void setViewerCanDelete(boolean viewerCanDelete) {
+        this.viewerCanDelete = viewerCanDelete;
     }
 }

--- a/backend/src/main/java/com/example/demo/club/model/PublicClubPostComment.java
+++ b/backend/src/main/java/com/example/demo/club/model/PublicClubPostComment.java
@@ -26,6 +26,10 @@ public class PublicClubPostComment {
     private String authorDisplayName;
     private String authorAvatarUrl;
 
+    // Same computed capability as PublicClubPost#isViewerCanDelete: never the viewer's or the
+    // author's oauth_user_id, just the boolean outcome of comparing them server-side.
+    private boolean viewerCanDelete;
+
     public Long getId() {
         return id;
     }
@@ -72,5 +76,13 @@ public class PublicClubPostComment {
 
     public void setAuthorAvatarUrl(String authorAvatarUrl) {
         this.authorAvatarUrl = authorAvatarUrl;
+    }
+
+    public boolean isViewerCanDelete() {
+        return viewerCanDelete;
+    }
+
+    public void setViewerCanDelete(boolean viewerCanDelete) {
+        this.viewerCanDelete = viewerCanDelete;
     }
 }

--- a/backend/src/main/java/com/example/demo/club/service/ClubContentModerationPolicy.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubContentModerationPolicy.java
@@ -23,8 +23,19 @@ public class ClubContentModerationPolicy {
     public boolean canModerate(Long viewerOauthUserId, Long contentAuthorOauthUserId, Club club,
                                 Authentication authentication) {
         boolean isAuthor = viewerOauthUserId != null && viewerOauthUserId.equals(contentAuthorOauthUserId);
-        return isAuthor
-            || Boolean.TRUE.equals(club.getCanManage())
-            || authenticatedUserResolver.isPlatformOwner(authentication);
+        return isAuthor || canModerateAnyContent(club, authentication);
+    }
+
+    /**
+     * The club-wide half of {@link #canModerate}, with no notion of a specific piece of content
+     * or its author: the club's own president ({@code club.canManage}) or a platform owner.
+     * Exposed on its own so callers that only need "does this viewer outrank every author in
+     * this club" -- {@code ClubPostController#feed}'s and {@code ClubPostCommentController#list}'s
+     * {@code viewerCanModerateAnyPost} capability flag, and {@code ClubPostController}'s own
+     * pin/unpin {@code requireManageAccess} guard -- use the exact same branch {@link #canModerate}
+     * itself delegates to here, rather than a second, independently-maintained copy of it.
+     */
+    public boolean canModerateAnyContent(Club club, Authentication authentication) {
+        return Boolean.TRUE.equals(club.getCanManage()) || authenticatedUserResolver.isPlatformOwner(authentication);
     }
 }

--- a/backend/src/main/java/com/example/demo/club/service/ClubPostCommentService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubPostCommentService.java
@@ -32,8 +32,9 @@ public class ClubPostCommentService {
         return clubPostCommentWriter.lockCountAndInsert(clubId, postId, authorOauthUserId, trimmedBody);
     }
 
-    public List<PublicClubPostComment> findPublicComments(Long postId) {
-        return clubPostMapper.findPublicCommentsByPostId(postId);
+    public List<PublicClubPostComment> findPublicComments(Long postId, Long viewerOauthUserId,
+                                                           boolean viewerCanModerateAnyPost) {
+        return clubPostMapper.findPublicCommentsByPostId(postId, viewerOauthUserId, viewerCanModerateAnyPost);
     }
 
     public ClubPostComment findByIdAndPostId(Long commentId, Long postId) {

--- a/backend/src/main/java/com/example/demo/club/service/ClubPostCommentWriter.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubPostCommentWriter.java
@@ -54,7 +54,10 @@ class ClubPostCommentWriter {
         comment.setBody(body);
         clubPostMapper.insertComment(comment);
 
-        PublicClubPostComment created = clubPostMapper.findPublicCommentByIdAndPostId(comment.getId(), postId);
+        // Mirrors ClubPostWriter#insertAndReadBack: the just-created comment's own author is
+        // always the viewer here, so viewerCanDelete reads back true unconditionally.
+        PublicClubPostComment created = clubPostMapper.findPublicCommentByIdAndPostId(
+            comment.getId(), postId, authorOauthUserId, false);
         if (created == null) {
             throw new IllegalStateException(
                 "Comment " + comment.getId() + " was not found immediately after being inserted");

--- a/backend/src/main/java/com/example/demo/club/service/ClubPostService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubPostService.java
@@ -60,12 +60,14 @@ public class ClubPostService {
         }
     }
 
-    public PostFeedPage findPublicFeed(Long clubId, int page, int size) {
+    public PostFeedPage findPublicFeed(Long clubId, int page, int size, Long viewerOauthUserId,
+                                        boolean viewerCanModerateAnyPost) {
         int limit = PaginationClamps.clampPageSize(size);
         int offset = PaginationClamps.clampOffset(page, limit);
         int clampedPage = PaginationClamps.clampPage(page);
 
-        List<PublicClubPost> items = clubPostMapper.findPublicFeedByClubId(clubId, offset, limit);
+        List<PublicClubPost> items = clubPostMapper.findPublicFeedByClubId(
+            clubId, offset, limit, viewerOauthUserId, viewerCanModerateAnyPost);
         int total = clubPostMapper.countFeedByClubId(clubId);
 
         return new PostFeedPage(items, clampedPage, limit, total);

--- a/backend/src/main/java/com/example/demo/club/service/ClubPostWriter.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubPostWriter.java
@@ -46,7 +46,12 @@ class ClubPostWriter {
         post.setImageUrl(imageUrl);
         clubPostMapper.insert(post);
 
-        PublicClubPost created = clubPostMapper.findPublicPostByIdAndClubId(post.getId(), clubId);
+        // The just-created post's own author is always the viewer here, so viewerCanDelete
+        // reads back true through the exact same authorship rule the feed applies to every
+        // other viewer (see ClubPostMapper.xml's PublicPostColumnList) -- viewerCanModerateAnyPost
+        // does not matter in this call because isAuthor already makes the CASE WHEN true.
+        PublicClubPost created = clubPostMapper.findPublicPostByIdAndClubId(
+            post.getId(), clubId, authorOauthUserId, false);
         if (created == null) {
             throw new IllegalStateException(
                 "Post " + post.getId() + " was not found immediately after being inserted");

--- a/backend/src/main/java/com/example/demo/club/service/ImageStorageService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ImageStorageService.java
@@ -51,6 +51,15 @@ public class ImageStorageService {
     private static final int MAX_DIMENSION = 1600;
     private static final float JPEG_QUALITY = 0.82f;
 
+    // Named once so every "we could not sniff a supported format" site (the type is genuinely
+    // unsupported, the stream has no readers at all, or the bytes are truncated before a
+    // reader is even chosen) shows the same actionable copy: which formats are accepted, and
+    // why the iPhone default (HEIC) so often trips this -- iOS Safari's own file picker usually
+    // converts to JPEG for web uploads, but a raw .heic pulled from the Files app is not decodable
+    // here (see #82).
+    private static final String UNSUPPORTED_IMAGE_TYPE_MESSAGE =
+        "Unsupported image type. Supported formats are JPEG, PNG, WebP, and GIF; HEIC is not supported.";
+
     // A UUID (as produced by UUID.randomUUID()) followed by an extension store() could have
     // written: ".jpg"/".gif" under club-posts/, since that is all store() has ever produced;
     // the wider extension set for the flat legacy pattern below matches what the pre-
@@ -167,11 +176,11 @@ public class ImageStorageService {
     private ImageFormat sniffFormat(byte[] bytes) {
         try (ImageInputStream iis = ImageIO.createImageInputStream(new ByteArrayInputStream(bytes))) {
             if (iis == null) {
-                throw new IllegalArgumentException("Unsupported image type");
+                throw new IllegalArgumentException(UNSUPPORTED_IMAGE_TYPE_MESSAGE);
             }
             Iterator<ImageReader> readers = ImageIO.getImageReaders(iis);
             if (!readers.hasNext()) {
-                throw new IllegalArgumentException("Unsupported image type");
+                throw new IllegalArgumentException(UNSUPPORTED_IMAGE_TYPE_MESSAGE);
             }
             ImageReader reader = readers.next();
             try {
@@ -193,7 +202,7 @@ public class ImageStorageService {
         try (ImageInputStream iis = ImageIO.createImageInputStream(new ByteArrayInputStream(bytes))) {
             Iterator<ImageReader> readers = ImageIO.getImageReaders(iis);
             if (!readers.hasNext()) {
-                throw new IllegalArgumentException("Unsupported image type");
+                throw new IllegalArgumentException(UNSUPPORTED_IMAGE_TYPE_MESSAGE);
             }
             ImageReader reader = readers.next();
             try {
@@ -294,7 +303,7 @@ public class ImageStorageService {
                     return GIF;
                 }
             }
-            throw new IllegalArgumentException("Unsupported image type");
+            throw new IllegalArgumentException(UNSUPPORTED_IMAGE_TYPE_MESSAGE);
         }
     }
 }

--- a/backend/src/main/resources/mapper/ClubPostMapper.xml
+++ b/backend/src/main/resources/mapper/ClubPostMapper.xml
@@ -57,6 +57,7 @@
         <result column="author_display_name" property="authorDisplayName" />
         <result column="author_avatar_url" property="authorAvatarUrl" />
         <result column="comment_count" property="commentCount" />
+        <result column="viewer_can_delete" property="viewerCanDelete" />
     </resultMap>
 
     <!-- Shared by findPublicFeedByClubId and findPublicPostByIdAndClubId so a freshly published
@@ -67,13 +68,22 @@
          through as-is: see EpochSecondsInstantTypeHandler's Javadoc for why that (not the raw
          column) is what makes PublicClubPost#createdAt an unambiguous instant instead of a
          wall-clock reading a browser in a different timezone could misread as its own local
-         time. -->
+         time.
+
+         viewer_can_delete is computed here, not exposed as author_oauth_user_id itself: TRUE
+         when the caller already has club-wide moderation power (viewerCanModerateAnyPost, the
+         club's own canManage or a platform owner) or is this row's own author. A NULL
+         viewerOauthUserId (an anonymous caller) makes the equality below unknown, which CASE
+         WHEN treats as false, same as MySQL/H2's own three-valued logic everywhere else in this
+         file. -->
     <sql id="PublicPostColumnList">
         cp.id, cp.club_id, cp.title, cp.image_url, cp.pinned_at,
         UNIX_TIMESTAMP(cp.created_at) AS created_at,
         ou.display_name AS author_display_name,
         ou.avatar_url   AS author_avatar_url,
-        (SELECT COUNT(*) FROM club_post_comment cpc WHERE cpc.post_id = cp.id) AS comment_count
+        (SELECT COUNT(*) FROM club_post_comment cpc WHERE cpc.post_id = cp.id) AS comment_count,
+        CASE WHEN #{viewerCanModerateAnyPost} = TRUE OR cp.author_oauth_user_id = #{viewerOauthUserId}
+             THEN TRUE ELSE FALSE END AS viewer_can_delete
     </sql>
 
     <!-- Deliberately not a wildcard select and not a reuse of ClubMemberView's/
@@ -171,6 +181,7 @@
                 typeHandler="com.example.demo.club.mapper.EpochSecondsInstantTypeHandler" />
         <result column="author_display_name" property="authorDisplayName" />
         <result column="author_avatar_url" property="authorAvatarUrl" />
+        <result column="viewer_can_delete" property="viewerCanDelete" />
     </resultMap>
 
     <!-- Shared by findPublicCommentsByPostId and findPublicCommentByIdAndPostId, mirroring
@@ -180,12 +191,18 @@
          PublicPostColumnList's cp.created_at: see EpochSecondsInstantTypeHandler's Javadoc for
          why that is what makes PublicClubPostComment#createdAt an unambiguous instant instead
          of a wall-clock reading a browser in a different timezone could misread as its own
-         local time. -->
+         local time.
+
+         viewer_can_delete follows the exact same rule as PublicPostColumnList's own column: see
+         that comment for why a NULL viewerOauthUserId (anonymous caller) correctly evaluates to
+         false rather than NULL. -->
     <sql id="PublicCommentColumnList">
         cpc.id, cpc.post_id, cpc.body,
         UNIX_TIMESTAMP(cpc.created_at) AS created_at,
         ou.display_name AS author_display_name,
-        ou.avatar_url   AS author_avatar_url
+        ou.avatar_url   AS author_avatar_url,
+        CASE WHEN #{viewerCanModerateAnyPost} = TRUE OR cpc.author_oauth_user_id = #{viewerOauthUserId}
+             THEN TRUE ELSE FALSE END AS viewer_can_delete
     </sql>
 
     <!-- Oldest first, flat, uncapped by pagination (the 50-comment cap makes it unnecessary,

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostCommentControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostCommentControllerTest.java
@@ -2,6 +2,7 @@ package com.example.demo.club.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -118,11 +119,32 @@ class ClubPostCommentControllerTest {
         when(clubPostService.findByIdAndClubId(9L, 1L)).thenReturn(post);
         PublicClubPostComment comment = new PublicClubPostComment();
         comment.setBody("Nice!");
-        when(clubPostCommentService.findPublicComments(9L)).thenReturn(List.of(comment));
+        when(clubPostCommentService.findPublicComments(eq(9L), any(), anyBoolean())).thenReturn(List.of(comment));
 
         mockMvc.perform(get("/api/clubs/1/posts/9/comments"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$[0].body").value("Nice!"));
+    }
+
+    // Mirrors ClubPostControllerTest's own capability-field test: the delete control for a
+    // comment's own author is driven by this same viewerCanDelete flag, not by comparing display
+    // names.
+    @Test
+    void listItemsCarryViewerCanDeleteFromTheServiceUnchanged() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setStatus("active");
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        ClubPost post = new ClubPost();
+        post.setId(9L);
+        when(clubPostService.findByIdAndClubId(9L, 1L)).thenReturn(post);
+        PublicClubPostComment comment = new PublicClubPostComment();
+        comment.setViewerCanDelete(true);
+        when(clubPostCommentService.findPublicComments(eq(9L), any(), anyBoolean())).thenReturn(List.of(comment));
+
+        mockMvc.perform(get("/api/clubs/1/posts/9/comments"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].viewerCanDelete").value(true));
     }
 
     @Test
@@ -170,7 +192,7 @@ class ClubPostCommentControllerTest {
         ClubPost post = new ClubPost();
         post.setId(9L);
         when(clubPostService.findByIdAndClubId(9L, 1L)).thenReturn(post);
-        when(clubPostCommentService.findPublicComments(9L)).thenReturn(List.of());
+        when(clubPostCommentService.findPublicComments(eq(9L), any(), anyBoolean())).thenReturn(List.of());
 
         mockMvc.perform(get("/api/clubs/1/posts/9/comments").principal(oauthToken(MEMBER_EMAIL)))
             .andExpect(status().isOk());

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostControllerTest.java
@@ -3,6 +3,7 @@ package com.example.demo.club.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -246,7 +247,7 @@ class ClubPostControllerTest {
         club.setId(1L);
         club.setStatus("active");
         when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
-        when(clubPostService.findPublicFeed(eq(1L), anyInt(), anyInt()))
+        when(clubPostService.findPublicFeed(eq(1L), anyInt(), anyInt(), any(), anyBoolean()))
             .thenReturn(new ClubPostService.PostFeedPage(List.of(), 0, 12, 0));
 
         mockMvc.perform(get("/api/clubs/1/posts"))
@@ -266,12 +267,51 @@ class ClubPostControllerTest {
         PublicClubPost post = new PublicClubPost();
         post.setId(9L);
         post.setCommentCount(3);
-        when(clubPostService.findPublicFeed(eq(1L), anyInt(), anyInt()))
+        when(clubPostService.findPublicFeed(eq(1L), anyInt(), anyInt(), any(), anyBoolean()))
             .thenReturn(new ClubPostService.PostFeedPage(List.of(post), 0, 12, 1));
 
         mockMvc.perform(get("/api/clubs/1/posts"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.items[0].commentCount").value(3));
+    }
+
+    // The capability field the frontend uses to show a delete control to a post's own author
+    // without ever seeing an oauth_user_id: the controller must forward the club's own
+    // canManage/platform-owner outcome, not recompute it differently from deletePost's own check.
+    @Test
+    void feedItemsCarryViewerCanDeleteFromTheServiceUnchanged() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setStatus("active");
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        PublicClubPost post = new PublicClubPost();
+        post.setId(9L);
+        post.setViewerCanDelete(true);
+        when(clubPostService.findPublicFeed(eq(1L), anyInt(), anyInt(), any(), anyBoolean()))
+            .thenReturn(new ClubPostService.PostFeedPage(List.of(post), 0, 12, 1));
+
+        mockMvc.perform(get("/api/clubs/1/posts"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.items[0].viewerCanDelete").value(true));
+    }
+
+    // A club's own president must give the controller a viewerCanModerateAnyPost of true, so
+    // the feed's viewerCanDelete can reflect the president's own moderation power over posts
+    // they did not author -- the exact ClubContentModerationPolicy matrix deletePost enforces.
+    @Test
+    void feedComputesViewerCanModerateAnyPostFromTheClubsCanManage() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setStatus("active");
+        club.setCanManage(true);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(clubPostService.findPublicFeed(eq(1L), anyInt(), anyInt(), any(), eq(true)))
+            .thenReturn(new ClubPostService.PostFeedPage(List.of(), 0, 12, 0));
+
+        mockMvc.perform(get("/api/clubs/1/posts").principal(oauthToken(PRESIDENT_EMAIL)))
+            .andExpect(status().isOk());
+
+        verify(clubPostService).findPublicFeed(eq(1L), anyInt(), anyInt(), any(), eq(true));
     }
 
     @Test
@@ -302,7 +342,7 @@ class ClubPostControllerTest {
         club.setStatus("pending");
         club.setViewerIsMember(true);
         when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
-        when(clubPostService.findPublicFeed(eq(1L), anyInt(), anyInt()))
+        when(clubPostService.findPublicFeed(eq(1L), anyInt(), anyInt(), any(), anyBoolean()))
             .thenReturn(new ClubPostService.PostFeedPage(List.of(), 0, 12, 0));
 
         mockMvc.perform(get("/api/clubs/1/posts").principal(oauthToken(MEMBER_EMAIL)))

--- a/backend/src/test/java/com/example/demo/club/controller/ClubPostFeedIntegrationTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubPostFeedIntegrationTest.java
@@ -201,7 +201,8 @@ class ClubPostFeedIntegrationTest {
         long filesBefore = countRegularFiles(clubPostsDir);
         int rowsBefore = countPostRows(clubId);
 
-        doReturn(null).when(clubPostMapperSpy).findPublicPostByIdAndClubId(any(), eq(clubId));
+        doReturn(null).when(clubPostMapperSpy)
+            .findPublicPostByIdAndClubId(any(), eq(clubId), any(), org.mockito.ArgumentMatchers.anyBoolean());
 
         mockMvc.perform(multipart("/api/clubs/" + clubId + "/posts")
                 .file(new MockMultipartFile("file", "photo.jpg", "image/jpeg", tinyJpeg()))
@@ -280,6 +281,36 @@ class ClubPostFeedIntegrationTest {
             .andExpect(jsonPath("$.items", Matchers.hasSize(1)))
             .andExpect(jsonPath("$.items[0].authorDisplayName").value("Ada Lovelace"))
             .andExpect(jsonPath("$.items[0].authorAvatarUrl").value("/uploads/avatar-cache/ada.jpg"));
+    }
+
+    // Full-stack proof of the capability field: the frontend can show a delete control to the
+    // post's own author, and to a club president, without either ever seeing an
+    // author_oauth_user_id or inferring authorship by comparing display names.
+    @Test
+    void feedItemsMarkViewerCanDeleteTrueForTheAuthorAndPresidentButFalseForEveryoneElse() throws Exception {
+        long clubId = createActiveClubWithAMember();
+        insertPost(clubId, "Post 1", null);
+        String presidentEmail = "president@example.com";
+        long presidentUid = insertOauthUser(presidentEmail, "President", null);
+        jdbcTemplate.update(
+            "INSERT INTO club_member (club_id, oauth_user_id, role_name) VALUES (?, ?, 'president')",
+            clubId, presidentUid);
+
+        mockMvc.perform(get("/api/clubs/" + clubId + "/posts").with(authentication(oauthToken(MEMBER_EMAIL))))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.items[0].viewerCanDelete").value(true));
+
+        mockMvc.perform(get("/api/clubs/" + clubId + "/posts").with(authentication(oauthToken(presidentEmail))))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.items[0].viewerCanDelete").value(true));
+
+        mockMvc.perform(get("/api/clubs/" + clubId + "/posts").with(authentication(oauthToken(OUTSIDER_EMAIL))))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.items[0].viewerCanDelete").value(false));
+
+        mockMvc.perform(get("/api/clubs/" + clubId + "/posts"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.items[0].viewerCanDelete").value(false));
     }
 
     // Real DB, real join: proves the correlated subquery in ClubPostMapper.xml's

--- a/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
+++ b/backend/src/test/java/com/example/demo/club/mapper/ClubPostMapperTest.java
@@ -312,7 +312,7 @@ class ClubPostMapperTest {
         insertCommentAt(1L, 1L, "First comment", "2024-01-01 10:00:00");
         insertCommentAt(2L, 1L, "Second comment", "2024-01-02 10:00:00");
 
-        List<PublicClubPostComment> comments = clubPostMapper.findPublicCommentsByPostId(1L);
+        List<PublicClubPostComment> comments = clubPostMapper.findPublicCommentsByPostId(1L, 1L, false);
 
         assertThat(comments).extracting(PublicClubPostComment::getBody)
             .containsExactly("First comment", "Second comment");
@@ -327,7 +327,7 @@ class ClubPostMapperTest {
         insertPost(1L, 1L, "2024-01-01 10:00:00", null);
         insertCommentAt(1L, 1L, "Great photo!", "2024-01-01 10:00:00");
 
-        PublicClubPostComment comment = clubPostMapper.findPublicCommentByIdAndPostId(1L, 1L);
+        PublicClubPostComment comment = clubPostMapper.findPublicCommentByIdAndPostId(1L, 1L, 1L, false);
 
         assertThat(comment).isNotNull();
         assertThat(comment.getBody()).isEqualTo("Great photo!");
@@ -341,7 +341,34 @@ class ClubPostMapperTest {
         insertPost(2L, 1L, "2024-01-02 10:00:00", null);
         insertCommentAt(1L, 1L, "Great photo!", "2024-01-01 10:00:00");
 
-        assertThat(clubPostMapper.findPublicCommentByIdAndPostId(1L, 2L)).isNull();
+        assertThat(clubPostMapper.findPublicCommentByIdAndPostId(1L, 2L, 1L, false)).isNull();
+    }
+
+    // Mirrors findPublicFeedByClubIdMarksViewerCanDeleteTrueOnlyForThePostsOwnAuthor: the same
+    // authorship rule, applied to comment rows instead of post rows.
+    @Test
+    void findPublicCommentsByPostIdMarksViewerCanDeleteTrueOnlyForTheCommentsOwnAuthor() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        insertCommentAt(1L, 1L, "Great photo!", "2024-01-01 10:00:00");
+
+        List<PublicClubPostComment> asAuthor = clubPostMapper.findPublicCommentsByPostId(1L, 1L, false);
+        List<PublicClubPostComment> asSomeoneElse = clubPostMapper.findPublicCommentsByPostId(1L, 2L, false);
+
+        assertThat(asAuthor).singleElement().satisfies(comment -> assertThat(comment.isViewerCanDelete()).isTrue());
+        assertThat(asSomeoneElse).singleElement()
+            .satisfies(comment -> assertThat(comment.isViewerCanDelete()).isFalse());
+    }
+
+    // Mirrors findPublicFeedByClubIdMarksViewerCanDeleteTrueForAModeratorRegardlessOfAuthorship.
+    @Test
+    void findPublicCommentsByPostIdMarksViewerCanDeleteTrueForAModeratorRegardlessOfAuthorship() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+        insertCommentAt(1L, 1L, "Great photo!", "2024-01-01 10:00:00");
+
+        List<PublicClubPostComment> asModerator = clubPostMapper.findPublicCommentsByPostId(1L, 2L, true);
+
+        assertThat(asModerator).singleElement()
+            .satisfies(comment -> assertThat(comment.isViewerCanDelete()).isTrue());
     }
 
     // Mirrors findPublicPostByIdAndClubIdConvertsALiteralCreatedAtUsingTheEffectiveSystemZone:
@@ -354,7 +381,7 @@ class ClubPostMapperTest {
         insertPost(1L, 1L, "2024-01-01 10:00:00", null);
         insertCommentAt(1L, 1L, "Great photo!", "2024-01-01 11:30:00");
 
-        PublicClubPostComment comment = clubPostMapper.findPublicCommentByIdAndPostId(1L, 1L);
+        PublicClubPostComment comment = clubPostMapper.findPublicCommentByIdAndPostId(1L, 1L, 1L, false);
 
         Instant expected = LocalDateTime.of(2024, 1, 1, 11, 30)
             .atZone(ZoneId.systemDefault())
@@ -376,7 +403,7 @@ class ClubPostMapperTest {
     void findPublicFeedByClubIdIncludesAuthorDisplayNameAndAvatarUrl() {
         insertPost(1L, 1L, "2024-01-01 10:00:00", null);
 
-        List<PublicClubPost> feed = clubPostMapper.findPublicFeedByClubId(1L, 0, 10);
+        List<PublicClubPost> feed = clubPostMapper.findPublicFeedByClubId(1L, 0, 10, 1L, false);
 
         assertThat(feed).singleElement().satisfies(post -> {
             assertThat(post.getId()).isEqualTo(1L);
@@ -385,6 +412,43 @@ class ClubPostMapperTest {
             assertThat(post.getAuthorDisplayName()).isEqualTo("Ada Lovelace");
             assertThat(post.getAuthorAvatarUrl()).isEqualTo("/uploads/avatar-cache/ada.jpg");
         });
+    }
+
+    // The capability field's own authorship rule: the post's own author (uid 1, matching
+    // insertPost's default author_oauth_user_id) reads viewer_can_delete true even without
+    // club-wide moderation power, while a different, non-moderating viewer reads false.
+    @Test
+    void findPublicFeedByClubIdMarksViewerCanDeleteTrueOnlyForThePostsOwnAuthor() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+
+        List<PublicClubPost> asAuthor = clubPostMapper.findPublicFeedByClubId(1L, 0, 10, 1L, false);
+        List<PublicClubPost> asSomeoneElse = clubPostMapper.findPublicFeedByClubId(1L, 0, 10, 2L, false);
+
+        assertThat(asAuthor).singleElement().satisfies(post -> assertThat(post.isViewerCanDelete()).isTrue());
+        assertThat(asSomeoneElse).singleElement().satisfies(post -> assertThat(post.isViewerCanDelete()).isFalse());
+    }
+
+    // The other half of the capability rule: a viewer with club-wide moderation power (the
+    // club's own canManage, or a platform owner -- computed by the caller, never by this SQL)
+    // can delete a post they did not author.
+    @Test
+    void findPublicFeedByClubIdMarksViewerCanDeleteTrueForAModeratorRegardlessOfAuthorship() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+
+        List<PublicClubPost> asModerator = clubPostMapper.findPublicFeedByClubId(1L, 0, 10, 2L, true);
+
+        assertThat(asModerator).singleElement().satisfies(post -> assertThat(post.isViewerCanDelete()).isTrue());
+    }
+
+    // An anonymous caller has no oauth_user_id at all; the equality against author_oauth_user_id
+    // must not silently evaluate to unknown-treated-as-true, only to false.
+    @Test
+    void findPublicFeedByClubIdMarksViewerCanDeleteFalseForAnAnonymousViewer() {
+        insertPost(1L, 1L, "2024-01-01 10:00:00", null);
+
+        List<PublicClubPost> asAnonymous = clubPostMapper.findPublicFeedByClubId(1L, 0, 10, null, false);
+
+        assertThat(asAnonymous).singleElement().satisfies(post -> assertThat(post.isViewerCanDelete()).isFalse());
     }
 
     // The public feed card shows a comment count without the caller ever fetching the
@@ -398,7 +462,7 @@ class ClubPostMapperTest {
         insertComment(1L, "First");
         insertComment(1L, "Second");
 
-        List<PublicClubPost> feed = clubPostMapper.findPublicFeedByClubId(1L, 0, 10);
+        List<PublicClubPost> feed = clubPostMapper.findPublicFeedByClubId(1L, 0, 10, 1L, false);
 
         assertThat(feed).extracting(PublicClubPost::getId, PublicClubPost::getCommentCount)
             .containsExactlyInAnyOrder(
@@ -411,7 +475,7 @@ class ClubPostMapperTest {
         insertPost(1L, 1L, "2024-01-01 10:00:00", null);
         insertComment(1L, "Nice!");
 
-        PublicClubPost post = clubPostMapper.findPublicPostByIdAndClubId(1L, 1L);
+        PublicClubPost post = clubPostMapper.findPublicPostByIdAndClubId(1L, 1L, 1L, false);
 
         assertThat(post.getCommentCount()).isEqualTo(1);
     }
@@ -433,7 +497,7 @@ class ClubPostMapperTest {
         insertPost(2L, 1L, "2023-01-01 10:00:00", "2024-06-01 00:00:00");
         insertPost(3L, 1L, "2024-01-02 10:00:00", null);
 
-        List<PublicClubPost> feed = clubPostMapper.findPublicFeedByClubId(1L, 0, 10);
+        List<PublicClubPost> feed = clubPostMapper.findPublicFeedByClubId(1L, 0, 10, 1L, false);
 
         assertThat(feed).extracting(PublicClubPost::getId).containsExactly(2L, 3L, 1L);
         assertThat(feed).extracting(PublicClubPost::getId).doesNotHaveDuplicates();
@@ -450,7 +514,7 @@ class ClubPostMapperTest {
         insertPost(3L, 2L, "2024-01-03 10:00:00", null);
 
         int count = clubPostMapper.countFeedByClubId(1L);
-        List<PublicClubPost> feed = clubPostMapper.findPublicFeedByClubId(1L, 0, 100);
+        List<PublicClubPost> feed = clubPostMapper.findPublicFeedByClubId(1L, 0, 100, 1L, false);
 
         assertThat(count).isEqualTo(2);
         assertThat(feed).hasSize(count);
@@ -464,7 +528,7 @@ class ClubPostMapperTest {
     void findPublicPostByIdAndClubIdReturnsTheSameSafeShapeAsTheFeed() {
         insertPost(1L, 1L, "2024-01-01 10:00:00", null);
 
-        PublicClubPost post = clubPostMapper.findPublicPostByIdAndClubId(1L, 1L);
+        PublicClubPost post = clubPostMapper.findPublicPostByIdAndClubId(1L, 1L, 1L, false);
 
         assertThat(post).isNotNull();
         assertThat(post.getId()).isEqualTo(1L);
@@ -482,7 +546,7 @@ class ClubPostMapperTest {
         jdbcTemplate.update("INSERT INTO clubs (id, name) VALUES (2, 'Robotics')");
         insertPost(1L, 1L, "2024-01-01 10:00:00", null);
 
-        PublicClubPost post = clubPostMapper.findPublicPostByIdAndClubId(1L, 2L);
+        PublicClubPost post = clubPostMapper.findPublicPostByIdAndClubId(1L, 2L, 1L, false);
 
         assertThat(post).isNull();
     }
@@ -505,7 +569,7 @@ class ClubPostMapperTest {
     void findPublicPostByIdAndClubIdConvertsALiteralCreatedAtUsingTheEffectiveSystemZone() {
         insertPost(1L, 1L, "2024-01-01 10:00:00", null);
 
-        PublicClubPost post = clubPostMapper.findPublicPostByIdAndClubId(1L, 1L);
+        PublicClubPost post = clubPostMapper.findPublicPostByIdAndClubId(1L, 1L, 1L, false);
 
         Instant expected = LocalDateTime.of(2024, 1, 1, 10, 0)
             .atZone(ZoneId.systemDefault())

--- a/backend/src/test/java/com/example/demo/club/service/ClubContentModerationPolicyTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubContentModerationPolicyTest.java
@@ -81,4 +81,45 @@ class ClubContentModerationPolicyTest {
 
         assertThat(result).isFalse();
     }
+
+    // canModerateAnyContent is the exact branch ClubPostController#feed and
+    // ClubPostCommentController#list reuse for their own viewerCanModerateAnyPost capability
+    // flag, and ClubPostController#requireManageAccess reuses for pin/unpin: it must agree with
+    // canModerate's own non-author branch in every case, since canModerate delegates to it.
+    @Test
+    void canModerateAnyContentIsTrueForTheClubPresident() {
+        Club club = clubWithCanManage(true);
+        when(authenticatedUserResolver.isPlatformOwner(authentication)).thenReturn(false);
+
+        assertThat(clubContentModerationPolicy.canModerateAnyContent(club, authentication)).isTrue();
+    }
+
+    @Test
+    void canModerateAnyContentIsTrueForAPlatformOwner() {
+        Club club = clubWithCanManage(false);
+        when(authenticatedUserResolver.isPlatformOwner(authentication)).thenReturn(true);
+
+        assertThat(clubContentModerationPolicy.canModerateAnyContent(club, authentication)).isTrue();
+    }
+
+    @Test
+    void canModerateAnyContentIsFalseForAnOrdinaryMember() {
+        Club club = clubWithCanManage(false);
+        when(authenticatedUserResolver.isPlatformOwner(authentication)).thenReturn(false);
+
+        assertThat(clubContentModerationPolicy.canModerateAnyContent(club, authentication)).isFalse();
+    }
+
+    // canModerate must not grant an ordinary member (not the author, not a president, not an
+    // owner) access just because canModerateAnyContent happens to be checked -- this is the
+    // delegation itself under test, not just canModerateAnyContent in isolation.
+    @Test
+    void canModerateDelegatesToCanModerateAnyContentForItsNonAuthorBranch() {
+        Club club = clubWithCanManage(true);
+
+        boolean result = clubContentModerationPolicy.canModerate(99L, AUTHOR_OAUTH_USER_ID, club, authentication);
+
+        assertThat(result).isEqualTo(clubContentModerationPolicy.canModerateAnyContent(club, authentication));
+        assertThat(result).isTrue();
+    }
 }

--- a/backend/src/test/java/com/example/demo/club/service/ClubPostCommentServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubPostCommentServiceTest.java
@@ -84,10 +84,22 @@ class ClubPostCommentServiceTest {
     @Test
     void findPublicCommentsDelegatesToTheMapper() {
         PublicClubPostComment comment = new PublicClubPostComment();
-        when(clubPostMapper.findPublicCommentsByPostId(10L)).thenReturn(List.of(comment));
+        when(clubPostMapper.findPublicCommentsByPostId(10L, 42L, true)).thenReturn(List.of(comment));
 
-        List<PublicClubPostComment> comments = clubPostCommentService.findPublicComments(10L);
+        List<PublicClubPostComment> comments = clubPostCommentService.findPublicComments(10L, 42L, true);
 
         assertThat(comments).containsExactly(comment);
+    }
+
+    // Mirrors ClubPostServiceTest's own capability-plumbing test: the viewer's identity and
+    // moderation power must reach the mapper unchanged, since PublicClubPostComment#viewerCanDelete
+    // is computed entirely by the mapper's own SQL.
+    @Test
+    void findPublicCommentsPassesTheViewerIdentityAndModerationPowerToTheMapperUnchanged() {
+        when(clubPostMapper.findPublicCommentsByPostId(10L, null, false)).thenReturn(List.of());
+
+        clubPostCommentService.findPublicComments(10L, null, false);
+
+        verify(clubPostMapper).findPublicCommentsByPostId(10L, null, false);
     }
 }

--- a/backend/src/test/java/com/example/demo/club/service/ClubPostCommentWriterTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubPostCommentWriterTest.java
@@ -3,6 +3,7 @@ package com.example.demo.club.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -68,7 +69,7 @@ class ClubPostCommentWriterTest {
         when(clubPostMapper.countCommentsByPostId(1L)).thenReturn(49);
         PublicClubPostComment readBack = new PublicClubPostComment();
         readBack.setBody("Nice!");
-        when(clubPostMapper.findPublicCommentByIdAndPostId(99L, 1L)).thenReturn(readBack);
+        when(clubPostMapper.findPublicCommentByIdAndPostId(99L, 1L, 5L, false)).thenReturn(readBack);
 
         clubPostCommentWriter.lockCountAndInsert(10L, 1L, 5L, "Nice!");
 
@@ -86,7 +87,7 @@ class ClubPostCommentWriterTest {
         PublicClubPostComment readBack = new PublicClubPostComment();
         readBack.setId(99L);
         readBack.setAuthorDisplayName("Ada Lovelace");
-        when(clubPostMapper.findPublicCommentByIdAndPostId(99L, 1L)).thenReturn(readBack);
+        when(clubPostMapper.findPublicCommentByIdAndPostId(99L, 1L, 5L, false)).thenReturn(readBack);
 
         PublicClubPostComment result = clubPostCommentWriter.lockCountAndInsert(10L, 1L, 5L, "Nice!");
 
@@ -97,7 +98,7 @@ class ClubPostCommentWriterTest {
     void lockCountAndInsertThrowsWhenTheReadBackFindsNoRow() {
         when(clubPostMapper.lockPostIdForUpdate(1L, 10L)).thenReturn(1L);
         when(clubPostMapper.countCommentsByPostId(1L)).thenReturn(0);
-        when(clubPostMapper.findPublicCommentByIdAndPostId(99L, 1L)).thenReturn(null);
+        when(clubPostMapper.findPublicCommentByIdAndPostId(99L, 1L, 5L, false)).thenReturn(null);
 
         assertThatThrownBy(() -> clubPostCommentWriter.lockCountAndInsert(10L, 1L, 5L, "Nice!"))
             .isInstanceOf(IllegalStateException.class);
@@ -109,7 +110,8 @@ class ClubPostCommentWriterTest {
     void lockCountAndInsertLocksBeforeCountingBeforeInserting() {
         when(clubPostMapper.lockPostIdForUpdate(1L, 10L)).thenReturn(1L);
         when(clubPostMapper.countCommentsByPostId(1L)).thenReturn(0);
-        when(clubPostMapper.findPublicCommentByIdAndPostId(any(), any())).thenReturn(new PublicClubPostComment());
+        when(clubPostMapper.findPublicCommentByIdAndPostId(any(), any(), any(), anyBoolean()))
+            .thenReturn(new PublicClubPostComment());
 
         clubPostCommentWriter.lockCountAndInsert(10L, 1L, 5L, "Nice!");
 

--- a/backend/src/test/java/com/example/demo/club/service/ClubPostServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubPostServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -180,31 +181,34 @@ class ClubPostServiceTest {
 
     @Test
     void findPublicFeedPassesTheClampedOffsetAndLimitToTheMapper() {
-        when(clubPostMapper.findPublicFeedByClubId(eq(1L), anyInt(), anyInt())).thenReturn(List.of());
+        when(clubPostMapper.findPublicFeedByClubId(eq(1L), anyInt(), anyInt(), any(), anyBoolean()))
+            .thenReturn(List.of());
         when(clubPostMapper.countFeedByClubId(1L)).thenReturn(0);
 
-        clubPostService.findPublicFeed(1L, 2, 10);
+        clubPostService.findPublicFeed(1L, 2, 10, 7L, false);
 
-        verify(clubPostMapper).findPublicFeedByClubId(1L, 20, 10);
+        verify(clubPostMapper).findPublicFeedByClubId(1L, 20, 10, 7L, false);
     }
 
     @Test
     void findPublicFeedEchoesTheClampedSizeNotTheRequestedOne() {
-        when(clubPostMapper.findPublicFeedByClubId(eq(1L), anyInt(), anyInt())).thenReturn(List.of());
+        when(clubPostMapper.findPublicFeedByClubId(eq(1L), anyInt(), anyInt(), any(), anyBoolean()))
+            .thenReturn(List.of());
         when(clubPostMapper.countFeedByClubId(1L)).thenReturn(0);
 
-        ClubPostService.PostFeedPage feedPage = clubPostService.findPublicFeed(1L, 0, 1000);
+        ClubPostService.PostFeedPage feedPage = clubPostService.findPublicFeed(1L, 0, 1000, null, false);
 
         assertThat(feedPage.size()).isEqualTo(100);
-        verify(clubPostMapper).findPublicFeedByClubId(1L, 0, 100);
+        verify(clubPostMapper).findPublicFeedByClubId(1L, 0, 100, null, false);
     }
 
     @Test
     void findPublicFeedEchoesTheClampedPageForANegativeRequestedPage() {
-        when(clubPostMapper.findPublicFeedByClubId(eq(1L), anyInt(), anyInt())).thenReturn(List.of());
+        when(clubPostMapper.findPublicFeedByClubId(eq(1L), anyInt(), anyInt(), any(), anyBoolean()))
+            .thenReturn(List.of());
         when(clubPostMapper.countFeedByClubId(1L)).thenReturn(0);
 
-        ClubPostService.PostFeedPage feedPage = clubPostService.findPublicFeed(1L, -5, 10);
+        ClubPostService.PostFeedPage feedPage = clubPostService.findPublicFeed(1L, -5, 10, null, false);
 
         assertThat(feedPage.page()).isEqualTo(0);
     }
@@ -212,15 +216,30 @@ class ClubPostServiceTest {
     @Test
     void findPublicFeedReportsTotalFromTheSharedCountQuery() {
         PublicClubPost item = new PublicClubPost();
-        when(clubPostMapper.findPublicFeedByClubId(eq(1L), anyInt(), anyInt())).thenReturn(List.of(item));
+        when(clubPostMapper.findPublicFeedByClubId(eq(1L), anyInt(), anyInt(), any(), anyBoolean()))
+            .thenReturn(List.of(item));
         when(clubPostMapper.countFeedByClubId(1L)).thenReturn(57);
 
-        ClubPostService.PostFeedPage feedPage = clubPostService.findPublicFeed(1L, 0, 12);
+        ClubPostService.PostFeedPage feedPage = clubPostService.findPublicFeed(1L, 0, 12, null, false);
 
         assertThat(feedPage.items()).containsExactly(item);
         assertThat(feedPage.total()).isEqualTo(57);
         assertThat(feedPage.page()).isEqualTo(0);
         assertThat(feedPage.size()).isEqualTo(12);
+    }
+
+    // The new capability-plumbing contract: whatever the caller passes as the viewer's identity
+    // and moderation power must reach the mapper unchanged, since PublicClubPost#viewerCanDelete
+    // is computed entirely by the mapper's own SQL (see ClubPostMapper.xml's PublicPostColumnList).
+    @Test
+    void findPublicFeedPassesTheViewerIdentityAndModerationPowerToTheMapperUnchanged() {
+        when(clubPostMapper.findPublicFeedByClubId(eq(1L), anyInt(), anyInt(), any(), anyBoolean()))
+            .thenReturn(List.of());
+        when(clubPostMapper.countFeedByClubId(1L)).thenReturn(0);
+
+        clubPostService.findPublicFeed(1L, 0, 10, 42L, true);
+
+        verify(clubPostMapper).findPublicFeedByClubId(1L, 0, 10, 42L, true);
     }
 
     // ---- pin ----

--- a/backend/src/test/java/com/example/demo/club/service/ClubPostWriterTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubPostWriterTest.java
@@ -42,7 +42,7 @@ class ClubPostWriterTest {
     void insertAndReadBackInsertsExactlyWhatItWasGiven() {
         PublicClubPost readBack = new PublicClubPost();
         readBack.setTitle("Meeting recap");
-        when(clubPostMapper.findPublicPostByIdAndClubId(99L, 1L)).thenReturn(readBack);
+        when(clubPostMapper.findPublicPostByIdAndClubId(99L, 1L, 10L, false)).thenReturn(readBack);
 
         clubPostWriter.insertAndReadBack(1L, 10L, "Meeting recap", "/uploads/club-posts/uuid.jpg");
 
@@ -59,7 +59,7 @@ class ClubPostWriterTest {
         PublicClubPost readBack = new PublicClubPost();
         readBack.setId(99L);
         readBack.setAuthorDisplayName("Ada Lovelace");
-        when(clubPostMapper.findPublicPostByIdAndClubId(99L, 1L)).thenReturn(readBack);
+        when(clubPostMapper.findPublicPostByIdAndClubId(99L, 1L, 10L, false)).thenReturn(readBack);
 
         PublicClubPost result =
             clubPostWriter.insertAndReadBack(1L, 10L, "Meeting recap", "/uploads/club-posts/uuid.jpg");
@@ -73,7 +73,7 @@ class ClubPostWriterTest {
     // object.
     @Test
     void insertAndReadBackThrowsWhenTheReadBackFindsNoRow() {
-        when(clubPostMapper.findPublicPostByIdAndClubId(99L, 1L)).thenReturn(null);
+        when(clubPostMapper.findPublicPostByIdAndClubId(99L, 1L, 10L, false)).thenReturn(null);
 
         assertThatThrownBy(() ->
             clubPostWriter.insertAndReadBack(1L, 10L, "Meeting recap", "/uploads/club-posts/uuid.jpg"))

--- a/backend/src/test/java/com/example/demo/club/service/ImageStorageServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ImageStorageServiceTest.java
@@ -56,6 +56,26 @@ class ImageStorageServiceTest {
         assertThatThrownBy(() -> service.store(file)).isInstanceOf(IllegalArgumentException.class);
     }
 
+    // The issue's own requirement (#82): the error a student sees for an unsupported format
+    // (most commonly a raw .heic pulled from the iPhone Files app, since iOS Safari's own file
+    // picker usually converts to JPEG for web uploads) must name every accepted format and call
+    // out that HEIC specifically is not one of them, not just say "unsupported".
+    @Test
+    void rejectsAnUnrecognizedFormatWithAMessageNamingTheAcceptedFormatsAndHeic() {
+        ImageStorageService service = service(uploadDir);
+        byte[] pdfBytes = "%PDF-1.4 not actually an image".getBytes();
+        MockMultipartFile file = new MockMultipartFile("file", "fake.gif", "image/gif", pdfBytes);
+
+        assertThatThrownBy(() -> service.store(file))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("JPEG")
+            .hasMessageContaining("PNG")
+            .hasMessageContaining("WebP")
+            .hasMessageContaining("GIF")
+            .hasMessageContaining("HEIC")
+            .hasMessageContaining("not supported");
+    }
+
     // A magic-byte prefix is enough for ImageIO to pick a candidate reader, but the reader then
     // throws IOException trying to actually parse the (truncated) header -- e.g. real-world
     // partial uploads from a dropped connection. That must surface as a readable 400, not an

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /uploads/
+Disallow: /clubs/*/media

--- a/frontend/src/services/clubPostService.spec.ts
+++ b/frontend/src/services/clubPostService.spec.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  createClubPostComment,
+  deleteClubPost,
+  deleteClubPostComment,
+  pinClubPost,
+  publishClubPost,
+  unpinClubPost,
+} from './clubPostService'
+
+const jsonResponse = (body: unknown) => ({
+  ok: true,
+  text: async () => JSON.stringify(body),
+  json: async () => body,
+})
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchMock = vi.fn()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('publishClubPost', () => {
+  it('sends a POST with FormData carrying the title and file, credentials included, and no explicit Content-Type', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ id: 9, title: 'Meeting recap' }))
+    const file = new File(['image'], 'photo.jpg', { type: 'image/jpeg' })
+
+    await publishClubPost('1', 'Meeting recap', file)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('http://localhost:8080/api/clubs/1/posts')
+    expect(init.method).toBe('POST')
+    expect(init.credentials).toBe('include')
+    expect(init.body).toBeInstanceOf(FormData)
+    const body = init.body as FormData
+    expect(body.get('title')).toBe('Meeting recap')
+    expect(body.get('file')).toBe(file)
+    // The browser must supply its own multipart boundary; an explicit Content-Type here would
+    // corrupt it (see clubPostService.ts's own comment on why this cannot go through request()).
+    expect(init.headers).toBeUndefined()
+  })
+
+  it('resolves with the created post parsed from the response body', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ id: 9, title: 'Meeting recap' }))
+
+    const created = await publishClubPost('1', 'Meeting recap', new File(['image'], 'photo.jpg'))
+
+    expect(created).toEqual({ id: 9, title: 'Meeting recap' })
+  })
+
+  it('rejects with the server error message verbatim on a non-2xx response', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () => 'Title must be 140 characters or fewer',
+    })
+
+    await expect(publishClubPost('1', 'x'.repeat(141), new File(['image'], 'photo.jpg'))).rejects.toThrow(
+      'Title must be 140 characters or fewer',
+    )
+  })
+})
+
+describe('deleteClubPost', () => {
+  it('sends a DELETE to the post resource with credentials included', async () => {
+    fetchMock.mockResolvedValue({ ok: true, text: async () => '' })
+
+    await deleteClubPost('1', 9)
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('http://localhost:8080/api/clubs/1/posts/9')
+    expect(init.method).toBe('DELETE')
+    expect(init.credentials).toBe('include')
+  })
+
+  it('rejects with the server error message verbatim on a 403', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: async () => 'You do not have access to delete this post',
+    })
+
+    await expect(deleteClubPost('1', 9)).rejects.toThrow('You do not have access to delete this post')
+  })
+})
+
+describe('pinClubPost and unpinClubPost', () => {
+  it('sends a PUT to pin', async () => {
+    fetchMock.mockResolvedValue({ ok: true, text: async () => '' })
+
+    await pinClubPost('1', 9)
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('http://localhost:8080/api/clubs/1/posts/9/pin')
+    expect(init.method).toBe('PUT')
+  })
+
+  it('sends a DELETE to unpin', async () => {
+    fetchMock.mockResolvedValue({ ok: true, text: async () => '' })
+
+    await unpinClubPost('1', 9)
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('http://localhost:8080/api/clubs/1/posts/9/pin')
+    expect(init.method).toBe('DELETE')
+  })
+
+  it('rejects with the pin cap message verbatim on a 409', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 409,
+      text: async () => 'At most 3 posts can be pinned. Unpin one first.',
+    })
+
+    await expect(pinClubPost('1', 9)).rejects.toThrow('At most 3 posts can be pinned. Unpin one first.')
+  })
+})
+
+describe('createClubPostComment', () => {
+  it('sends a POST with a JSON body containing the comment text', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ id: 5, body: 'Nice!' }))
+
+    await createClubPostComment('1', 9, 'Nice!')
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('http://localhost:8080/api/clubs/1/posts/9/comments')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body as string)).toEqual({ body: 'Nice!' })
+  })
+
+  it('rejects with the comment cap message verbatim on a 409', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 409,
+      text: async () => 'This post already has the maximum number of comments',
+    })
+
+    await expect(createClubPostComment('1', 9, 'Nice!')).rejects.toThrow(
+      'This post already has the maximum number of comments',
+    )
+  })
+})
+
+describe('deleteClubPostComment', () => {
+  it('sends a DELETE to the comment resource', async () => {
+    fetchMock.mockResolvedValue({ ok: true, text: async () => '' })
+
+    await deleteClubPostComment('1', 9, 5)
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('http://localhost:8080/api/clubs/1/posts/9/comments/5')
+    expect(init.method).toBe('DELETE')
+  })
+})

--- a/frontend/src/services/clubPostService.ts
+++ b/frontend/src/services/clubPostService.ts
@@ -1,4 +1,4 @@
-import type { ClubPostComment, ClubPostFeedPage } from '../types/clubPost'
+import type { ClubPost, ClubPostComment, ClubPostFeedPage } from '../types/clubPost'
 import { buildApiUrl } from './httpClient'
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
@@ -32,3 +32,56 @@ export const fetchClubPostComments = (
   request<ClubPostComment[]>(
     `/api/clubs/${clubIdOrSlug}/posts/${postId}/comments`,
   )
+
+// Deliberately not routed through request(): that helper does not set a Content-Type, but a
+// caller could still be tempted to add one for a "JSON-like" POST. FormData needs the browser
+// to supply its own multipart boundary in Content-Type, so this mirrors
+// ClubAdminView#handleImageUpload's raw fetch exactly rather than reusing request().
+export const publishClubPost = async (
+  clubIdOrSlug: number | string,
+  title: string,
+  file: File,
+): Promise<ClubPost> => {
+  const formData = new FormData()
+  formData.append('title', title)
+  formData.append('file', file)
+  const response = await fetch(buildApiUrl(`/api/clubs/${clubIdOrSlug}/posts`), {
+    method: 'POST',
+    credentials: 'include',
+    body: formData,
+  })
+  if (!response.ok) {
+    const message = await response.text()
+    throw new Error(message || `Request failed with status ${response.status}`)
+  }
+  return (await response.json()) as ClubPost
+}
+
+export const deleteClubPost = (clubIdOrSlug: number | string, postId: number | string) =>
+  request<void>(`/api/clubs/${clubIdOrSlug}/posts/${postId}`, { method: 'DELETE' })
+
+export const pinClubPost = (clubIdOrSlug: number | string, postId: number | string) =>
+  request<void>(`/api/clubs/${clubIdOrSlug}/posts/${postId}/pin`, { method: 'PUT' })
+
+export const unpinClubPost = (clubIdOrSlug: number | string, postId: number | string) =>
+  request<void>(`/api/clubs/${clubIdOrSlug}/posts/${postId}/pin`, { method: 'DELETE' })
+
+export const createClubPostComment = (
+  clubIdOrSlug: number | string,
+  postId: number | string,
+  body: string,
+) =>
+  request<ClubPostComment>(`/api/clubs/${clubIdOrSlug}/posts/${postId}/comments`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ body }),
+  })
+
+export const deleteClubPostComment = (
+  clubIdOrSlug: number | string,
+  postId: number | string,
+  commentId: number | string,
+) =>
+  request<void>(`/api/clubs/${clubIdOrSlug}/posts/${postId}/comments/${commentId}`, {
+    method: 'DELETE',
+  })

--- a/frontend/src/types/clubPost.ts
+++ b/frontend/src/types/clubPost.ts
@@ -13,6 +13,13 @@ export interface ClubPost {
   authorDisplayName: string
   authorAvatarUrl: string | null
   commentCount: number
+  /**
+   * Computed by the backend from the viewer's own identity and the club's canManage/platform-
+   * owner status (see PublicClubPost#isViewerCanDelete's Javadoc) -- never the author's or the
+   * viewer's own oauth_user_id. Drives the delete control without inferring authorship from
+   * display names.
+   */
+  viewerCanDelete: boolean
 }
 
 export interface ClubPostComment {
@@ -27,6 +34,8 @@ export interface ClubPostComment {
    * "Z") -- safe to hand straight to `new Date(...)`.
    */
   createdAt: string
+  /** Same capability contract as ClubPost#viewerCanDelete, applied to a single comment. */
+  viewerCanDelete: boolean
 }
 
 export interface ClubPostFeedPage {

--- a/frontend/src/views/ClubMediaView.spec.ts
+++ b/frontend/src/views/ClubMediaView.spec.ts
@@ -107,6 +107,22 @@ const buildAuthUser = (overrides: Partial<AuthUser> = {}): AuthUser => ({
   ...overrides,
 })
 
+// Lets a test control exactly when a mocked fetchClubMediaFeed call resolves, so an ordering
+// scenario (an older request's response arriving after a newer one) can be reproduced
+// deterministically instead of hoping a real race happens to line up the same way.
+interface Deferred<T> {
+  promise: Promise<T>
+  resolve: (value: T) => void
+}
+
+const createDeferred = <T,>(): Deferred<T> => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
 let router: Router
 
 const mountAtMediaRoute = async (path = '/clubs/1/media') => {
@@ -905,6 +921,63 @@ describe('ClubMediaView post deletion pagination regressions', () => {
     expect(fetchClubMediaFeedMock).toHaveBeenCalledTimes(2)
     expect(router.currentRoute.value.query.page).toBeUndefined()
     expect(wrapper.text()).toContain('No posts yet.')
+  })
+
+  // The exact race the second review round called out: a delete's own backfill fetch for the
+  // page the viewer is leaving must not clobber an immediate Next click's own, newer load --
+  // deterministic via a manually-resolved (deferred) promise rather than hoping a real race
+  // lines up the same way on every test run.
+  it('ignores a stale post-delete backfill response for the old page when Next was clicked before it resolved', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValueOnce(
+      buildFeed({
+        items: [
+          buildPost({ id: 1, title: 'Post 1', viewerCanDelete: true }),
+          buildPost({ id: 2, title: 'Post 2' }),
+        ],
+        page: 0,
+        size: 2,
+        total: 4,
+      }),
+    )
+    const backfillDeferred = createDeferred<ClubPostFeedPage>()
+    fetchClubMediaFeedMock.mockReturnValueOnce(backfillDeferred.promise)
+    const nextPageDeferred = createDeferred<ClubPostFeedPage>()
+    fetchClubMediaFeedMock.mockReturnValueOnce(nextPageDeferred.promise)
+    deleteClubPostMock.mockResolvedValue(undefined)
+
+    const wrapper = await mountAtMediaRoute('/clubs/1/media?page=0&size=2')
+    await flushPromises()
+
+    // Deleting post 1 leaves post 2 on the page (never an empty list), so the Next button stays
+    // mounted and enabled while its own backfill fetch for page 0 is still in flight below.
+    await wrapper.find('.mv-post-delete').trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).toContain('Post 2')
+
+    // The viewer navigates to the next page before that backfill fetch has resolved.
+    await wrapper.find('.mv-pagination button:last-of-type').trigger('click')
+    await flushPromises()
+
+    // The Next navigation's own, newer fetch resolves first.
+    nextPageDeferred.resolve(buildFeed({ items: [buildPost({ id: 4, title: 'Post 4' })], page: 1, size: 2, total: 3 }))
+    await flushPromises()
+
+    expect(router.currentRoute.value.query.page).toBe('1')
+    expect(wrapper.text()).toContain('Post 4')
+    expect(wrapper.find('.mv-pagination-status').text()).toBe('Page 2 of 2')
+
+    // The stale backfill for the abandoned page 0 finally resolves and must be ignored entirely:
+    // no write to posts/page/size/total, and no navigation.
+    backfillDeferred.resolve(
+      buildFeed({ items: [buildPost({ id: 99, title: 'Stale Backfill Post' })], page: 0, size: 2, total: 1 }),
+    )
+    await flushPromises()
+
+    expect(router.currentRoute.value.query.page).toBe('1')
+    expect(wrapper.text()).toContain('Post 4')
+    expect(wrapper.text()).not.toContain('Stale Backfill Post')
+    expect(wrapper.find('.mv-pagination-status').text()).toBe('Page 2 of 2')
   })
 })
 

--- a/frontend/src/views/ClubMediaView.spec.ts
+++ b/frontend/src/views/ClubMediaView.spec.ts
@@ -9,10 +9,25 @@ vi.mock('../services/clubService', () => ({
 vi.mock('../services/clubPostService', () => ({
   fetchClubMediaFeed: vi.fn(),
   fetchClubPostComments: vi.fn(),
+  publishClubPost: vi.fn(),
+  deleteClubPost: vi.fn(),
+  pinClubPost: vi.fn(),
+  unpinClubPost: vi.fn(),
+  createClubPostComment: vi.fn(),
+  deleteClubPostComment: vi.fn(),
 }))
 
 import { fetchClubById } from '../services/clubService'
-import { fetchClubMediaFeed, fetchClubPostComments } from '../services/clubPostService'
+import {
+  fetchClubMediaFeed,
+  fetchClubPostComments,
+  publishClubPost,
+  deleteClubPost,
+  pinClubPost,
+  unpinClubPost,
+  createClubPostComment,
+  deleteClubPostComment,
+} from '../services/clubPostService'
 import type { Club } from '../types/club'
 import type { ClubPost, ClubPostComment, ClubPostFeedPage } from '../types/clubPost'
 import ClubMediaView from './ClubMediaView.vue'
@@ -20,6 +35,12 @@ import ClubMediaView from './ClubMediaView.vue'
 const fetchClubByIdMock = vi.mocked(fetchClubById)
 const fetchClubMediaFeedMock = vi.mocked(fetchClubMediaFeed)
 const fetchClubPostCommentsMock = vi.mocked(fetchClubPostComments)
+const publishClubPostMock = vi.mocked(publishClubPost)
+const deleteClubPostMock = vi.mocked(deleteClubPost)
+const pinClubPostMock = vi.mocked(pinClubPost)
+const unpinClubPostMock = vi.mocked(unpinClubPost)
+const createClubPostCommentMock = vi.mocked(createClubPostComment)
+const deleteClubPostCommentMock = vi.mocked(deleteClubPostComment)
 
 const buildClub = (overrides: Partial<Club> = {}): Club => ({
   id: 1,
@@ -35,6 +56,7 @@ const buildClub = (overrides: Partial<Club> = {}): Club => ({
   imageUrl: null,
   memberCount: 42,
   achievements: [],
+  viewerIsMember: false,
   canManage: false,
   ...overrides,
 })
@@ -49,6 +71,7 @@ const buildPost = (overrides: Partial<ClubPost> = {}): ClubPost => ({
   authorDisplayName: 'Ada Lovelace',
   authorAvatarUrl: '/uploads/avatar-cache/ada.jpg',
   commentCount: 0,
+  viewerCanDelete: false,
   ...overrides,
 })
 
@@ -67,6 +90,7 @@ const buildComment = (overrides: Partial<ClubPostComment> = {}): ClubPostComment
   authorAvatarUrl: null,
   body: 'Great photo!',
   createdAt: new Date().toISOString(),
+  viewerCanDelete: false,
   ...overrides,
 })
 
@@ -86,10 +110,21 @@ beforeEach(() => {
   fetchClubByIdMock.mockReset()
   fetchClubMediaFeedMock.mockReset()
   fetchClubPostCommentsMock.mockReset()
+  publishClubPostMock.mockReset()
+  deleteClubPostMock.mockReset()
+  pinClubPostMock.mockReset()
+  unpinClubPostMock.mockReset()
+  createClubPostCommentMock.mockReset()
+  deleteClubPostCommentMock.mockReset()
+  vi.stubGlobal('URL', Object.assign(URL, {
+    createObjectURL: vi.fn(() => 'blob:mock-preview'),
+    revokeObjectURL: vi.fn(),
+  }))
 })
 
 afterEach(() => {
   document.head.querySelectorAll('meta[name="robots"]').forEach((node) => node.remove())
+  vi.unstubAllGlobals()
 })
 
 describe('ClubMediaView loading, error and empty states', () => {
@@ -385,6 +420,418 @@ describe('ClubMediaView comments', () => {
 
     expect(toggle.attributes('aria-expanded')).toBe('true')
     expect(toggle.attributes('aria-controls')).toBe(regionId)
+  })
+})
+
+describe('ClubMediaView publish form', () => {
+  it('hides the publish form from a non-member', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub({ viewerIsMember: false }))
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed())
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    expect(wrapper.find('.mv-publish').exists()).toBe(false)
+  })
+
+  it('shows the publish form, a public-visibility notice, and the supported formats to a member', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub({ viewerIsMember: true }))
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed())
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    const publishSection = wrapper.find('.mv-publish')
+    expect(publishSection.exists()).toBe(true)
+    expect(publishSection.text()).toContain('visible to anyone')
+    expect(publishSection.text()).toContain('logged in')
+    expect(publishSection.text()).toContain('JPEG')
+    expect(publishSection.text()).toContain('PNG')
+    expect(publishSection.text()).toContain('WebP')
+    expect(publishSection.text()).toContain('GIF')
+    expect(publishSection.text()).toContain('HEIC')
+    expect(publishSection.text()).toContain('not supported')
+  })
+
+  it('counts down the title character limit as the member types', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub({ viewerIsMember: true }))
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed())
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    expect(wrapper.find('.mv-publish .mv-counter').text()).toBe('0/140')
+
+    await wrapper.find('.mv-publish-title-input').setValue('Meeting recap')
+
+    expect(wrapper.find('.mv-publish .mv-counter').text()).toBe('13/140')
+  })
+
+  it('shows a local preview of the selected photo via URL.createObjectURL and revokes it when a new file replaces it', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub({ viewerIsMember: true }))
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed())
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    expect(wrapper.find('.mv-publish-preview').exists()).toBe(false)
+
+    const fileInput = wrapper.find<HTMLInputElement>('.mv-publish-file-input')
+    const firstFile = new File(['a'], 'first.jpg', { type: 'image/jpeg' })
+    Object.defineProperty(fileInput.element, 'files', { configurable: true, value: [firstFile] })
+    await fileInput.trigger('change')
+
+    expect(URL.createObjectURL).toHaveBeenCalledWith(firstFile)
+    expect(wrapper.find('.mv-publish-preview').attributes('src')).toBe('blob:mock-preview')
+
+    const secondFile = new File(['b'], 'second.jpg', { type: 'image/jpeg' })
+    Object.defineProperty(fileInput.element, 'files', { configurable: true, value: [secondFile] })
+    await fileInput.trigger('change')
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-preview')
+    expect(URL.createObjectURL).toHaveBeenCalledWith(secondFile)
+  })
+
+  it('revokes the preview URL on unmount', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub({ viewerIsMember: true }))
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed())
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    const fileInput = wrapper.find<HTMLInputElement>('.mv-publish-file-input')
+    Object.defineProperty(fileInput.element, 'files', {
+      configurable: true,
+      value: [new File(['a'], 'first.jpg', { type: 'image/jpeg' })],
+    })
+    await fileInput.trigger('change')
+
+    wrapper.unmount()
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-preview')
+  })
+
+  it('submits the title and file via publishClubPost and prepends the created post without a manual reload', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub({ viewerIsMember: true }))
+    fetchClubMediaFeedMock.mockResolvedValue(
+      buildFeed({ items: [buildPost({ id: 1, title: 'Existing post' })], total: 1 }),
+    )
+    const created = buildPost({ id: 99, title: 'Meeting recap', viewerCanDelete: true })
+    publishClubPostMock.mockResolvedValue(created)
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    await wrapper.find('.mv-publish-title-input').setValue('Meeting recap')
+    const file = new File(['a'], 'photo.jpg', { type: 'image/jpeg' })
+    const fileInput = wrapper.find<HTMLInputElement>('.mv-publish-file-input')
+    Object.defineProperty(fileInput.element, 'files', { configurable: true, value: [file] })
+    await fileInput.trigger('change')
+
+    await wrapper.find('.mv-publish-form').trigger('submit')
+    await flushPromises()
+
+    expect(publishClubPostMock).toHaveBeenCalledWith('1', 'Meeting recap', file)
+    expect(fetchClubMediaFeedMock).toHaveBeenCalledTimes(1)
+    const titles = wrapper.findAll('.mv-post-title').map((node) => node.text())
+    expect(titles).toEqual(['Meeting recap', 'Existing post'])
+  })
+
+  it('clears the form after a successful publish', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub({ viewerIsMember: true }))
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed())
+    publishClubPostMock.mockResolvedValue(buildPost({ id: 99 }))
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    await wrapper.find('.mv-publish-title-input').setValue('Meeting recap')
+    const fileInput = wrapper.find<HTMLInputElement>('.mv-publish-file-input')
+    Object.defineProperty(fileInput.element, 'files', {
+      configurable: true,
+      value: [new File(['a'], 'photo.jpg', { type: 'image/jpeg' })],
+    })
+    await fileInput.trigger('change')
+
+    await wrapper.find('.mv-publish-form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.find<HTMLInputElement>('.mv-publish-title-input').element.value).toBe('')
+    expect(wrapper.find('.mv-publish-preview').exists()).toBe(false)
+  })
+
+  it('shows a required-photo message and does not call publishClubPost when no file is selected', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub({ viewerIsMember: true }))
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed())
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    await wrapper.find('.mv-publish-title-input').setValue('Meeting recap')
+    await wrapper.find('.mv-publish-form').trigger('submit')
+    await flushPromises()
+
+    expect(publishClubPostMock).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('A photo is required')
+  })
+
+  it('surfaces the server error message verbatim, including the unsupported-format wording', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub({ viewerIsMember: true }))
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed())
+    publishClubPostMock.mockRejectedValue(
+      new Error('Unsupported image type. Supported formats are JPEG, PNG, WebP, and GIF; HEIC is not supported.'),
+    )
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    await wrapper.find('.mv-publish-title-input').setValue('Meeting recap')
+    const fileInput = wrapper.find<HTMLInputElement>('.mv-publish-file-input')
+    Object.defineProperty(fileInput.element, 'files', {
+      configurable: true,
+      value: [new File(['a'], 'photo.heic', { type: 'image/heic' })],
+    })
+    await fileInput.trigger('change')
+    await wrapper.find('.mv-publish-form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain(
+      'Unsupported image type. Supported formats are JPEG, PNG, WebP, and GIF; HEIC is not supported.',
+    )
+  })
+})
+
+describe('ClubMediaView comment form', () => {
+  it('hides the comment form from a non-member', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub({ viewerIsMember: false }))
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 7 })], total: 1 }))
+    fetchClubPostCommentsMock.mockResolvedValue([])
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('.mv-comment-form').exists()).toBe(false)
+  })
+
+  it('shows a comment form with a 300 character counter to a member', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub({ viewerIsMember: true }))
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 7 })], total: 1 }))
+    fetchClubPostCommentsMock.mockResolvedValue([])
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    await flushPromises()
+
+    const form = wrapper.find('.mv-comment-form')
+    expect(form.exists()).toBe(true)
+    expect(form.find('.mv-counter').text()).toBe('0/300')
+
+    await form.find('.mv-comment-input').setValue('Nice photo!')
+
+    expect(form.find('.mv-counter').text()).toBe('11/300')
+  })
+
+  it('submits a comment, appends it to the list, and bumps the comment count without a manual reload', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub({ viewerIsMember: true }))
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 7, commentCount: 0 })], total: 1 }))
+    fetchClubPostCommentsMock.mockResolvedValue([])
+    createClubPostCommentMock.mockResolvedValue(buildComment({ id: 5, body: 'Nice photo!' }))
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    await flushPromises()
+
+    await wrapper.find('.mv-comment-form .mv-comment-input').setValue('Nice photo!')
+    await wrapper.find('.mv-comment-form').trigger('submit')
+    await flushPromises()
+
+    expect(createClubPostCommentMock).toHaveBeenCalledWith('1', 7, 'Nice photo!')
+    expect(wrapper.find('.mv-comment-body').text()).toBe('Nice photo!')
+    expect(wrapper.text()).toContain('Hide comments')
+    expect(wrapper.find('.mv-comment-form .mv-comment-input').element).toHaveProperty('value', '')
+  })
+
+  it('surfaces the comment cap error message verbatim', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub({ viewerIsMember: true }))
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 7 })], total: 1 }))
+    fetchClubPostCommentsMock.mockResolvedValue([])
+    createClubPostCommentMock.mockRejectedValue(new Error('This post already has 50 comments'))
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    await flushPromises()
+
+    await wrapper.find('.mv-comment-form .mv-comment-input').setValue('One more!')
+    await wrapper.find('.mv-comment-form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('This post already has 50 comments')
+  })
+})
+
+describe('ClubMediaView post and comment deletion', () => {
+  it('shows a delete button on a post only when the post grants viewerCanDelete', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValue(
+      buildFeed({
+        items: [
+          buildPost({ id: 1, viewerCanDelete: true }),
+          buildPost({ id: 2, viewerCanDelete: false }),
+        ],
+        total: 2,
+      }),
+    )
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    const cards = wrapper.findAll('li.mv-post-card')
+    expect(cards[0]!.find('.mv-post-delete').exists()).toBe(true)
+    expect(cards[1]!.find('.mv-post-delete').exists()).toBe(false)
+  })
+
+  it('deletes a post and removes it from the feed without a manual reload', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValue(
+      buildFeed({ items: [buildPost({ id: 1, viewerCanDelete: true })], total: 1 }),
+    )
+    deleteClubPostMock.mockResolvedValue(undefined)
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    await wrapper.find('.mv-post-delete').trigger('click')
+    await flushPromises()
+
+    expect(deleteClubPostMock).toHaveBeenCalledWith('1', 1)
+    expect(fetchClubMediaFeedMock).toHaveBeenCalledTimes(1)
+    expect(wrapper.find('li.mv-post-card').exists()).toBe(false)
+    expect(wrapper.text()).toContain('No posts yet.')
+  })
+
+  it('surfaces a 403 delete error message verbatim and keeps the post visible', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValue(
+      buildFeed({ items: [buildPost({ id: 1, viewerCanDelete: true })], total: 1 }),
+    )
+    deleteClubPostMock.mockRejectedValue(new Error('You do not have access to delete this post'))
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    await wrapper.find('.mv-post-delete').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('You do not have access to delete this post')
+    expect(wrapper.find('li.mv-post-card').exists()).toBe(true)
+  })
+
+  it('shows a delete button on a comment only when the comment grants viewerCanDelete', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 7 })], total: 1 }))
+    fetchClubPostCommentsMock.mockResolvedValue([
+      buildComment({ id: 1, viewerCanDelete: true }),
+      buildComment({ id: 2, viewerCanDelete: false }),
+    ])
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    await flushPromises()
+
+    const comments = wrapper.findAll('li.mv-comment')
+    expect(comments[0]!.find('.mv-comment-delete').exists()).toBe(true)
+    expect(comments[1]!.find('.mv-comment-delete').exists()).toBe(false)
+  })
+
+  it('deletes a comment and decrements the comment count without a manual reload', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 7, commentCount: 1 })], total: 1 }))
+    fetchClubPostCommentsMock.mockResolvedValue([buildComment({ id: 1, viewerCanDelete: true })])
+    deleteClubPostCommentMock.mockResolvedValue(undefined)
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    await flushPromises()
+
+    await wrapper.find('.mv-comment-delete').trigger('click')
+    await flushPromises()
+
+    expect(deleteClubPostCommentMock).toHaveBeenCalledWith('1', 7, 1)
+    expect(wrapper.find('.mv-comment').exists()).toBe(false)
+    expect(wrapper.text()).toContain('No comments yet.')
+  })
+})
+
+describe('ClubMediaView pin and unpin', () => {
+  it('shows pin controls only when the viewer canManage the club', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub({ canManage: false }))
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 1 })], total: 1 }))
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    expect(wrapper.find('.mv-pin-toggle').exists()).toBe(false)
+  })
+
+  it('pins an unpinned post and relabels the control to Unpin', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub({ canManage: true }))
+    fetchClubMediaFeedMock.mockResolvedValue(
+      buildFeed({ items: [buildPost({ id: 1, pinnedAt: null })], total: 1 }),
+    )
+    pinClubPostMock.mockResolvedValue(undefined)
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    expect(wrapper.find('.mv-pin-toggle').text()).toBe('Pin')
+    await wrapper.find('.mv-pin-toggle').trigger('click')
+    await flushPromises()
+
+    expect(pinClubPostMock).toHaveBeenCalledWith('1', 1)
+    expect(wrapper.find('.mv-pin-toggle').text()).toBe('Unpin')
+    expect(wrapper.find('.mv-badge-pinned').exists()).toBe(true)
+  })
+
+  it('unpins a pinned post and relabels the control to Pin', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub({ canManage: true }))
+    fetchClubMediaFeedMock.mockResolvedValue(
+      buildFeed({ items: [buildPost({ id: 1, pinnedAt: '2024-06-01T00:00:00Z' })], total: 1 }),
+    )
+    unpinClubPostMock.mockResolvedValue(undefined)
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    expect(wrapper.find('.mv-pin-toggle').text()).toBe('Unpin')
+    await wrapper.find('.mv-pin-toggle').trigger('click')
+    await flushPromises()
+
+    expect(unpinClubPostMock).toHaveBeenCalledWith('1', 1)
+    expect(wrapper.find('.mv-pin-toggle').text()).toBe('Pin')
+    expect(wrapper.find('.mv-badge-pinned').exists()).toBe(false)
+  })
+
+  it('surfaces the pin cap 409 message verbatim', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub({ canManage: true }))
+    fetchClubMediaFeedMock.mockResolvedValue(
+      buildFeed({ items: [buildPost({ id: 1, pinnedAt: null })], total: 1 }),
+    )
+    pinClubPostMock.mockRejectedValue(new Error('At most 3 posts can be pinned. Unpin one first.'))
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    await wrapper.find('.mv-pin-toggle').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('At most 3 posts can be pinned. Unpin one first.')
   })
 })
 

--- a/frontend/src/views/ClubMediaView.spec.ts
+++ b/frontend/src/views/ClubMediaView.spec.ts
@@ -107,20 +107,23 @@ const buildAuthUser = (overrides: Partial<AuthUser> = {}): AuthUser => ({
   ...overrides,
 })
 
-// Lets a test control exactly when a mocked fetchClubMediaFeed call resolves, so an ordering
-// scenario (an older request's response arriving after a newer one) can be reproduced
-// deterministically instead of hoping a real race happens to line up the same way.
+// Lets a test control exactly when and how a mocked fetch call settles (resolve or reject), so
+// an ordering scenario (an older request's response arriving after a newer one) can be
+// reproduced deterministically instead of hoping a real race happens to line up the same way.
 interface Deferred<T> {
   promise: Promise<T>
   resolve: (value: T) => void
+  reject: (reason: unknown) => void
 }
 
 const createDeferred = <T,>(): Deferred<T> => {
   let resolve!: (value: T) => void
-  const promise = new Promise<T>((res) => {
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
     resolve = res
+    reject = rej
   })
-  return { promise, resolve }
+  return { promise, resolve, reject }
 }
 
 let router: Router
@@ -706,7 +709,8 @@ describe('ClubMediaView comment form', () => {
   it('submits a comment, appends it to the list, and bumps the comment count without a manual reload', async () => {
     fetchClubByIdMock.mockResolvedValue(buildClub({ viewerIsMember: true }))
     fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 7, commentCount: 0 })], total: 1 }))
-    fetchClubPostCommentsMock.mockResolvedValue([])
+    fetchClubPostCommentsMock.mockResolvedValueOnce([])
+    fetchClubPostCommentsMock.mockResolvedValueOnce([buildComment({ id: 5, body: 'Nice photo!' })])
     createClubPostCommentMock.mockResolvedValue(buildComment({ id: 5, body: 'Nice photo!' }))
 
     const wrapper = await mountAtMediaRoute()
@@ -722,6 +726,12 @@ describe('ClubMediaView comment form', () => {
     expect(wrapper.find('.mv-comment-body').text()).toBe('Nice photo!')
     expect(wrapper.text()).toContain('Hide comments')
     expect(wrapper.find('.mv-comment-form .mv-comment-input').element).toHaveProperty('value', '')
+
+    // The comment count comes from the reconciled server list's own length (1), not the
+    // optimistic +1 layered on top of it -- collapsing back to the toggle's own label is what
+    // surfaces post.commentCount, proving the two were never added together.
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    expect(wrapper.text()).toContain('Show comments (1)')
   })
 
   it('surfaces the comment cap error message verbatim', async () => {
@@ -740,6 +750,92 @@ describe('ClubMediaView comment form', () => {
     await flushPromises()
 
     expect(wrapper.text()).toContain('This post already has 50 comments')
+  })
+
+  // The final #82 review finding: a comments GET issued before a submit (e.g. from expanding
+  // the panel) can still be in flight when that submit's own reconciliation fetch completes.
+  // Deterministic via a manually-resolved (deferred) promise for the original GET, so the exact
+  // "older request settles after the newer one" ordering is forced rather than hoped for.
+  it('shows the complete server list and ignores a stale GET that resolves after a submit made while the initial load was still pending', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub({ viewerIsMember: true }))
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 7, commentCount: 1 })], total: 1 }))
+    const initialGetDeferred = createDeferred<ClubPostComment[]>()
+    fetchClubPostCommentsMock.mockReturnValueOnce(initialGetDeferred.promise)
+    fetchClubPostCommentsMock.mockResolvedValueOnce([
+      buildComment({ id: 5, body: 'Earlier comment' }),
+      buildComment({ id: 6, body: 'Nice photo!' }),
+    ])
+    createClubPostCommentMock.mockResolvedValue(buildComment({ id: 6, body: 'Nice photo!' }))
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    // Expanding comments issues a GET that is deliberately left pending below.
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).toContain('Loading comments')
+
+    // The member submits a comment while that GET is still in flight.
+    await wrapper.find('.mv-comment-form .mv-comment-input').setValue('Nice photo!')
+    await wrapper.find('.mv-comment-form').trigger('submit')
+    await flushPromises()
+
+    const commentBodies = () => wrapper.findAll('.mv-comment-body').map((node) => node.text())
+
+    // The submit's own reconciliation fetch (the newer, second mocked call) has already
+    // resolved with the authoritative, complete list -- immediate, useful feedback, not just
+    // a lone optimistic comment.
+    expect(wrapper.text()).not.toContain('Loading comments')
+    expect(commentBodies()).toEqual(['Earlier comment', 'Nice photo!'])
+
+    // The original, now-stale GET finally resolves with a pre-submission snapshot that is
+    // missing the new comment entirely.
+    initialGetDeferred.resolve([])
+    await flushPromises()
+
+    // That stale response must be discarded outright: the complete list stays exactly as the
+    // reconciliation left it, and the new comment is never dropped.
+    expect(commentBodies()).toEqual(['Earlier comment', 'Nice photo!'])
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    expect(wrapper.text()).toContain('Show comments (2)')
+  })
+
+  // Same race as above, but the stale, older GET settles by rejecting instead of resolving --
+  // proving the generation guard discards a late error the same way it discards a late success.
+  it('shows the complete server list and ignores a stale GET that errors after a submit made while the initial load was still pending', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub({ viewerIsMember: true }))
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 7, commentCount: 1 })], total: 1 }))
+    const initialGetDeferred = createDeferred<ClubPostComment[]>()
+    fetchClubPostCommentsMock.mockReturnValueOnce(initialGetDeferred.promise)
+    fetchClubPostCommentsMock.mockResolvedValueOnce([
+      buildComment({ id: 5, body: 'Earlier comment' }),
+      buildComment({ id: 6, body: 'Nice photo!' }),
+    ])
+    createClubPostCommentMock.mockResolvedValue(buildComment({ id: 6, body: 'Nice photo!' }))
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).toContain('Loading comments')
+
+    await wrapper.find('.mv-comment-form .mv-comment-input').setValue('Nice photo!')
+    await wrapper.find('.mv-comment-form').trigger('submit')
+    await flushPromises()
+
+    const commentBodies = () => wrapper.findAll('.mv-comment-body').map((node) => node.text())
+    expect(commentBodies()).toEqual(['Earlier comment', 'Nice photo!'])
+
+    // The original GET finally settles, but by erroring rather than resolving.
+    initialGetDeferred.reject(new Error('Network error'))
+    await flushPromises()
+
+    // The stale rejection must not revert the panel to an error state or drop the new comment.
+    expect(commentBodies()).toEqual(['Earlier comment', 'Nice photo!'])
+    expect(wrapper.text()).not.toContain('Network error')
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    expect(wrapper.text()).toContain('Show comments (2)')
   })
 })
 

--- a/frontend/src/views/ClubMediaView.spec.ts
+++ b/frontend/src/views/ClubMediaView.spec.ts
@@ -1,4 +1,5 @@
 import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
 import { createMemoryHistory, createRouter, type Router } from 'vue-router'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -28,6 +29,8 @@ import {
   createClubPostComment,
   deleteClubPostComment,
 } from '../services/clubPostService'
+import { useAuthStore } from '../stores/auth'
+import type { AuthUser } from '../types/auth'
 import type { Club } from '../types/club'
 import type { ClubPost, ClubPostComment, ClubPostFeedPage } from '../types/clubPost'
 import ClubMediaView from './ClubMediaView.vue'
@@ -94,6 +97,16 @@ const buildComment = (overrides: Partial<ClubPostComment> = {}): ClubPostComment
   ...overrides,
 })
 
+const buildAuthUser = (overrides: Partial<AuthUser> = {}): AuthUser => ({
+  id: '1',
+  email: 'owner@example.com',
+  displayName: 'Platform Owner',
+  avatarUrl: '',
+  provider: 'google',
+  isOwner: true,
+  ...overrides,
+})
+
 let router: Router
 
 const mountAtMediaRoute = async (path = '/clubs/1/media') => {
@@ -107,6 +120,7 @@ const mountAtMediaRoute = async (path = '/clubs/1/media') => {
 }
 
 beforeEach(() => {
+  setActivePinia(createPinia())
   fetchClubByIdMock.mockReset()
   fetchClubMediaFeedMock.mockReset()
   fetchClubPostCommentsMock.mockReset()
@@ -296,6 +310,45 @@ describe('ClubMediaView pagination', () => {
 
     expect(fetchClubMediaFeedMock).toHaveBeenCalledTimes(2)
     expect(fetchClubByIdMock).toHaveBeenCalledTimes(1)
+  })
+
+  // A stale post/comment action error or an unsent comment draft must never survive a feed
+  // context reload: it is scoped to a specific post id on the page the viewer just left, and a
+  // later page reusing that same id (however unlikely in production) must start clean rather
+  // than silently resurface someone else's leftover error text or half-typed comment.
+  it('clears a stale per-post action error and an unsent comment draft when the page changes', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub({ viewerIsMember: true }))
+    fetchClubMediaFeedMock.mockResolvedValueOnce(
+      buildFeed({ items: [buildPost({ id: 7, viewerCanDelete: true })], page: 0, size: 12, total: 24 }),
+    )
+    fetchClubMediaFeedMock.mockResolvedValueOnce(
+      buildFeed({ items: [buildPost({ id: 7 })], page: 1, size: 12, total: 24 }),
+    )
+    fetchClubPostCommentsMock.mockResolvedValue([])
+    deleteClubPostMock.mockRejectedValue(new Error('You do not have access to delete this post'))
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    await wrapper.find('.mv-post-delete').trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).toContain('You do not have access to delete this post')
+
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    await flushPromises()
+    await wrapper.find('.mv-comment-form .mv-comment-input').setValue('Draft that should not survive a page change')
+    expect(wrapper.find<HTMLTextAreaElement>('.mv-comment-form .mv-comment-input').element.value).toBe(
+      'Draft that should not survive a page change',
+    )
+
+    await wrapper.find('.mv-pagination button:last-of-type').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('You do not have access to delete this post')
+
+    await wrapper.find('.mv-comments-toggle').trigger('click')
+    await flushPromises()
+    expect(wrapper.find<HTMLTextAreaElement>('.mv-comment-form .mv-comment-input').element.value).toBe('')
   })
 })
 
@@ -695,11 +748,12 @@ describe('ClubMediaView post and comment deletion', () => {
     expect(cards[1]!.find('.mv-post-delete').exists()).toBe(false)
   })
 
-  it('deletes a post and removes it from the feed without a manual reload', async () => {
+  it('deletes a post, backfills the current page from the server, and removes it from the feed without a manual reload', async () => {
     fetchClubByIdMock.mockResolvedValue(buildClub())
-    fetchClubMediaFeedMock.mockResolvedValue(
+    fetchClubMediaFeedMock.mockResolvedValueOnce(
       buildFeed({ items: [buildPost({ id: 1, viewerCanDelete: true })], total: 1 }),
     )
+    fetchClubMediaFeedMock.mockResolvedValueOnce(buildFeed({ items: [], total: 0 }))
     deleteClubPostMock.mockResolvedValue(undefined)
 
     const wrapper = await mountAtMediaRoute()
@@ -709,7 +763,8 @@ describe('ClubMediaView post and comment deletion', () => {
     await flushPromises()
 
     expect(deleteClubPostMock).toHaveBeenCalledWith('1', 1)
-    expect(fetchClubMediaFeedMock).toHaveBeenCalledTimes(1)
+    expect(fetchClubMediaFeedMock).toHaveBeenCalledTimes(2)
+    expect(fetchClubMediaFeedMock).toHaveBeenNthCalledWith(2, '1', 0, 12)
     expect(wrapper.find('li.mv-post-card').exists()).toBe(false)
     expect(wrapper.text()).toContain('No posts yet.')
   })
@@ -769,9 +824,139 @@ describe('ClubMediaView post and comment deletion', () => {
   })
 })
 
+describe('ClubMediaView post deletion pagination regressions', () => {
+  it('backfills the current page with the item that slides up from the next page after a delete', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValueOnce(
+      buildFeed({
+        items: [
+          buildPost({ id: 1, title: 'Post 1', viewerCanDelete: true }),
+          buildPost({ id: 2, title: 'Post 2' }),
+        ],
+        page: 0,
+        size: 2,
+        total: 3,
+      }),
+    )
+    fetchClubMediaFeedMock.mockResolvedValueOnce(
+      buildFeed({
+        items: [buildPost({ id: 2, title: 'Post 2' }), buildPost({ id: 3, title: 'Post 3' })],
+        page: 0,
+        size: 2,
+        total: 2,
+      }),
+    )
+    deleteClubPostMock.mockResolvedValue(undefined)
+
+    const wrapper = await mountAtMediaRoute('/clubs/1/media?page=0&size=2')
+    await flushPromises()
+
+    await wrapper.find('.mv-post-delete').trigger('click')
+    await flushPromises()
+
+    expect(fetchClubMediaFeedMock).toHaveBeenCalledTimes(2)
+    expect(fetchClubMediaFeedMock).toHaveBeenNthCalledWith(2, '1', 0, 2)
+    const titles = wrapper.findAll('.mv-post-title').map((node) => node.text())
+    expect(titles).toEqual(['Post 2', 'Post 3'])
+  })
+
+  // The stranding scenario the issue calls out: deleting the only post on a nonzero page must
+  // not leave the viewer looking at an empty page when earlier pages still have content.
+  it('navigates back to the previous page when deleting the last item strands the viewer on an emptied nonzero page', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValueOnce(
+      buildFeed({ items: [buildPost({ id: 2, title: 'Post 2', viewerCanDelete: true })], page: 1, size: 1, total: 2 }),
+    )
+    fetchClubMediaFeedMock.mockResolvedValueOnce(buildFeed({ items: [], page: 1, size: 1, total: 1 }))
+    fetchClubMediaFeedMock.mockResolvedValueOnce(
+      buildFeed({ items: [buildPost({ id: 1, title: 'Post 1' })], page: 0, size: 1, total: 1 }),
+    )
+    deleteClubPostMock.mockResolvedValue(undefined)
+
+    const wrapper = await mountAtMediaRoute('/clubs/1/media?page=1&size=1')
+    await flushPromises()
+    expect(wrapper.text()).toContain('Post 2')
+
+    await wrapper.find('.mv-post-delete').trigger('click')
+    await flushPromises()
+
+    expect(fetchClubMediaFeedMock).toHaveBeenCalledTimes(3)
+    expect(fetchClubMediaFeedMock).toHaveBeenNthCalledWith(2, '1', 1, 1)
+    expect(fetchClubMediaFeedMock).toHaveBeenNthCalledWith(3, '1', 0, 1)
+    expect(router.currentRoute.value.query.page).toBe('0')
+    expect(wrapper.text()).toContain('Post 1')
+    expect(wrapper.text()).toContain('Page 1 of 1')
+  })
+
+  it('does not navigate away when deleting the last item leaves page zero empty', async () => {
+    fetchClubByIdMock.mockResolvedValue(buildClub())
+    fetchClubMediaFeedMock.mockResolvedValueOnce(
+      buildFeed({ items: [buildPost({ id: 1, viewerCanDelete: true })], page: 0, size: 12, total: 1 }),
+    )
+    fetchClubMediaFeedMock.mockResolvedValueOnce(buildFeed({ items: [], page: 0, size: 12, total: 0 }))
+    deleteClubPostMock.mockResolvedValue(undefined)
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    await wrapper.find('.mv-post-delete').trigger('click')
+    await flushPromises()
+
+    expect(fetchClubMediaFeedMock).toHaveBeenCalledTimes(2)
+    expect(router.currentRoute.value.query.page).toBeUndefined()
+    expect(wrapper.text()).toContain('No posts yet.')
+  })
+})
+
 describe('ClubMediaView pin and unpin', () => {
   it('shows pin controls only when the viewer canManage the club', async () => {
     fetchClubByIdMock.mockResolvedValue(buildClub({ canManage: false }))
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 1 })], total: 1 }))
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    expect(wrapper.find('.mv-pin-toggle').exists()).toBe(false)
+  })
+
+  // A platform owner is not necessarily a member of every club, so they will never be its
+  // president -- club.canManage stays false for them -- but the pin/unpin power must still
+  // reach them, the same club.canManage-or-owner pattern ClubAdminView already relies on.
+  it('shows pin controls for a platform owner even when the club reports canManage as false', async () => {
+    const authStore = useAuthStore()
+    authStore.currentUser = buildAuthUser({ isOwner: true })
+    fetchClubByIdMock.mockResolvedValue(buildClub({ canManage: false }))
+    fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 1 })], total: 1 }))
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    expect(wrapper.find('.mv-pin-toggle').exists()).toBe(true)
+  })
+
+  it('pins a post as a platform owner who is not the club president', async () => {
+    const authStore = useAuthStore()
+    authStore.currentUser = buildAuthUser({ isOwner: true })
+    fetchClubByIdMock.mockResolvedValue(buildClub({ canManage: false }))
+    fetchClubMediaFeedMock.mockResolvedValue(
+      buildFeed({ items: [buildPost({ id: 1, pinnedAt: null })], total: 1 }),
+    )
+    pinClubPostMock.mockResolvedValue(undefined)
+
+    const wrapper = await mountAtMediaRoute()
+    await flushPromises()
+
+    await wrapper.find('.mv-pin-toggle').trigger('click')
+    await flushPromises()
+
+    expect(pinClubPostMock).toHaveBeenCalledWith('1', 1)
+    expect(wrapper.find('.mv-badge-pinned').exists()).toBe(true)
+  })
+
+  it('hides pin controls from an ordinary member who is neither the president nor a platform owner', async () => {
+    const authStore = useAuthStore()
+    authStore.currentUser = buildAuthUser({ isOwner: false })
+    fetchClubByIdMock.mockResolvedValue(buildClub({ canManage: false, viewerIsMember: true }))
     fetchClubMediaFeedMock.mockResolvedValue(buildFeed({ items: [buildPost({ id: 1 })], total: 1 }))
 
     const wrapper = await mountAtMediaRoute()

--- a/frontend/src/views/ClubMediaView.vue
+++ b/frontend/src/views/ClubMediaView.vue
@@ -55,6 +55,13 @@ const error = ref('')
 
 const expandedPostIds = ref<Set<number>>(new Set())
 const commentsByPost = ref<Record<number, CommentsEntry>>({})
+// A per-post monotonically increasing counter, never reset (not even by `load()`'s own state
+// reset): the single source of truth for "which in-flight comments request is the newest one"
+// for a given post. Comparing a response's captured generation against the live one at
+// resolution time is what lets loadComments and reconcileCommentsAfterSubmit below tell a
+// still-relevant response apart from a stale one that must be discarded, regardless of which
+// of two in-flight requests happens to resolve (or reject) last.
+const commentsRequestGeneration = ref<Record<number, number>>({})
 let loadedClubId: string | null = null
 
 const routeClubId = computed(() => {
@@ -147,18 +154,37 @@ const isExpanded = (postId: number) => expandedPostIds.value.has(postId)
 const emptyCommentsEntry: CommentsEntry = { loading: false, error: '', comments: [] }
 const commentsState = (postId: number) => commentsByPost.value[postId] ?? emptyCommentsEntry
 
+// Claims the next generation number for a post's comments request and records it as the live
+// one; a caller compares its own captured number against `commentsRequestGeneration.value[postId]`
+// once its request settles to know whether it is still the newest one.
+const bumpCommentsGeneration = (postId: number) => {
+  const next = (commentsRequestGeneration.value[postId] ?? 0) + 1
+  commentsRequestGeneration.value = { ...commentsRequestGeneration.value, [postId]: next }
+  return next
+}
+
 const loadComments = async (postId: number) => {
+  const generation = bumpCommentsGeneration(postId)
   commentsByPost.value = {
     ...commentsByPost.value,
     [postId]: { loading: true, error: '', comments: [] },
   }
   try {
     const comments = await fetchClubPostComments(routeClubId.value, postId)
+    if (commentsRequestGeneration.value[postId] !== generation) {
+      // A newer request for this same post (another loadComments call, or a post-submit
+      // reconciliation) has since superseded this one; applying this stale response now would
+      // silently undo whatever that newer request already wrote.
+      return
+    }
     commentsByPost.value = {
       ...commentsByPost.value,
       [postId]: { loading: false, error: '', comments },
     }
   } catch (err) {
+    if (commentsRequestGeneration.value[postId] !== generation) {
+      return
+    }
     const message = err instanceof Error ? err.message : 'Failed to load comments'
     commentsByPost.value = {
       ...commentsByPost.value,
@@ -265,6 +291,10 @@ const submitComment = async (postId: number) => {
   commentForms.value = { ...commentForms.value, [postId]: { ...state, submitting: true, error: '' } }
   try {
     const created = await createClubPostComment(routeClubId.value, postId, state.body)
+    // Immediate, useful feedback: show the just-created comment right away, appended to
+    // whatever is currently displayed -- even if that is empty because the list was still
+    // loading or had errored. reconcileCommentsAfterSubmit below replaces this with the
+    // authoritative server list right after, so this optimistic view is never the last word.
     const existing = commentsState(postId)
     commentsByPost.value = {
       ...commentsByPost.value,
@@ -274,12 +304,43 @@ const submitComment = async (postId: number) => {
       post.id === postId ? { ...post, commentCount: post.commentCount + 1 } : post,
     )
     commentForms.value = { ...commentForms.value, [postId]: { ...emptyCommentFormState } }
+    await reconcileCommentsAfterSubmit(postId)
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Failed to post comment'
     commentForms.value = {
       ...commentForms.value,
       [postId]: { ...state, submitting: false, error: message },
     }
+  }
+}
+
+// A comment box is usable even while its post's comment list is still loading or has errored
+// (the form does not wait on that state -- see the template), so the optimistic append in
+// submitComment above can start from an incomplete or empty list. Worse, an older loadComments
+// GET issued before this submit (e.g. from expanding the comments panel) can still be in flight
+// and would otherwise resolve afterwards with a pre-submission snapshot that clobbers the new
+// comment. Refetching here under the same generation-token guard loadComments uses fixes both:
+// whichever request for this post is actually the newest is the only one ever applied, and the
+// comment count is set from the authoritative list's own length rather than layered on top of
+// the optimistic +1 above, so the two can never double-count.
+const reconcileCommentsAfterSubmit = async (postId: number) => {
+  const generation = bumpCommentsGeneration(postId)
+  try {
+    const comments = await fetchClubPostComments(routeClubId.value, postId)
+    if (commentsRequestGeneration.value[postId] !== generation) {
+      return
+    }
+    commentsByPost.value = {
+      ...commentsByPost.value,
+      [postId]: { loading: false, error: '', comments },
+    }
+    posts.value = posts.value.map((post) =>
+      post.id === postId ? { ...post, commentCount: comments.length } : post,
+    )
+  } catch {
+    // The comment itself was already posted successfully -- the optimistic append above is
+    // still visible -- so a failed reconciliation fetch does not surface a second, confusing
+    // error for an action that already succeeded.
   }
 }
 

--- a/frontend/src/views/ClubMediaView.vue
+++ b/frontend/src/views/ClubMediaView.vue
@@ -2,7 +2,16 @@
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { fetchClubById } from '../services/clubService'
-import { fetchClubMediaFeed, fetchClubPostComments } from '../services/clubPostService'
+import {
+  fetchClubMediaFeed,
+  fetchClubPostComments,
+  publishClubPost,
+  deleteClubPost,
+  pinClubPost,
+  unpinClubPost,
+  createClubPostComment,
+  deleteClubPostComment,
+} from '../services/clubPostService'
 import type { Club } from '../types/club'
 import type { ClubPost, ClubPostComment } from '../types/clubPost'
 import { clubPostImage } from '../utils/clubImages'
@@ -10,11 +19,23 @@ import { userAvatar } from '../utils/avatarImages'
 import BackButton from '../components/BackButton.vue'
 
 const DEFAULT_PAGE_SIZE = 12
+const TITLE_MAX_LENGTH = 140
+const COMMENT_MAX_LENGTH = 300
+const SUPPORTED_FORMATS_NOTICE =
+  'Supported formats: JPEG, PNG, WebP, and GIF. HEIC (the default photo format on many iPhones) is not supported.'
+const PUBLIC_VISIBILITY_NOTICE =
+  'This photo will be visible to anyone who visits this page, including people who are not logged in.'
 
 interface CommentsEntry {
   loading: boolean
   error: string
   comments: ClubPostComment[]
+}
+
+interface CommentFormState {
+  body: string
+  submitting: boolean
+  error: string
 }
 
 const route = useRoute()
@@ -143,6 +164,203 @@ const toggleComments = (postId: number) => {
   }
 }
 
+// ---- Publishing (member-only) ----
+
+const publishTitle = ref('')
+const publishFile = ref<File | null>(null)
+const publishPreviewUrl = ref('')
+const publishing = ref(false)
+const publishError = ref('')
+const publishFileInput = ref<HTMLInputElement | null>(null)
+
+const revokePublishPreview = () => {
+  if (publishPreviewUrl.value) {
+    URL.revokeObjectURL(publishPreviewUrl.value)
+    publishPreviewUrl.value = ''
+  }
+}
+
+const handlePublishFileChange = (event: Event) => {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0] ?? null
+  revokePublishPreview()
+  publishFile.value = file
+  if (file) {
+    publishPreviewUrl.value = URL.createObjectURL(file)
+  }
+}
+
+const resetPublishForm = () => {
+  publishTitle.value = ''
+  publishFile.value = null
+  revokePublishPreview()
+  if (publishFileInput.value) {
+    publishFileInput.value.value = ''
+  }
+}
+
+// Raw fetch with FormData and no explicit Content-Type (see publishClubPost's own Javadoc-style
+// comment): the created post is prepended locally so the feed updates without a page reload or
+// a second round trip back to the server.
+const handlePublish = async () => {
+  if (!club.value || publishing.value) {
+    return
+  }
+  if (!publishFile.value) {
+    publishError.value = 'A photo is required'
+    return
+  }
+
+  publishing.value = true
+  publishError.value = ''
+  try {
+    const created = await publishClubPost(routeClubId.value, publishTitle.value, publishFile.value)
+    posts.value = [created, ...posts.value]
+    total.value += 1
+    resetPublishForm()
+  } catch (err) {
+    publishError.value = err instanceof Error ? err.message : 'Failed to publish post'
+  } finally {
+    publishing.value = false
+  }
+}
+
+// ---- Commenting (member-only) ----
+
+const commentForms = ref<Record<number, CommentFormState>>({})
+const emptyCommentFormState: CommentFormState = { body: '', submitting: false, error: '' }
+
+const commentFormState = (postId: number) => commentForms.value[postId] ?? emptyCommentFormState
+
+const updateCommentBody = (postId: number, body: string) => {
+  commentForms.value = {
+    ...commentForms.value,
+    [postId]: { ...commentFormState(postId), body },
+  }
+}
+
+const submitComment = async (postId: number) => {
+  const state = commentFormState(postId)
+  if (state.submitting) {
+    return
+  }
+  commentForms.value = { ...commentForms.value, [postId]: { ...state, submitting: true, error: '' } }
+  try {
+    const created = await createClubPostComment(routeClubId.value, postId, state.body)
+    const existing = commentsState(postId)
+    commentsByPost.value = {
+      ...commentsByPost.value,
+      [postId]: { loading: false, error: '', comments: [...existing.comments, created] },
+    }
+    posts.value = posts.value.map((post) =>
+      post.id === postId ? { ...post, commentCount: post.commentCount + 1 } : post,
+    )
+    commentForms.value = { ...commentForms.value, [postId]: { ...emptyCommentFormState } }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to post comment'
+    commentForms.value = {
+      ...commentForms.value,
+      [postId]: { ...state, submitting: false, error: message },
+    }
+  }
+}
+
+// ---- Post deletion, pin/unpin, and comment deletion ----
+
+const postActionError = ref<Record<number, string>>({})
+const deletingPostIds = ref<Set<number>>(new Set())
+const pinningPostIds = ref<Set<number>>(new Set())
+const commentActionError = ref<Record<number, string>>({})
+const deletingCommentIds = ref<Set<number>>(new Set())
+
+const isDeletingPost = (postId: number) => deletingPostIds.value.has(postId)
+const isPinningPost = (postId: number) => pinningPostIds.value.has(postId)
+const isDeletingComment = (commentId: number) => deletingCommentIds.value.has(commentId)
+
+const handleDeletePost = async (postId: number) => {
+  if (isDeletingPost(postId)) {
+    return
+  }
+  const next = new Set(deletingPostIds.value)
+  next.add(postId)
+  deletingPostIds.value = next
+  postActionError.value = { ...postActionError.value, [postId]: '' }
+  try {
+    await deleteClubPost(routeClubId.value, postId)
+    posts.value = posts.value.filter((post) => post.id !== postId)
+    total.value = Math.max(0, total.value - 1)
+  } catch (err) {
+    postActionError.value = {
+      ...postActionError.value,
+      [postId]: err instanceof Error ? err.message : 'Failed to delete post',
+    }
+  } finally {
+    const cleared = new Set(deletingPostIds.value)
+    cleared.delete(postId)
+    deletingPostIds.value = cleared
+  }
+}
+
+const handleTogglePin = async (post: ClubPost) => {
+  if (isPinningPost(post.id)) {
+    return
+  }
+  const next = new Set(pinningPostIds.value)
+  next.add(post.id)
+  pinningPostIds.value = next
+  postActionError.value = { ...postActionError.value, [post.id]: '' }
+  try {
+    if (post.pinnedAt) {
+      await unpinClubPost(routeClubId.value, post.id)
+      posts.value = posts.value.map((p) => (p.id === post.id ? { ...p, pinnedAt: null } : p))
+    } else {
+      await pinClubPost(routeClubId.value, post.id)
+      posts.value = posts.value.map((p) =>
+        p.id === post.id ? { ...p, pinnedAt: new Date().toISOString() } : p,
+      )
+    }
+  } catch (err) {
+    postActionError.value = {
+      ...postActionError.value,
+      [post.id]: err instanceof Error ? err.message : 'Failed to update pin',
+    }
+  } finally {
+    const cleared = new Set(pinningPostIds.value)
+    cleared.delete(post.id)
+    pinningPostIds.value = cleared
+  }
+}
+
+const handleDeleteComment = async (postId: number, commentId: number) => {
+  if (isDeletingComment(commentId)) {
+    return
+  }
+  const next = new Set(deletingCommentIds.value)
+  next.add(commentId)
+  deletingCommentIds.value = next
+  commentActionError.value = { ...commentActionError.value, [commentId]: '' }
+  try {
+    await deleteClubPostComment(routeClubId.value, postId, commentId)
+    const existing = commentsState(postId)
+    commentsByPost.value = {
+      ...commentsByPost.value,
+      [postId]: { ...existing, comments: existing.comments.filter((comment) => comment.id !== commentId) },
+    }
+    posts.value = posts.value.map((post) =>
+      post.id === postId ? { ...post, commentCount: Math.max(0, post.commentCount - 1) } : post,
+    )
+  } catch (err) {
+    commentActionError.value = {
+      ...commentActionError.value,
+      [commentId]: err instanceof Error ? err.message : 'Failed to delete comment',
+    }
+  } finally {
+    const cleared = new Set(deletingCommentIds.value)
+    cleared.delete(commentId)
+    deletingCommentIds.value = cleared
+  }
+}
+
 const relativeTimeFormatter = new Intl.RelativeTimeFormat('en', { numeric: 'auto' })
 const relativeTimeDivisions: Array<[Intl.RelativeTimeFormatUnit, number]> = [
   ['year', 60 * 60 * 24 * 365],
@@ -191,6 +409,7 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  revokePublishPreview()
   const existing = document.head.querySelector('meta[name="robots"]')
   if (!existing) {
     return
@@ -229,6 +448,51 @@ watch(
         <p class="mv-subtitle">Activity photos and updates shared by club members.</p>
       </header>
 
+      <section v-if="club?.viewerIsMember" class="mv-publish">
+        <h2 class="mv-publish-title">Share an update</h2>
+        <p class="mv-publish-notice">{{ PUBLIC_VISIBILITY_NOTICE }}</p>
+        <form class="mv-publish-form" @submit.prevent="handlePublish">
+          <label class="mv-field">
+            <span>Title</span>
+            <input
+              v-model="publishTitle"
+              type="text"
+              class="mv-publish-title-input"
+              :maxlength="TITLE_MAX_LENGTH"
+              placeholder="What's happening?"
+              :disabled="publishing"
+            />
+          </label>
+          <p class="mv-counter">{{ publishTitle.length }}/{{ TITLE_MAX_LENGTH }}</p>
+
+          <label class="mv-field">
+            <span>Photo</span>
+            <input
+              ref="publishFileInput"
+              type="file"
+              class="mv-publish-file-input"
+              accept="image/jpeg,image/png,image/webp,image/gif"
+              :disabled="publishing"
+              @change="handlePublishFileChange"
+            />
+          </label>
+          <p class="mv-format-notice">{{ SUPPORTED_FORMATS_NOTICE }}</p>
+
+          <img
+            v-if="publishPreviewUrl"
+            :src="publishPreviewUrl"
+            alt="Selected photo preview"
+            class="mv-publish-preview"
+          />
+
+          <p v-if="publishError" class="mv-status mv-status--error">{{ publishError }}</p>
+
+          <button type="submit" class="mv-publish-submit" :disabled="publishing">
+            {{ publishing ? 'Publishing…' : 'Publish' }}
+          </button>
+        </form>
+      </section>
+
       <p v-if="posts.length === 0" class="mv-empty">No posts yet. Check back soon.</p>
 
       <ul v-else class="mv-post-list">
@@ -260,6 +524,32 @@ watch(
             >
               {{ isExpanded(post.id) ? 'Hide comments' : `Show comments (${post.commentCount})` }}
             </button>
+
+            <p v-if="postActionError[post.id]" class="mv-status mv-status--error">
+              {{ postActionError[post.id] }}
+            </p>
+
+            <div v-if="club?.canManage || post.viewerCanDelete" class="mv-post-actions">
+              <button
+                v-if="club?.canManage"
+                type="button"
+                class="mv-pin-toggle"
+                :disabled="isPinningPost(post.id)"
+                @click="handleTogglePin(post)"
+              >
+                {{ post.pinnedAt ? 'Unpin' : 'Pin' }}
+              </button>
+              <button
+                v-if="post.viewerCanDelete"
+                type="button"
+                class="mv-post-delete"
+                :disabled="isDeletingPost(post.id)"
+                @click="handleDeletePost(post.id)"
+              >
+                Delete post
+              </button>
+            </div>
+
             <div
               v-show="isExpanded(post.id)"
               :id="commentsRegionId(post.id)"
@@ -279,8 +569,41 @@ watch(
                   <p class="mv-comment-author">{{ comment.authorDisplayName }}</p>
                   <p class="mv-comment-body">{{ comment.body }}</p>
                   <p class="mv-comment-time">{{ formatRelativeTime(comment.createdAt) }}</p>
+                  <button
+                    v-if="comment.viewerCanDelete"
+                    type="button"
+                    class="mv-comment-delete"
+                    :disabled="isDeletingComment(comment.id)"
+                    @click="handleDeleteComment(post.id, comment.id)"
+                  >
+                    Delete
+                  </button>
+                  <p v-if="commentActionError[comment.id]" class="mv-status mv-status--error">
+                    {{ commentActionError[comment.id] }}
+                  </p>
                 </li>
               </ul>
+
+              <form v-if="club?.viewerIsMember" class="mv-comment-form" @submit.prevent="submitComment(post.id)">
+                <label class="mv-field">
+                  <span class="mv-visually-hidden">Add a comment</span>
+                  <textarea
+                    :value="commentFormState(post.id).body"
+                    class="mv-comment-input"
+                    :maxlength="COMMENT_MAX_LENGTH"
+                    placeholder="Add a comment"
+                    :disabled="commentFormState(post.id).submitting"
+                    @input="updateCommentBody(post.id, ($event.target as HTMLTextAreaElement).value)"
+                  ></textarea>
+                </label>
+                <p class="mv-counter">{{ commentFormState(post.id).body.length }}/{{ COMMENT_MAX_LENGTH }}</p>
+                <p v-if="commentFormState(post.id).error" class="mv-status mv-status--error">
+                  {{ commentFormState(post.id).error }}
+                </p>
+                <button type="submit" class="mv-comment-submit" :disabled="commentFormState(post.id).submitting">
+                  Post comment
+                </button>
+              </form>
             </div>
           </div>
         </li>
@@ -342,6 +665,121 @@ watch(
   padding: 1.5rem;
   text-align: center;
   color: var(--mv-text-faint);
+}
+
+.mv-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.mv-publish {
+  border-radius: 24px;
+  border: 1px solid var(--mv-border);
+  background: var(--mv-surface-card);
+  box-shadow: var(--mv-shadow-card);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.mv-publish-title {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.mv-publish-notice,
+.mv-format-notice {
+  margin: 0;
+  color: var(--mv-text-faint);
+  font-size: 0.9rem;
+}
+
+.mv-publish-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.mv-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.mv-field input,
+.mv-field textarea {
+  border-radius: 12px;
+  border: 1px solid var(--mv-border);
+  padding: 0.5rem 0.75rem;
+  font: inherit;
+  background: var(--mv-surface-muted);
+  color: inherit;
+}
+
+.mv-counter {
+  margin: 0;
+  align-self: flex-end;
+  font-size: 0.8rem;
+  color: var(--mv-text-dim);
+}
+
+.mv-publish-preview {
+  max-width: 240px;
+  border-radius: 14px;
+  object-fit: cover;
+}
+
+.mv-publish-submit,
+.mv-comment-submit {
+  align-self: flex-start;
+  border-radius: 999px;
+  border: 1px solid var(--mv-border-strong);
+  background: var(--mv-surface-accent);
+  color: var(--mv-gold);
+  font-weight: 600;
+  padding: 0.45rem 1.2rem;
+  cursor: pointer;
+}
+
+.mv-publish-submit:disabled,
+.mv-comment-submit:disabled,
+.mv-pin-toggle:disabled,
+.mv-post-delete:disabled,
+.mv-comment-delete:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.mv-post-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.mv-pin-toggle,
+.mv-post-delete,
+.mv-comment-delete {
+  border-radius: 999px;
+  border: 1px solid var(--mv-border);
+  padding: 0.35rem 0.9rem;
+  background: var(--mv-surface-muted);
+  color: var(--mv-text-soft);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.mv-comment-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-top: 0.75rem;
 }
 
 .mv-post-list {

--- a/frontend/src/views/ClubMediaView.vue
+++ b/frontend/src/views/ClubMediaView.vue
@@ -327,11 +327,30 @@ const handleDeletePost = async (postId: number) => {
 // nonzero page and the re-fetch shows it is now empty, the viewer would otherwise be stranded
 // on a page with nothing to show, so this navigates back to the previous (now-valid) page
 // instead, which itself reloads through the normal query-driven `load()` path.
+//
+// The request's own club id, page, and size are captured up front, before the `await`, and
+// re-checked against the live route once the response arrives: a fast Next/Previous click (or a
+// club navigation) issued while this backfill is still in flight must not let this now-stale
+// response overwrite whatever that newer navigation's own `load()` call already wrote -- last
+// network response to resolve is not necessarily the last request the viewer actually intended.
 const backfillCurrentPageAfterPostDeletion = async () => {
+  const requestedClubId = routeClubId.value
+  const requestedPage = page.value
+  const requestedSize = size.value
+  const requestedQueryPage = route.query.page
+  const requestedQuerySize = route.query.size
+  const isStillTheSameFeedContext = () =>
+    routeClubId.value === requestedClubId &&
+    route.query.page === requestedQueryPage &&
+    route.query.size === requestedQuerySize
+
   try {
-    const feed = await fetchClubMediaFeed(routeClubId.value, page.value, size.value)
-    if (feed.items.length === 0 && page.value > 0) {
-      goToPage(page.value - 1)
+    const feed = await fetchClubMediaFeed(requestedClubId, requestedPage, requestedSize)
+    if (!isStillTheSameFeedContext()) {
+      return
+    }
+    if (feed.items.length === 0 && requestedPage > 0) {
+      goToPage(requestedPage - 1)
       return
     }
     posts.value = feed.items

--- a/frontend/src/views/ClubMediaView.vue
+++ b/frontend/src/views/ClubMediaView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
 import { useRoute, useRouter } from 'vue-router'
 import { fetchClubById } from '../services/clubService'
 import {
@@ -12,6 +13,7 @@ import {
   createClubPostComment,
   deleteClubPostComment,
 } from '../services/clubPostService'
+import { useAuthStore } from '../stores/auth'
 import type { Club } from '../types/club'
 import type { ClubPost, ClubPostComment } from '../types/clubPost'
 import { clubPostImage } from '../utils/clubImages'
@@ -40,6 +42,8 @@ interface CommentFormState {
 
 const route = useRoute()
 const router = useRouter()
+const authStore = useAuthStore()
+const { currentUser } = storeToRefs(authStore)
 
 const club = ref<Club | null>(null)
 const posts = ref<ClubPost[]>([])
@@ -58,6 +62,11 @@ const routeClubId = computed(() => {
   const value = Array.isArray(raw) ? raw[0] : raw
   return value ?? ''
 })
+
+// Pin/unpin is an editorial power over the whole club, not tied to any one post's authorship:
+// the club's own president (club.canManage) or a platform owner (currentUser.isOwner), the
+// same club.canManage-or-owner pattern ClubAdminView's canManageMembers already uses.
+const canManagePins = computed(() => Boolean(club.value?.canManage) || Boolean(currentUser.value?.isOwner))
 
 const commentsRegionId = (postId: number) => `club-media-comments-${postId}`
 
@@ -83,6 +92,15 @@ const load = async () => {
   error.value = ''
   expandedPostIds.value = new Set()
   commentsByPost.value = {}
+  // A page/club navigation leaves the previous page's posts and comments behind entirely, so
+  // any in-flight action error or unsent comment draft tied to those (now off-screen) post/
+  // comment ids must not silently reappear if a later page happens to reuse the same ids.
+  commentForms.value = {}
+  postActionError.value = {}
+  commentActionError.value = {}
+  deletingPostIds.value = new Set()
+  pinningPostIds.value = new Set()
+  deletingCommentIds.value = new Set()
 
   const requestedPage = Math.max(0, parseQueryInt(route.query.page, 0))
   const requestedSize = Math.max(1, parseQueryInt(route.query.size, DEFAULT_PAGE_SIZE))
@@ -289,6 +307,7 @@ const handleDeletePost = async (postId: number) => {
     await deleteClubPost(routeClubId.value, postId)
     posts.value = posts.value.filter((post) => post.id !== postId)
     total.value = Math.max(0, total.value - 1)
+    await backfillCurrentPageAfterPostDeletion()
   } catch (err) {
     postActionError.value = {
       ...postActionError.value,
@@ -298,6 +317,30 @@ const handleDeletePost = async (postId: number) => {
     const cleared = new Set(deletingPostIds.value)
     cleared.delete(postId)
     deletingPostIds.value = cleared
+  }
+}
+
+// Deleting a post shrinks the current page below a full page's worth of items without ever
+// pulling in the item that should now slide up from the next page -- the local, optimistic
+// removal above only ever shrinks the list. This re-fetches the same page from the server so
+// that backfill can happen, still without a manual browser reload: if the current page is a
+// nonzero page and the re-fetch shows it is now empty, the viewer would otherwise be stranded
+// on a page with nothing to show, so this navigates back to the previous (now-valid) page
+// instead, which itself reloads through the normal query-driven `load()` path.
+const backfillCurrentPageAfterPostDeletion = async () => {
+  try {
+    const feed = await fetchClubMediaFeed(routeClubId.value, page.value, size.value)
+    if (feed.items.length === 0 && page.value > 0) {
+      goToPage(page.value - 1)
+      return
+    }
+    posts.value = feed.items
+    page.value = feed.page
+    size.value = feed.size
+    total.value = feed.total
+  } catch {
+    // The delete itself already succeeded; a failed backfill just leaves the optimistic,
+    // already-shorter local list in place rather than surfacing a second, confusing error.
   }
 }
 
@@ -529,9 +572,9 @@ watch(
               {{ postActionError[post.id] }}
             </p>
 
-            <div v-if="club?.canManage || post.viewerCanDelete" class="mv-post-actions">
+            <div v-if="canManagePins || post.viewerCanDelete" class="mv-post-actions">
               <button
-                v-if="club?.canManage"
+                v-if="canManagePins"
                 type="button"
                 class="mv-pin-toggle"
                 :disabled="isPinningPost(post.id)"


### PR DESCRIPTION
## Summary

- Add member publishing with local preview, multipart upload, public-visibility notice, and supported-format guidance.
- Add member comments plus capability-safe post/comment deletion and president/platform-owner pin controls.
- Keep paginated media state consistent across deletes, navigation, retries, and concurrent comment requests.
- Add crawler policy for uploads and media pages without introducing v-html or public user identifiers.

## Verification

- `./mvnw test` (357 tests passed)
- `npm run test:unit -- --run` (192 tests passed)
- `npm run build` passed
- Three independent review rounds completed; final race finding fixed with deterministic deferred-promise regression coverage

Closes bangxiao0927/HSclubs#82

---
Generated by Codet
