### PR TITLE
Club media: reconcile documentation and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Instaloader must use an authenticated Instagram session; anonymous access is not
 If Instaloader cannot resolve a profile picture, the backend also tries Instagram's web profile API before returning the short-lived SVG fallback.
 The backend preloads avatars for clubs with an `instagramUrl`, stores them under `backend/uploads/avatar-cache/instagram`, and refreshes cached files after 60 days. The scheduler checks twice daily, but it only contacts Instagram for missing or expired files. Keep the upload directory and Instaloader session file on persistent, private storage in production.
 
+Club post photos (the club media feed) are stored under `${app.upload.dir}/club-posts/`
+(same upload root as the avatar cache, default `backend/uploads`). Like the avatar cache,
+this directory must live on persistent, private storage in production: it is not backed up
+by the database, and a nightly job only reclaims files no club post still references -- it
+does not recreate anything lost.
+
 Frontend:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -69,11 +69,15 @@ Instaloader must use an authenticated Instagram session; anonymous access is not
 If Instaloader cannot resolve a profile picture, the backend also tries Instagram's web profile API before returning the short-lived SVG fallback.
 The backend preloads avatars for clubs with an `instagramUrl`, stores them under `backend/uploads/avatar-cache/instagram`, and refreshes cached files after 60 days. The scheduler checks twice daily, but it only contacts Instagram for missing or expired files. Keep the upload directory and Instaloader session file on persistent, private storage in production.
 
-Club post photos (the club media feed) are stored under `${app.upload.dir}/club-posts/`
-(same upload root as the avatar cache, default `backend/uploads`). Like the avatar cache,
-this directory must live on persistent, private storage in production: it is not backed up
-by the database. A separate nightly (3 AM) job reclaims orphaned files under the legacy
-top-level club-image upload location and `club-posts/` -- after a 10-minute grace period, and
+`${app.upload.dir}/club-posts/` (default `backend/uploads/club-posts`, under the same
+`${app.upload.dir}` root as the avatar cache above) stores both a club's own cover image and
+club media-feed post photos: both go through the same upload pipeline (`ImageStorageService`),
+which always writes under this one subdirectory regardless of which feature uploaded the
+file. A flat file directly under `${app.upload.dir}` (not inside `club-posts/`) is a legacy
+club cover image from before that pipeline existed; new uploads are never written there.
+Like the avatar cache, `club-posts/` must live on persistent, private storage in production:
+it is not backed up by the database. A separate nightly (3 AM) job reclaims orphaned files
+under the legacy top-level location and `club-posts/` -- after a 10-minute grace period, and
 never the Instagram avatar cache -- but it does not recreate anything already lost.
 
 Frontend:

--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ The backend preloads avatars for clubs with an `instagramUrl`, stores them under
 Club post photos (the club media feed) are stored under `${app.upload.dir}/club-posts/`
 (same upload root as the avatar cache, default `backend/uploads`). Like the avatar cache,
 this directory must live on persistent, private storage in production: it is not backed up
-by the database, and a nightly job only reclaims files no club post still references -- it
-does not recreate anything lost.
+by the database. A separate nightly (3 AM) job reclaims orphaned files under the legacy
+top-level club-image upload location and `club-posts/` -- after a 10-minute grace period, and
+never the Instagram avatar cache -- but it does not recreate anything already lost.
 
 Frontend:
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -176,12 +176,23 @@ the database: JPEG/PNG/WebP are flattened, EXIF-stripped, and re-encoded to JPEG
 5MB for JPEG/PNG/WebP, 2MB for GIF. Both the format and these limits are enforced from the
 file's sniffed magic bytes, never the client-declared `Content-Type`.
 
+These are application-level limits, checked by `ImageStorageService` only after the request
+has already cleared a stricter, earlier ceiling: Spring's own
+`spring.servlet.multipart.max-file-size` (6MB per part) and `max-request-size` (8MB total).
+A file larger than that multipart ceiling never reaches `ImageStorageService` at all -- Spring
+rejects it first with a 413, before the title is even read, so it cannot also produce one of
+the 400s below. The two limits are deliberately layered (6MB above the application's own 5MB
+JPEG/PNG/WebP limit): if they were equal, Spring would take the file before the readable
+400 could ever be produced, turning that validation into dead code.
+
 Response: 201 with a `PublicClubPost` body (shape above).
 
 Status: 201 | 400 (missing/empty title or file, title over 140 characters, unsupported or
-corrupt image, image over its format's size or resolution limit) | 403 (authenticated but not
-a member of this club) | 404 (club not found) | 500 (rare: the post could not be read back
-immediately after being written, or the file could not be stored)
+corrupt image, or image over its *application-level* format size or resolution limit -- see
+above) | 403 (authenticated but not a member of this club) | 404 (club not found) | 413 (the
+file or overall request exceeded Spring's multipart ceiling before any application code ran --
+see "Error Responses" below) | 500 (rare: the post could not be read back immediately after
+being written, or the file could not be stored)
 
 ### GET /api/clubs/{clubSlugOrId}/posts
 Read a club's public post feed, newest and pinned-first. Public; no authentication required,
@@ -341,4 +352,5 @@ Before any of these are implemented, the proposer should:
 | 403 | Permission denied |
 | 404 | Resource not found |
 | 409 | Conflict (duplicate request) |
+| 413 | Any multipart upload (e.g. `POST /api/clubs/{clubSlugOrId}/posts` above) exceeded `spring.servlet.multipart.max-file-size` (6MB per part) or `max-request-size` (8MB total). A request whose raw body exceeds `server.tomcat.max-swallow-size` (10MB) may instead have its connection aborted before this response body can be delivered. |
 | 500 | Internal server error |

--- a/docs/API.md
+++ b/docs/API.md
@@ -101,6 +101,167 @@ Delete club. Requires: platform_owner. Status: 204
 
 ---
 
+## Club Media (Posts and Comments)
+
+A per-club photo feed: members publish a post (one photo plus a title), anyone can read the
+public feed and its comments, and members can comment. See
+`docs/FIRST_REPO_ROADMAP.md` item 23 for why this shipped and which moderation/storage/
+deletion/abuse concerns it addresses (rate limiting on publishing is still open -- see
+`docs/ISSUES.md`).
+
+All eight endpoints below live under `/api/clubs`, following the same primary-route
+convention as the rest of this section (see the "Future API Needs" preamble later in this
+file for how new routes should be proposed).
+
+**Photo URLs are unauthenticated, unguessable capability URLs, not authorization-checked
+resources.** `imageUrl` and `authorAvatarUrl` values under `/uploads/club-posts/<uuid>.jpg`
+are served by the static `/uploads/**` resource handler (`WebConfig`), which sits under
+Spring Security's `anyRequest().permitAll()` -- it does not check `clubs.status`,
+`ClubVisibilityPolicy`, or authentication at all. The feed and comment endpoints below are
+gated (a non-active club's feed is hidden from non-members), but once a client has a photo
+URL -- from the feed, from a shared link, or by guessing -- nothing stops it from being
+fetched directly, by anyone, forever (until the post is deleted). Security rests entirely on
+the UUIDv4 filename being unguessable, the same model as an unlisted document link. This is a
+deliberate trade-off: serving images through an authorization-aware controller instead would
+also have to cover club cover images, and would give up static file serving and HTTP caching.
+
+A `PublicClubPost` (returned by publish and by the feed) looks like:
+```json
+{
+  "id": 12,
+  "clubId": 3,
+  "title": "Robotics build day",
+  "imageUrl": "/uploads/club-posts/3f9c1b2a-3e3d-4a2e-9a8b-2b6b7d5e1a11.jpg",
+  "pinnedAt": null,
+  "createdAt": "2026-08-03T18:42:11Z",
+  "authorDisplayName": "Maya Chen",
+  "authorAvatarUrl": "https://...",
+  "commentCount": 4,
+  "viewerCanDelete": false
+}
+```
+`viewerCanDelete` is computed server-side from the caller's own identity and the club's
+moderation state; it is never the author's or viewer's own user ID. Never present:
+`authorOauthUserId`, the author's email, or any other account field.
+
+A `PublicClubPostComment` (returned by comment creation and by the comment list) looks like:
+```json
+{
+  "id": 5,
+  "postId": 12,
+  "body": "Great turnout today!",
+  "createdAt": "2026-08-03T19:02:44Z",
+  "authorDisplayName": "Maya Chen",
+  "authorAvatarUrl": "https://...",
+  "viewerCanDelete": true
+}
+```
+
+### POST /api/clubs/{clubSlugOrId}/posts
+Publish a post: one photo plus a title. Requires: authenticated club member.
+
+Request: `multipart/form-data` with fields `title` (string, 1-140 characters after trimming)
+and `file` (the image). This is one atomic request; there is no separate "upload the photo,
+then create the post" step, so a post can never reference a photo that was never actually
+stored.
+
+The file is validated and re-encoded by `ImageStorageService` before anything is written to
+the database: JPEG/PNG/WebP are flattened, EXIF-stripped, and re-encoded to JPEG (capped at
+1600px on the long edge); GIF passes through unchanged to preserve animation. Size limits:
+5MB for JPEG/PNG/WebP, 2MB for GIF. Both the format and these limits are enforced from the
+file's sniffed magic bytes, never the client-declared `Content-Type`.
+
+Response: 201 with a `PublicClubPost` body (shape above).
+
+Status: 201 | 400 (missing/empty title or file, title over 140 characters, unsupported or
+corrupt image, image over its format's size or resolution limit) | 403 (authenticated but not
+a member of this club) | 404 (club not found) | 500 (rare: the post could not be read back
+immediately after being written, or the file could not be stored)
+
+### GET /api/clubs/{clubSlugOrId}/posts
+Read a club's public post feed, newest and pinned-first. Public; no authentication required,
+but an authenticated viewer's own capabilities (see `viewerCanDelete` above) are reflected in
+the response.
+
+Visibility follows `ClubVisibilityPolicy`, the same policy the comment list below uses: an
+`active` club's feed is visible to anyone; a non-`active` club's feed is visible only to a
+member of that club, its president, or a platform owner. A club that exists but is not
+visible to the caller returns 404, the same as a club that does not exist at all, so its
+existence is not leaked.
+
+Query params: `page` (default `0`) and `size` (default `12`).
+
+Response envelope:
+```json
+{
+  "items": [ /* PublicClubPost */ ],
+  "page": 0,
+  "size": 12,
+  "total": 37
+}
+```
+`page` and `size` in the response are clamped, not the raw request values: `size` is clamped
+to between 1 and 100, a negative `page` is clamped to `0`, and both echoed values are what was
+actually served. A client computing `ceil(total / size)` from the response must use these
+clamped values, not whatever it originally requested, or it can be misled about how many
+pages exist.
+
+Status: 200 | 404 (club not found, or not visible to this caller)
+
+### PUT /api/clubs/{clubSlugOrId}/posts/{postId}/pin
+Pin a post to the front of the feed. Requires: the club's own president, or a platform owner
+(pinning is an editorial power, not a publishing one -- the post's own author is not enough
+on its own). At most 3 posts can be pinned per club at a time.
+
+Status: 204 | 403 (not the club's president or a platform owner) | 404 (club or post not
+found) | 409 (3 posts already pinned, or a concurrent pin attempt on the same club timed out
+the lock -- both mean "try again", not a server error)
+
+### DELETE /api/clubs/{clubSlugOrId}/posts/{postId}/pin
+Unpin a post. Same authorization as pin above.
+
+Status: 204 | 403 | 404 (club or post not found)
+
+### DELETE /api/clubs/{clubSlugOrId}/posts/{postId}
+Delete a post: removes the row, its photo file on disk, and its comments (cascade). Requires:
+the post's own author, the club's president, or a platform owner (the same moderation matrix
+`ClubContentModerationPolicy` applies to comment deletion below).
+
+Status: 204 | 403 (authenticated but not the author/president/owner) | 404 (club or post not
+found) | 500 (rare: the row was already gone by the time the delete ran)
+
+### GET /api/clubs/{clubSlugOrId}/posts/{postId}/comments
+Read a post's comments, oldest first. Public; same `ClubVisibilityPolicy` gating as the feed
+above, so a comment thread is never visible where the post itself would not be.
+
+Response: a plain JSON array of `PublicClubPostComment` (shape above); not paginated or
+wrapped in an envelope.
+
+Status: 200 | 404 (club not found or not visible, or post not found in this club)
+
+### POST /api/clubs/{clubSlugOrId}/posts/{postId}/comments
+Post a comment. Requires: authenticated club member.
+
+Request body:
+```json
+{ "body": "Great turnout today!" }
+```
+`body` must be 1-300 characters after trimming.
+
+Response: 201 with a `PublicClubPostComment` body (shape above).
+
+Status: 201 | 400 (missing/empty body, or over 300 characters) | 403 (not a member) | 404
+(club or post not found) | 409 (post already has 50 comments -- the per-post cap -- or a
+concurrent comment on the same post timed out the lock; both mean "try again")
+
+### DELETE /api/clubs/{clubSlugOrId}/posts/{postId}/comments/{commentId}
+Delete a comment. Requires: the comment's own author, the club's president, or a platform
+owner.
+
+Status: 204 | 403 | 404 (club not found, post not found in this club, or comment not found)
+
+---
+
 ## Membership
 
 ### GET /api/clubs/{id}/members

--- a/docs/API.md
+++ b/docs/API.md
@@ -114,8 +114,8 @@ convention as the rest of this section (see the "Future API Needs" preamble late
 file for how new routes should be proposed).
 
 **Photo URLs are unauthenticated, unguessable capability URLs, not authorization-checked
-resources.** `imageUrl` and `authorAvatarUrl` values under `/uploads/club-posts/<uuid>.jpg`
-are served by the static `/uploads/**` resource handler (`WebConfig`), which sits under
+resources.** A post's own `imageUrl`, under `/uploads/club-posts/<uuid>.jpg`, is served by
+the static `/uploads/**` resource handler (`WebConfig`), which sits under
 Spring Security's `anyRequest().permitAll()` -- it does not check `clubs.status`,
 `ClubVisibilityPolicy`, or authentication at all. The feed and comment endpoints below are
 gated (a non-active club's feed is hidden from non-members), but once a client has a photo
@@ -124,6 +124,11 @@ fetched directly, by anyone, forever (until the post is deleted). Security rests
 the UUIDv4 filename being unguessable, the same model as an unlisted document link. This is a
 deliberate trade-off: serving images through an authorization-aware controller instead would
 also have to cover club cover images, and would give up static file serving and HTTP caching.
+
+`authorAvatarUrl` is not part of this boundary: it is `oauth_users.avatar_url`, populated
+from the OAuth provider's own profile picture claim (e.g. Google's `picture`) at login, and
+is an external URL on the provider's own domain, not a file under `/uploads/**`. It can be
+`null` when the provider did not supply one.
 
 A `PublicClubPost` (returned by publish and by the feed) looks like:
 ```json

--- a/docs/DEVELOPMENT_SEQUENCE.md
+++ b/docs/DEVELOPMENT_SEQUENCE.md
@@ -180,7 +180,10 @@ Keep each implementation chunk small enough to verify in one sitting:
 
 Avoid these until the core loop is stable:
 
-- Social media timelines.
+- Social media timelines beyond the club post photo feed already shipped (see
+  docs/FIRST_REPO_ROADMAP.md item 23): no stories, likes, algorithmic ranking, or
+  cross-club timelines. That feed still has no publish rate limiting (see docs/ISSUES.md);
+  close that gap before expanding the feature rather than building on top of it.
 - Complex recommendation algorithms.
 - Native mobile development.
 - Separate aggregator backend.

--- a/docs/FIRST_REPO_ROADMAP.md
+++ b/docs/FIRST_REPO_ROADMAP.md
@@ -277,9 +277,10 @@ Useful for presidents, but it needs careful data modeling and should come after 
 
 ### 23. Media area and media timeline (Shipped)
 
-This item was originally deferred here because a social feed or story-like timeline creates
-moderation, storage, abuse, and deletion requirements. It shipped as a per-club photo post
-feed (club media, implemented in issues bangxiao0927/HSclubs#76 through bangxiao0927/HSclubs#82,
+This item was originally deferred under "P4 - Defer" because a social feed or story-like
+timeline creates moderation, storage, abuse, and deletion requirements. It shipped as a
+per-club photo post feed (club media, implemented in issues bangxiao0927/HSclubs#76 through
+bangxiao0927/HSclubs#82,
 PRs bangxiao0927/HSclubs#84, bangxiao0927/HSclubs#85, bangxiao0927/HSclubs#86,
 bangxiao0927/HSclubs#87, bangxiao0927/HSclubs#88, bangxiao0927/HSclubs#89, and
 bangxiao0927/HSclubs#91; bangxiao0927/HSclubs#83 is this documentation reconciliation itself,

--- a/docs/FIRST_REPO_ROADMAP.md
+++ b/docs/FIRST_REPO_ROADMAP.md
@@ -275,11 +275,34 @@ Useful for events, but it should reuse a stable application flow.
 
 Useful for presidents, but it needs careful data modeling and should come after membership workflows are dependable.
 
+### 23. Media area and media timeline (Shipped)
+
+This item was originally deferred here because a social feed or story-like timeline creates
+moderation, storage, abuse, and deletion requirements. It shipped as a per-club photo post
+feed (club media, tracked in issues bangxiao0927/HSclubs#78 through bangxiao0927/HSclubs#83,
+PRs bangxiao0927/HSclubs#84, bangxiao0927/HSclubs#85, bangxiao0927/HSclubs#86,
+bangxiao0927/HSclubs#87, bangxiao0927/HSclubs#88, bangxiao0927/HSclubs#89, and
+bangxiao0927/HSclubs#91), with the original concerns addressed directly rather than avoided:
+
+- **Moderation:** a club's own president, or a platform owner, can delete any post or comment
+  in that club; only members can publish a post or a comment; comments are capped at 50 per
+  post.
+- **Storage:** every non-GIF upload is re-encoded to a single flattened, EXIF-stripped JPEG
+  (capped at 1600px on the long edge, ~5MB source limit before re-encoding), GIFs are capped
+  at 2MB and stored as-is, and a nightly scheduled job reclaims any file on disk no club or
+  club post still references.
+- **Deletion:** deleting a post removes its photo file from disk, not just its database row.
+- **Abuse:** partially addressed. The per-file size caps and the 50-comment-per-post cap bound
+  a single request, but nothing yet bounds how often a member can publish a post or a comment.
+  Rate limiting on media publishing remains an open gap -- see `docs/ISSUES.md`.
+
+Photo URLs are unauthenticated, unguessable UUID capability URLs
+(`/uploads/club-posts/<uuid>.jpg`), served by a static resource handler that does not check
+club status, visibility, or authentication, even though the feed JSON itself is gated on
+`clubs.status = 'active'`. This is a deliberate trade-off, not an oversight -- see
+`docs/API.md` for the reasoning.
+
 ## P4 - Defer
-
-### 23. Media area and media timeline
-
-Defer this work. A social feed or story-like timeline creates moderation, storage, abuse, and deletion requirements. It is not the right first feature for a low-maintenance school project.
 
 ### 24. 2nd repo creation
 

--- a/docs/FIRST_REPO_ROADMAP.md
+++ b/docs/FIRST_REPO_ROADMAP.md
@@ -279,18 +279,22 @@ Useful for presidents, but it needs careful data modeling and should come after 
 
 This item was originally deferred here because a social feed or story-like timeline creates
 moderation, storage, abuse, and deletion requirements. It shipped as a per-club photo post
-feed (club media, tracked in issues bangxiao0927/HSclubs#78 through bangxiao0927/HSclubs#83,
+feed (club media, implemented in issues bangxiao0927/HSclubs#76 through bangxiao0927/HSclubs#82,
 PRs bangxiao0927/HSclubs#84, bangxiao0927/HSclubs#85, bangxiao0927/HSclubs#86,
 bangxiao0927/HSclubs#87, bangxiao0927/HSclubs#88, bangxiao0927/HSclubs#89, and
-bangxiao0927/HSclubs#91), with the original concerns addressed directly rather than avoided:
+bangxiao0927/HSclubs#91; bangxiao0927/HSclubs#83 is this documentation reconciliation itself,
+not implementation), with the original concerns addressed directly rather than avoided:
 
 - **Moderation:** a club's own president, or a platform owner, can delete any post or comment
   in that club; only members can publish a post or a comment; comments are capped at 50 per
   post.
 - **Storage:** every non-GIF upload is re-encoded to a single flattened, EXIF-stripped JPEG
   (capped at 1600px on the long edge, ~5MB source limit before re-encoding), GIFs are capped
-  at 2MB and stored as-is, and a nightly scheduled job reclaims any file on disk no club or
-  club post still references.
+  at 2MB and stored as-is, and a nightly (3 AM) scheduled job reclaims orphaned files under
+  the legacy top-level club-image upload location and `club-posts/` that no club or club post
+  still references, after a 10-minute grace period so an in-flight upload is never mistaken
+  for an orphan. It does not touch the Instagram avatar cache or any other subsystem sharing
+  the same upload root.
 - **Deletion:** deleting a post removes its photo file from disk, not just its database row.
 - **Abuse:** partially addressed. The per-file size caps and the 50-comment-per-post cap bound
   a single request, but nothing yet bounds how often a member can publish a post or a comment.

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -503,9 +503,11 @@ gained an explicit `X-Content-Type-Options: nosniff` header via bangxiao0927/HSc
 the resource mapping itself is unchanged since the 2025-07-17 pass). Both original gaps are
 closed: `ClubImageController#uploadImage` deletes the
 previous `imageUrl` file after the new one is committed (bangxiao0927/HSclubs#45), and
-`UploadCleanupService` runs a nightly (3 AM) scheduled sweep with a 10-minute grace period
-(bangxiao0927/HSclubs#45, scope widened to also cover `club-posts/` -- while explicitly
-excluding the Instagram avatar cache -- by bangxiao0927/HSclubs#85). No open gap remains.
+`UploadCleanupService` runs a nightly (3 AM) scheduled sweep, introduced in
+bangxiao0927/HSclubs#45. That original sweep had neither a grace period nor any notion of
+`club-posts/` (club posts did not exist yet); bangxiao0927/HSclubs#85 later added the
+10-minute grace period, widened the scope to also walk `club-posts/` recursively, and
+explicitly excluded the Instagram avatar cache. No open gap remains.
 
 **Problem (Verification):**
 `ClubImageController.java` saves images to `backend/uploads/` with UUID filenames and returns `/uploads/{uuid}.{ext}` URLs. Need to verify:

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -556,28 +556,36 @@ A future maintainer opening `SecurityConfig.java` has to reverse-engineer the in
 and deletion requirements that did not have answers yet.
 
 **Solution:**
-Shipped a per-club photo post feed (issues bangxiao0927/HSclubs#78 through
-bangxiao0927/HSclubs#83) with those requirements answered directly:
+Shipped a per-club photo post feed, implemented in issues bangxiao0927/HSclubs#76 through
+bangxiao0927/HSclubs#82 (bangxiao0927/HSclubs#83, this entry's own issue, is the documentation
+and roadmap reconciliation that followed, not implementation), with those requirements
+answered directly:
 1. `ClubPost`/`ClubPostComment` schema, mapper, and `ImageStorageService` hardening
-   (bangxiao0927/HSclubs#84, bangxiao0927/HSclubs#85).
-2. Publish-a-post and read-the-feed endpoints (bangxiao0927/HSclubs#86).
-3. Pinning, capped at 3 posts per club (bangxiao0927/HSclubs#87).
-4. Comments (capped at 50 per post) and moderation-gated deletion of posts and comments
-   (bangxiao0927/HSclubs#88).
-5. The public, read-only media page (bangxiao0927/HSclubs#89).
+   (bangxiao0927/HSclubs#76, bangxiao0927/HSclubs#77; PRs bangxiao0927/HSclubs#84,
+   bangxiao0927/HSclubs#85).
+2. Publish-a-post and read-the-feed endpoints (bangxiao0927/HSclubs#78; PR
+   bangxiao0927/HSclubs#86).
+3. Comments (capped at 50 per post) and moderation-gated deletion of posts and comments
+   (bangxiao0927/HSclubs#79; PR bangxiao0927/HSclubs#88).
+4. Pinning, capped at 3 posts per club (bangxiao0927/HSclubs#80; PR bangxiao0927/HSclubs#87).
+5. The public, read-only media page (bangxiao0927/HSclubs#81; PR bangxiao0927/HSclubs#89).
 6. Authenticated publish/comment/delete/pin interactions on that page
-   (bangxiao0927/HSclubs#91).
+   (bangxiao0927/HSclubs#82; PR bangxiao0927/HSclubs#91).
 
 **Expected Outcome:**
 - Moderation: a club's own president, or a platform owner, can delete any post or comment in
   that club; only members can publish a post or a comment.
 - Storage: every non-GIF upload is re-encoded to a flattened, EXIF-stripped JPEG capped at
-  1600px; GIFs are capped at 2MB; a nightly job reclaims orphaned files.
+  1600px; GIFs are capped at 2MB; a nightly (3 AM) job reclaims orphaned files under the
+  legacy top-level club-image upload location and `club-posts/` after a 10-minute grace
+  period, excluding the Instagram avatar cache and any other subsystem on the same upload
+  root.
 - Deletion: deleting a post removes its photo file from disk, not just its row.
 - Abuse: partially addressed by per-file size caps and the 50-comment-per-post cap. Rate
   limiting on how often a member can publish is still open — see Issue #21 below.
 - Left explicitly out of scope: `clubs.visibility` semantics (see Issue #20 below) and photo
-  URLs remain unauthenticated, unguessable capability URLs (see `docs/API.md`).
+  URLs (post images only, not author avatars) remain unauthenticated, unguessable capability
+  URLs (see `docs/API.md`).
 
 ---
 
@@ -590,7 +598,8 @@ bangxiao0927/HSclubs#83) with those requirements answered directly:
 `clubs.visibility` (`schema.sql`, default `'public'`) is selected, inserted, and updated by
 `ClubMapper`/`ClubMapper.xml`, but no query anywhere filters or branches on it. The only
 visibility gating that exists is `ClubVisibilityPolicy`, which uses `clubs.status = 'active'`
-for the club media feed (see `docs/FIRST_REPO_ROADMAP.md` item 23 and
+for the club media feed (introduced in bangxiao0927/HSclubs#78; see
+`docs/FIRST_REPO_ROADMAP.md` item 23 and this gap's own reconciliation in
 bangxiao0927/HSclubs#83), not `clubs.visibility`. The club media feature deliberately did not
 become the first place to enforce this column: hiding a club's post feed while
 `GET /api/clubs/{id}` still returns that same club's full details publicly would be

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -26,22 +26,21 @@ Work through issues in this order. Completed issues are collapsed at the bottom.
 | Seq | # | Issue | Status | Priority | Effort |
 |-----|---|-------|--------|----------|--------|
 | 1 | #9 | Verify president permissions | open | P0 | Small |
-| 2 | #17 | Club image storage verify & cleanup | open | P0 | Small |
-| 3 | #7 | Club creation UI in admin page | open | P0 | Medium |
-| 4 | #18 | Document SecurityConfig authorization model | open | P0 | Tiny |
-| 5 | #5 | Account creation data collection (home school) | open | P1 | Medium |
-| 6 | #8 | President assignment page | open | P1 | Medium |
-| 7 | #14 | Profile page completeness | open | P1 | Small |
-| 8 | #6 | Homepage images from DB | open | P1 | Small |
-| 9 | #3 | Club summary API | open | P1 | Medium |
-| 10 | #16 | Login remember period | open | P2 | Small |
-| 11 | #15 | Theme matching design PDF | open | P2 | Medium |
-| 12 | #11 | Club recommendation page | open | P2 | Medium |
-| 13 | #10 | Comment & rating system | deferred | P3 | Large |
-| 14 | #12 | QR code club application | deferred | P3 | Medium |
-| 15 | #13 | Meeting attendance system | deferred | P3 | Large |
-| 16 | #20 | Define `clubs.visibility` semantics | open | P3 | Medium |
-| 17 | #21 | Rate limiting on media publishing | open | P3 | Small |
+| 2 | #7 | Club creation UI in admin page | open | P0 | Medium |
+| 3 | #18 | Document SecurityConfig authorization model | open | P0 | Tiny |
+| 4 | #5 | Account creation data collection (home school) | open | P1 | Medium |
+| 5 | #8 | President assignment page | open | P1 | Medium |
+| 6 | #14 | Profile page completeness | open | P1 | Small |
+| 7 | #6 | Homepage images from DB | open | P1 | Small |
+| 8 | #3 | Club summary API | open | P1 | Medium |
+| 9 | #16 | Login remember period | open | P2 | Small |
+| 10 | #15 | Theme matching design PDF | open | P2 | Medium |
+| 11 | #11 | Club recommendation page | open | P2 | Medium |
+| 12 | #10 | Comment & rating system | deferred | P3 | Large |
+| 13 | #12 | QR code club application | deferred | P3 | Medium |
+| 14 | #13 | Meeting attendance system | deferred | P3 | Large |
+| 15 | #20 | Define `clubs.visibility` semantics | open | P3 | Medium |
+| 16 | #21 | Rate limiting on media publishing | open | P3 | Small |
 
 ---
 
@@ -497,9 +496,16 @@ CREATE TABLE persistent_logins (
 
 ## Issue #17: Verify Club Image Storage & Serving
 
-**Status:** `open`
-**PR:** —
-**Verified:** 2025-07-17 — WebConfig.java serves /uploads/** correctly. Gaps: old image not deleted on replacement (orphan leak), no scheduled cleanup of unreferenced files.
+**Status:** `done`
+**PR:** bangxiao0927/HSclubs#45, bangxiao0927/HSclubs#85
+**Verified:** 2026-08-04 — `WebConfig.java` still serves `/uploads/**` correctly (it later
+gained an explicit `X-Content-Type-Options: nosniff` header via bangxiao0927/HSclubs#85, but
+the resource mapping itself is unchanged since the 2025-07-17 pass). Both original gaps are
+closed: `ClubImageController#uploadImage` deletes the
+previous `imageUrl` file after the new one is committed (bangxiao0927/HSclubs#45), and
+`UploadCleanupService` runs a nightly (3 AM) scheduled sweep with a 10-minute grace period
+(bangxiao0927/HSclubs#45, scope widened to also cover `club-posts/` -- while explicitly
+excluding the Instagram avatar cache -- by bangxiao0927/HSclubs#85). No open gap remains.
 
 **Problem (Verification):**
 `ClubImageController.java` saves images to `backend/uploads/` with UUID filenames and returns `/uploads/{uuid}.{ext}` URLs. Need to verify:
@@ -512,12 +518,16 @@ CREATE TABLE persistent_logins (
 1. Confirm Spring Boot serves `/uploads/**` from the `uploads/` directory (check `WebConfig.java` or `application.yaml`).
 2. Test upload flow end-to-end: select file -> upload -> verify image displays.
 3. Delete old image file when a club's image is updated (currently the old file is orphaned).
+   -- Done in bangxiao0927/HSclubs#45.
 4. Add a scheduled task to clean up orphaned upload files not referenced by any club.
+   -- Done in bangxiao0927/HSclubs#45; rescoped to also walk `club-posts/` (and stay isolated
+   from the Instagram avatar cache) in bangxiao0927/HSclubs#85.
 
 **Expected Outcome:**
 - Club images upload and display correctly.
 - Old images are deleted when replaced.
-- No disk space leaks from orphaned files.
+- No disk space leaks from orphaned files under the legacy top-level upload location or
+  `club-posts/`.
 
 ---
 
@@ -682,7 +692,7 @@ anywhere in the codebase yet.
 | 14 | Profile page completeness | open | P1 | Small |
 | 15 | Theme matching PDF | open | P2 | Medium |
 | 16 | Login remember period | open | P2 | Small |
-| 17 | Club image storage verify | open | P0 | Small |
+| 17 | Club image storage verify & cleanup | done | — | — |
 | 18 | Document SecurityConfig | open | P0 | Tiny |
 | 19 | Club media - photo feed, comments, pinning | done | — | — |
 | 20 | Define `clubs.visibility` semantics | open | P3 | Medium |

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -40,6 +40,8 @@ Work through issues in this order. Completed issues are collapsed at the bottom.
 | 13 | #10 | Comment & rating system | deferred | P3 | Large |
 | 14 | #12 | QR code club application | deferred | P3 | Medium |
 | 15 | #13 | Meeting attendance system | deferred | P3 | Large |
+| 16 | #20 | Define `clubs.visibility` semantics | open | P3 | Medium |
+| 17 | #21 | Rate limiting on media publishing | open | P3 | Small |
 
 ---
 
@@ -542,6 +544,115 @@ A future maintainer opening `SecurityConfig.java` has to reverse-engineer the in
 
 ---
 
+## Issue #19: Club Media - Photo Feed, Comments, and Pinning
+
+**Status:** `done`
+**PR:** bangxiao0927/HSclubs#84, bangxiao0927/HSclubs#85, bangxiao0927/HSclubs#86, bangxiao0927/HSclubs#87, bangxiao0927/HSclubs#88, bangxiao0927/HSclubs#89, bangxiao0927/HSclubs#91
+**Verified:** 2026-08-04 — All eight `/api/clubs/{clubSlugOrId}/posts...` endpoints exist and match `docs/API.md`; see that file for the full request/response reference.
+
+**Problem:**
+`docs/FIRST_REPO_ROADMAP.md` item 23 ("Media area and media timeline") was filed under
+"P4 - Defer" because a social feed or story-like timeline creates moderation, storage, abuse,
+and deletion requirements that did not have answers yet.
+
+**Solution:**
+Shipped a per-club photo post feed (issues bangxiao0927/HSclubs#78 through
+bangxiao0927/HSclubs#83) with those requirements answered directly:
+1. `ClubPost`/`ClubPostComment` schema, mapper, and `ImageStorageService` hardening
+   (bangxiao0927/HSclubs#84, bangxiao0927/HSclubs#85).
+2. Publish-a-post and read-the-feed endpoints (bangxiao0927/HSclubs#86).
+3. Pinning, capped at 3 posts per club (bangxiao0927/HSclubs#87).
+4. Comments (capped at 50 per post) and moderation-gated deletion of posts and comments
+   (bangxiao0927/HSclubs#88).
+5. The public, read-only media page (bangxiao0927/HSclubs#89).
+6. Authenticated publish/comment/delete/pin interactions on that page
+   (bangxiao0927/HSclubs#91).
+
+**Expected Outcome:**
+- Moderation: a club's own president, or a platform owner, can delete any post or comment in
+  that club; only members can publish a post or a comment.
+- Storage: every non-GIF upload is re-encoded to a flattened, EXIF-stripped JPEG capped at
+  1600px; GIFs are capped at 2MB; a nightly job reclaims orphaned files.
+- Deletion: deleting a post removes its photo file from disk, not just its row.
+- Abuse: partially addressed by per-file size caps and the 50-comment-per-post cap. Rate
+  limiting on how often a member can publish is still open — see Issue #21 below.
+- Left explicitly out of scope: `clubs.visibility` semantics (see Issue #20 below) and photo
+  URLs remain unauthenticated, unguessable capability URLs (see `docs/API.md`).
+
+---
+
+## Issue #20: `clubs.visibility` Column Has No Defined Semantics
+
+**Status:** `open`
+**PR:** —
+
+**Problem:**
+`clubs.visibility` (`schema.sql`, default `'public'`) is selected, inserted, and updated by
+`ClubMapper`/`ClubMapper.xml`, but no query anywhere filters or branches on it. The only
+visibility gating that exists is `ClubVisibilityPolicy`, which uses `clubs.status = 'active'`
+for the club media feed (see `docs/FIRST_REPO_ROADMAP.md` item 23 and
+bangxiao0927/HSclubs#83), not `clubs.visibility`. The club media feature deliberately did not
+become the first place to enforce this column: hiding a club's post feed while
+`GET /api/clubs/{id}` still returns that same club's full details publicly would be
+incoherent, not a fix.
+
+**Solution:**
+Define private-club behavior as its own standalone design task before writing any code that
+reads `clubs.visibility`:
+1. Decide what "private" should mean for a club: hidden from `GET /api/clubs` listing only,
+   hidden from `GET /api/clubs/{id}` detail too, or hidden from the media feed and comments
+   as well.
+2. Decide who can still see a private club (members, the president, platform owners; anyone
+   else at all).
+3. Apply that decision consistently across every endpoint that currently treats "active" as
+   "publicly visible" (`ClubController`, `ClubVisibilityPolicy`, the summary/recommendation
+   endpoints), not just the media feed.
+4. Only then start reading `clubs.visibility` in a `WHERE` clause or policy check.
+
+**Expected Outcome:**
+- `clubs.visibility` either has a documented, enforced meaning everywhere club visibility is
+  decided, or is removed if it turns out to duplicate `clubs.status`.
+- No endpoint is left checking `clubs.status` for the general case and `clubs.visibility` for
+  another, with the two silently able to disagree.
+
+---
+
+## Issue #21: No Rate Limiting on Media Publishing
+
+**Status:** `open`
+**PR:** —
+
+**Problem:**
+Neither `ClubPostController#publish` nor `ClubPostCommentController#create` limits how often
+a single member can call them. The only constraints in place are per-request: a 5MB
+(JPEG/PNG/WebP) or 2MB (GIF) file size cap per post, a 140-character title cap, a
+300-character comment body cap, and a 50-comment-per-post cap. A member who is otherwise in
+good standing can loop the publish endpoint to fill disk space with posts, or loop the
+comment endpoint to fill a post's 50-comment cap on many posts in quick succession. No
+rate-limiting mechanism (in-memory token bucket, Redis-backed limiter, or similar) exists
+anywhere in the codebase yet.
+
+**Solution:**
+1. Pick a scope and window: per-member-per-club, or per-member platform-wide; per-minute,
+   per-hour, or per-day.
+2. Pick a mechanism appropriate for a single-instance deployment first (e.g. an in-memory
+   token bucket keyed by `oauth_user_id`), since this is a single-school app with one backend
+   instance; only move to a shared store (Redis, a database-backed counter) if the app is
+   ever run with more than one backend instance.
+3. Return 429 (or the existing 409 "try again" convention already used for the comment-cap
+   and pin-cap conflicts) with a message the frontend can show as a cooldown notice.
+4. Add the limiter to both `ClubPostController#publish` and
+   `ClubPostCommentController#create`; consider whether pin/unpin need it too (lower priority:
+   they do not create new storage).
+
+**Expected Outcome:**
+- A member cannot exhaust disk space or spam a club's feed by looping the publish or comment
+  endpoint.
+- The limiter fails closed (rejects) rather than failing open if its own state is
+  unavailable.
+
+---
+
 ## Summary Table (historical — see Work Order at top for current sequence)
 
 | # | Issue | Status | Priority | Effort |
@@ -564,3 +675,6 @@ A future maintainer opening `SecurityConfig.java` has to reverse-engineer the in
 | 16 | Login remember period | open | P2 | Small |
 | 17 | Club image storage verify | open | P0 | Small |
 | 18 | Document SecurityConfig | open | P0 | Tiny |
+| 19 | Club media - photo feed, comments, pinning | done | — | — |
+| 20 | Define `clubs.visibility` semantics | open | P3 | Medium |
+| 21 | Rate limiting on media publishing | open | P3 | Small |


### PR DESCRIPTION
## Summary

- Reconcile the roadmap and development sequence with the shipped club media feature and its moderation, storage, and deletion trade-offs.
- Document all eight media endpoints, clamped pagination, authorization rules, upload limits, and capability-URL boundary.
- Record completed implementation PRs plus the remaining visibility-semantics and rate-limiting follow-ups.
- Clarify persistent upload storage, cleanup scope/history, and the shared club-posts layout for cover and post images.

## Verification

- Source/history consistency audit completed for endpoints, limits, status codes, PR mappings, storage layout, and cleanup behavior
- Targeted backend documentation assertions and related tests passed (131 tests)
- Three independent review rounds completed; final attribution and roadmap wording findings fixed

Closes bangxiao0927/HSclubs#83

---
Generated by Codet
