### PR TITLE
Stop shipping local-dev defaults to production: h2-console, stdout SQL logging, non-Secure session cookie

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -95,6 +95,19 @@ FRONTEND_ORIGIN=http://localhost:4173
 # working with "authorization_request_not_found".
 # SESSION_COOKIE_SAME_SITE=lax
 
+# Marks JSESSIONID as Secure so it is never sent over plain HTTP. Defaults to
+# false because a Secure cookie is dropped by the browser on http://localhost,
+# which would break local login. Production serves over HTTPS and must set this
+# to true. Note the app reads X-Forwarded-Proto (server.forward-headers-strategy),
+# so the reverse proxy has to send that header for HTTPS to be detected at all.
+# SESSION_COOKIE_SECURE=true
+
+# MyBatis statement logging. Off by default: the stdout logger prints every
+# statement together with its bound parameters, which for the auth queries means
+# user emails and display names end up in the process log. The h2 profile turns
+# it on for local development; set this only for temporary debugging.
+# MYBATIS_LOG_IMPL=org.apache.ibatis.logging.stdout.StdOutImpl
+
 # Server-side CSRF token enforcement (in addition to the SameSite cookie above).
 # Defaults to false. Only set to true once the frontend reads the XSRF-TOKEN
 # cookie and sends it back as the X-XSRF-TOKEN header on state-changing requests.

--- a/backend/src/main/resources/application-h2.yaml
+++ b/backend/src/main/resources/application-h2.yaml
@@ -23,3 +23,9 @@ spring:
     console:
       enabled: true
       path: /h2-console
+
+# Local development wants to see the SQL MyBatis actually runs; the base config keeps this off
+# because the printed bound parameters include user PII (see application.yaml).
+mybatis:
+  configuration:
+    log-impl: org.apache.ibatis.logging.stdout.StdOutImpl

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -1,6 +1,12 @@
 server:
   address: 127.0.0.1
   port: 8080
+  # nginx terminates TLS and proxies to plain HTTP (see docs/DEPLOYMENT.md), so without this
+  # the app sees every request as insecure: request.isSecure() stays false, Tomcat then omits
+  # the Secure attribute from JSESSIONID, and any absolute URL the app builds (notably the
+  # OAuth2 redirect) comes out as http://. "framework" makes Spring honour X-Forwarded-Proto,
+  # which the proxy already sends.
+  forward-headers-strategy: ${SERVER_FORWARD_HEADERS_STRATEGY:framework}
   # At the 2MB default, Tomcat aborts the connection on an oversize upload rather than
   # delivering the error body, so the client sees a network error instead of the readable 400
   # ImageStorageService produces. This must exceed multipart.max-request-size below.
@@ -19,6 +25,11 @@ server:
         # cross-site subrequests (images, fetch, iframes), which is what CSRF actually
         # exploits, so this is not a meaningful weakening.
         same-site: ${SESSION_COOKIE_SAME_SITE:lax}
+        # Defaults to false so plain-HTTP local development still gets a session at all (a
+        # Secure cookie is dropped by the browser over http://localhost). Production must set
+        # SESSION_COOKIE_SECURE=true: this is a 7-day session cookie, and without it the
+        # cookie is eligible to travel over a plain-HTTP request.
+        secure: ${SESSION_COOKIE_SECURE:false}
 
 app:
   club-location-repair:
@@ -125,8 +136,15 @@ mybatis:
   type-aliases-package: com.example.demo
   configuration:
     map-underscore-to-camel-case: true
-    log-impl: org.apache.ibatis.logging.stdout.StdOutImpl
+    # Statement logging is a local-dev aid and stays off by default: StdOutImpl prints every
+    # statement together with its bound parameters, which for the auth-layer queries means
+    # user emails, display names, and avatar URLs land in the process log. The h2 profile
+    # turns it back on (see application-h2.yaml), and MYBATIS_LOG_IMPL can enable it
+    # temporarily anywhere else.
+    log-impl: ${MYBATIS_LOG_IMPL:org.apache.ibatis.logging.nologging.NoLoggingImpl}
 
-# H2 Console (dev only)
-spring.h2.console.enabled: true
-spring.h2.console.path: /h2-console
+# The H2 console is deliberately NOT configured here. It used to be enabled in this base file
+# despite its "dev only" comment, and since the H2 driver is a runtime dependency and
+# SecurityConfig ends in anyRequest().permitAll(), that left /h2-console reachable by anyone
+# on a production deployment, with a login form that accepts an arbitrary JDBC URL. It is now
+# only enabled by the h2 profile (application-h2.yaml), which is local development.

--- a/backend/src/test/java/com/example/demo/auth/controller/AcceptTermsFlowIntegrationTest.java
+++ b/backend/src/test/java/com/example/demo/auth/controller/AcceptTermsFlowIntegrationTest.java
@@ -36,8 +36,12 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("h2")
-@TestPropertySource(properties =
-    "spring.datasource.url=jdbc:h2:mem:accept_terms_flow_test;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE")
+@TestPropertySource(properties = {
+    "spring.datasource.url=jdbc:h2:mem:accept_terms_flow_test;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+    // The h2 profile turns on MyBatis stdout logging for local development; keep it out of the
+    // build log, which src/test/resources/application.yaml cannot do (a profile-specific file
+    // wins over it).
+    "mybatis.configuration.log-impl=org.apache.ibatis.logging.nologging.NoLoggingImpl"})
 class AcceptTermsFlowIntegrationTest {
 
     private static final String EMAIL = "new-student@example.com";

--- a/backend/src/test/java/com/example/demo/config/H2SchemaFixtureIntegrationTest.java
+++ b/backend/src/test/java/com/example/demo/config/H2SchemaFixtureIntegrationTest.java
@@ -21,8 +21,12 @@ import org.springframework.test.context.TestPropertySource;
  */
 @SpringBootTest
 @ActiveProfiles("h2")
-@TestPropertySource(properties =
-    "spring.datasource.url=jdbc:h2:mem:h2_schema_fixture_test;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE")
+@TestPropertySource(properties = {
+    "spring.datasource.url=jdbc:h2:mem:h2_schema_fixture_test;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+    // The h2 profile turns on MyBatis stdout logging for local development; keep it out of the
+    // build log, which src/test/resources/application.yaml cannot do (a profile-specific file
+    // wins over it).
+    "mybatis.configuration.log-impl=org.apache.ibatis.logging.nologging.NoLoggingImpl"})
 class H2SchemaFixtureIntegrationTest {
 
     @Autowired

--- a/backend/src/test/java/com/example/demo/config/ProductionConfigDefaultsTest.java
+++ b/backend/src/test/java/com/example/demo/config/ProductionConfigDefaultsTest.java
@@ -1,0 +1,89 @@
+package com.example.demo.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.PropertySourcesPlaceholdersResolver;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.FileSystemResource;
+
+/**
+ * Guards the defaults a deployment actually runs with. There is no production profile -- the
+ * documented deployment starts the app with no SPRING_PROFILES_ACTIVE at all -- so whatever the
+ * base application.yaml says is what production gets, and a "dev only" comment next to a key is
+ * not a control. These assertions read the real main-source files from disk on purpose:
+ * src/test/resources/application.yaml shadows the base config for every @SpringBootTest, so a
+ * context-based test would only be checking the test fixture.
+ */
+class ProductionConfigDefaultsTest {
+
+    private static final Path BASE_CONFIG = Path.of("src/main/resources/application.yaml");
+    private static final Path H2_PROFILE_CONFIG = Path.of("src/main/resources/application-h2.yaml");
+
+    // The H2 driver is a runtime dependency and SecurityConfig ends in anyRequest().permitAll(),
+    // so enabling the console outside the h2 profile publishes an unauthenticated page that
+    // connects to any JDBC URL a visitor types -- including the production database.
+    @Test
+    void baseConfigDoesNotEnableTheH2Console() throws IOException {
+        assertThat(resolve(BASE_CONFIG, "spring.h2.console.enabled")).isNull();
+        assertThat(resolve(BASE_CONFIG, "spring.h2.console.path")).isNull();
+    }
+
+    @Test
+    void theH2ProfileStillEnablesTheConsoleForLocalDevelopment() throws IOException {
+        assertThat(resolve(H2_PROFILE_CONFIG, "spring.h2.console.enabled")).isEqualTo("true");
+    }
+
+    // StdOutImpl prints every statement with its bound parameters, so the auth-layer queries
+    // put user emails, display names, and avatar URLs into the process log.
+    @Test
+    void baseConfigDoesNotLogEverySqlStatementAndItsParameters() throws IOException {
+        assertThat(resolve(BASE_CONFIG, "mybatis.configuration.log-impl"))
+            .isNotNull()
+            .doesNotContain("StdOutImpl");
+    }
+
+    @Test
+    void theH2ProfileKeepsStatementLoggingForLocalDevelopment() throws IOException {
+        assertThat(resolve(H2_PROFILE_CONFIG, "mybatis.configuration.log-impl")).contains("StdOutImpl");
+    }
+
+    // Tomcat only marks JSESSIONID as Secure when request.isSecure() is true, which behind a
+    // TLS-terminating proxy depends entirely on X-Forwarded-Proto being honoured.
+    @Test
+    void baseConfigCanMarkTheSessionCookieSecureAndTrustsTheProxyProtocolHeader() throws IOException {
+        assertThat(resolve(BASE_CONFIG, "server.servlet.session.cookie.secure")).isNotNull();
+        assertThat(resolve(BASE_CONFIG, "server.forward-headers-strategy")).isEqualTo("framework");
+    }
+
+    /**
+     * Returns the property's value with placeholders resolved against nothing but the file
+     * itself, i.e. the default a deployment gets when the corresponding environment variable is
+     * not set. Returns null when the key is absent.
+     */
+    private static String resolve(Path configFile, String key) throws IOException {
+        List<PropertySource<?>> loaded =
+            new YamlPropertySourceLoader().load(configFile.toString(), new FileSystemResource(configFile));
+        MutablePropertySources sources = new MutablePropertySources();
+        loaded.forEach(sources::addLast);
+
+        Object raw = null;
+        for (PropertySource<?> source : loaded) {
+            Object value = source.getProperty(key);
+            if (value != null) {
+                raw = value;
+                break;
+            }
+        }
+        if (raw == null) {
+            return null;
+        }
+        return new PropertySourcesPlaceholdersResolver(sources).resolvePlaceholders(raw.toString()).toString();
+    }
+}

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -70,6 +70,28 @@ FRONTEND_ORIGIN=http://localhost:4173
 # APP_AUTHORIZATION_REQUEST_BASE_URI=/api/auth/authorize
 ```
 
+### Production session cookie
+
+Set this on any HTTPS deployment:
+
+```bash
+SESSION_COOKIE_SECURE=true
+```
+
+It defaults to `false` so that plain-HTTP local development still gets a session at all (a
+`Secure` cookie is dropped by the browser on `http://localhost`). The session cookie lives for
+7 days, so leaving it unset in production means that cookie is eligible to be sent over a
+plain-HTTP request.
+
+This depends on the reverse proxy forwarding the original scheme: the backend sits behind
+TLS termination and would otherwise see every request as insecure. The app reads
+`X-Forwarded-Proto` (`server.forward-headers-strategy: framework`), and the nginx example
+below sends it on every proxied location.
+
+The H2 console is not part of a production deployment. It is enabled only by the `h2`
+profile; do not set `SPRING_PROFILES_ACTIVE=h2` on a server, since that profile also points
+the datasource at an in-memory database and runs the destructive local schema fixture.
+
 ### Instaloader avatar cache
 
 The Linux initializer creates a private Python virtual environment, installs
@@ -405,6 +427,11 @@ server {
         proxy_pass http://127.0.0.1:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # Required, like the /api/ block above: without the original scheme the backend
+        # treats the request as plain HTTP, so JSESSIONID loses its Secure attribute and
+        # any absolute URL the app builds during the OAuth handshake comes out as http://.
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     # Gzip
@@ -489,6 +516,8 @@ The `/api/auth/providers` endpoint auto-discovers all configured providers.
 - [ ] `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` set
 - [ ] `APP_OWNER_EMAILS` populated (comma-separated)
 - [ ] `FRONTEND_ORIGIN` matches production URL
+- [ ] `SESSION_COOKIE_SECURE=true` set, and the proxy sends `X-Forwarded-Proto`
+- [ ] `SPRING_PROFILES_ACTIVE` is unset (the `h2` profile is local-only and enables the H2 console)
 - [ ] Google OAuth redirect URIs include production URL
 - [ ] Frontend built with correct `VITE_API_BASE_URL`
 - [ ] Nginx configured with SSL (certbot)


### PR DESCRIPTION
Closes #99.

There is no production profile in this repo -- the documented deployment starts the app with no `SPRING_PROFILES_ACTIVE` -- so the base `application.yaml` is exactly what a server runs. The "dev only" comments next to these keys were not controls.

## Changes

- **H2 console removed from the base config.** It was enabled there, not only in the `h2` profile. The H2 driver is a `runtime` dependency and `SecurityConfig` ends in `anyRequest().permitAll()`, so `/h2-console` was reachable by anyone on a deployed instance, with a login form that accepts an arbitrary JDBC URL. `application-h2.yaml` already enables it, so local development is unchanged.
- **Statement logging defaults to the no-op logger.** `StdOutImpl` was unconditional and prints bound parameters, so auth-layer queries were writing user emails, display names, and avatar URLs into the process log on every request. The `h2` profile keeps stdout logging; `MYBATIS_LOG_IMPL` re-enables it anywhere for temporary debugging.
- **The session cookie can now actually be Secure.** The flag was unset *and* the app did not honour `X-Forwarded-Proto`, so behind nginx's TLS termination Tomcat saw plain HTTP and omitted `Secure` from a 7-day cookie. Adds `server.forward-headers-strategy: framework` plus a `SESSION_COOKIE_SECURE` toggle (default `false` so `http://localhost` login still works).
- Docs: `backend/.env.example` and `docs/DEPLOYMENT.md` describe both new variables, the production checklist gains two items, and the nginx `/oauth2/` block gets the `X-Forwarded-Proto` header it was missing (the `/api/` block already had it).

## Verification

- New `ProductionConfigDefaultsTest` (5 tests) reads the real main-source YAML **from disk** on purpose: `src/test/resources/application.yaml` shadows the base config for every `@SpringBootTest`, so a context-based test would only assert the test fixture. Placeholders are resolved against the file alone, i.e. it asserts the default a deployment gets when the env var is absent.
- Reverting only `backend/src/main/resources` makes 4 of those 5 fail (the fifth guards that the `h2` profile still enables the console for local dev).
- Full `mvnw test`: 391 tests, only the 8 pre-existing Windows-only `InstagramAvatarCacheServiceTest` failures (see #109).

No behaviour change for anyone running with the `h2` profile locally.