### PR TITLE
Club PUT: real partial edits, and status/visibility/approval/slug are no longer manager-editable

### DIFF
--- a/backend/src/main/java/com/example/demo/club/controller/ClubController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubController.java
@@ -5,6 +5,7 @@ import com.example.demo.club.model.ClubMemberView;
 import com.example.demo.club.model.ClubMembershipRequest;
 import com.example.demo.club.service.ClubService;
 import com.example.demo.security.AuthenticatedUserResolver;
+import tools.jackson.databind.JsonNode;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -82,11 +83,14 @@ public class ClubController {
 
     @PutMapping("/{clubSlugOrId}")
     public Club update(@PathVariable String clubSlugOrId,
-                       @RequestBody Club club,
+                       @RequestBody JsonNode patch,
                        Authentication authentication) {
         Club existing = requireManageAccess(clubSlugOrId, authentication);
         try {
-            return clubService.update(existing.getId(), club);
+            // The body is taken as raw JSON, not bound into a Club, so the service can tell
+            // "field omitted" from "field explicitly set to null": binding into a POJO collapses
+            // both into null, which is what made a partial edit wipe every other column.
+            return clubService.update(existing.getId(), patch);
         } catch (IllegalArgumentException ex) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage());
         }

--- a/backend/src/main/java/com/example/demo/club/service/ClubService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubService.java
@@ -163,6 +163,10 @@ public class ClubService {
      * Fields outside {@link #MANAGER_EDITABLE_FIELDS} are ignored, whatever the caller sends.
      */
     public Club update(Long id, JsonNode patch) {
+        // Re-read the row here rather than trusting a club the caller already loaded: what this
+        // method writes back is the whole row, so it must be merged onto the stored values as
+        // this service sees them, not onto an instance a controller may have mutated (the
+        // controller's copy carries viewer/permission fields) or held across another write.
         Club existing = clubMapper.findById(id);
         if (existing == null) {
             throw new IllegalArgumentException("Club not found");

--- a/backend/src/main/java/com/example/demo/club/service/ClubService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubService.java
@@ -7,6 +7,10 @@ import com.example.demo.club.model.ClubMemberView;
 import com.example.demo.club.model.ClubMembershipRequest;
 import com.example.demo.club.model.ViewerMembershipStatus;
 import com.example.demo.common.PaginationClamps;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,12 +32,33 @@ public class ClubService {
     );
     private static final Set<String> ALLOWED_MEMBER_ROLES = Set.of("member", "president");
 
+    // Exactly the fields a club manager may edit through PUT /api/clubs/{id}. Everything else
+    // the update statement writes -- slug (the club's public URL), status, visibility,
+    // approved_at, approved_by_oauth_user_id -- is carried over from the stored row instead:
+    // those decide whether a club is listed and published at all, and a club president must not
+    // be able to change them by adding a key to their edit request. image_url is absent for the
+    // same reason it is absent from the SQL: it only ever changes through the upload flow.
+    private static final Set<String> MANAGER_EDITABLE_FIELDS = Set.of(
+        "name",
+        "aliasName",
+        "description",
+        "category",
+        "meetingSchedule",
+        "scheduleNote",
+        "location",
+        "contactEmail",
+        "advisor",
+        "achievements"
+    );
+
     private final ClubMapper clubMapper;
     private final OAuthUserMapper oAuthUserMapper;
+    private final ObjectMapper objectMapper;
 
-    public ClubService(ClubMapper clubMapper, OAuthUserMapper oAuthUserMapper) {
+    public ClubService(ClubMapper clubMapper, OAuthUserMapper oAuthUserMapper, ObjectMapper objectMapper) {
         this.clubMapper = clubMapper;
         this.oAuthUserMapper = oAuthUserMapper;
+        this.objectMapper = objectMapper;
     }
 
     // ---- Listing ----
@@ -130,13 +155,43 @@ public class ClubService {
         return clubMapper.findById(club.getId());
     }
 
-    public Club update(Long id, Club club) {
-        normalizeClub(club);
-        club.setId(id);
-        clubMapper.update(club);
+    /**
+     * Applies a manager's edit to a club. The patch is raw request JSON so that an omitted field
+     * keeps its stored value while an explicitly null field clears it -- the update statement
+     * writes every column, so binding the body into a Club first (where both cases look like
+     * null) meant a partial edit silently wiped description, advisor, schedule, and the rest.
+     * Fields outside {@link #MANAGER_EDITABLE_FIELDS} are ignored, whatever the caller sends.
+     */
+    public Club update(Long id, JsonNode patch) {
+        Club existing = clubMapper.findById(id);
+        if (existing == null) {
+            throw new IllegalArgumentException("Club not found");
+        }
+        Club merged = applyEditableFields(existing, patch);
+        normalizeClub(merged);
+        merged.setId(id);
+        clubMapper.update(merged);
         // Same reasoning as create(): member_count is never written by this update, so
-        // re-fetch instead of returning the caller-supplied (and now stale) `club`.
+        // re-fetch instead of returning the now-stale in-memory club.
         return clubMapper.findById(id);
+    }
+
+    private Club applyEditableFields(Club existing, JsonNode patch) {
+        if (patch == null || !patch.isObject()) {
+            throw new IllegalArgumentException("Request body must be a JSON object");
+        }
+        ObjectNode editable = objectMapper.createObjectNode();
+        patch.properties().stream()
+            .filter(field -> MANAGER_EDITABLE_FIELDS.contains(field.getKey()))
+            .forEach(field -> editable.set(field.getKey(), field.getValue()));
+        try {
+            // readerForUpdating applies only the properties present in the tree, so an omitted
+            // key leaves the stored value untouched and an explicit null still clears it.
+            return objectMapper.readerForUpdating(existing).readValue(editable);
+        } catch (JacksonException e) {
+            // A wrong JSON type for a field (e.g. "achievements": 5) is a bad request, not a 500.
+            throw new IllegalArgumentException("Invalid club field value", e);
+        }
     }
 
     // The only path allowed to change a club's stored image URL: called from the dedicated,

--- a/backend/src/test/java/com/example/demo/club/service/ClubServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubServiceTest.java
@@ -12,21 +12,26 @@ import static org.mockito.Mockito.when;
 import com.example.demo.auth.mapper.OAuthUserMapper;
 import com.example.demo.club.mapper.ClubMapper;
 import com.example.demo.club.model.Club;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class ClubServiceTest {
 
     private ClubMapper clubMapper;
     private ClubService clubService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
     void setUp() {
         clubMapper = mock(ClubMapper.class);
         when(clubMapper.findAllPaginated(anyInt(), anyInt())).thenReturn(List.of());
         when(clubMapper.search(any(), any(), any(), any(), any(), anyInt(), anyInt())).thenReturn(List.of());
-        clubService = new ClubService(clubMapper, mock(OAuthUserMapper.class));
+        clubService = new ClubService(clubMapper, mock(OAuthUserMapper.class), objectMapper);
     }
 
     @Test
@@ -111,5 +116,93 @@ class ClubServiceTest {
         Club resolved = clubService.resolveBySlugOrId("does-not-exist", "viewer@example.com");
 
         assertThat(resolved).isNull();
+    }
+
+    // The update statement writes every column, so what the service hands it *is* the new row.
+    // A manager editing one field must not blank out the fields their form never sent.
+    @Test
+    void updateKeepsStoredValuesForFieldsTheRequestDidNotMention() {
+        when(clubMapper.findById(7L)).thenReturn(storedClub());
+
+        clubService.update(7L, json("{\"name\":\"Chess Team\"}"));
+
+        Club written = captureUpdatedClub();
+        assertThat(written.getName()).isEqualTo("Chess Team");
+        assertThat(written.getDescription()).isEqualTo("Weekly chess practice");
+        assertThat(written.getAdvisor()).isEqualTo("Ms. Lee");
+        assertThat(written.getContactEmail()).isEqualTo("chess@example.com");
+        assertThat(written.getMeetingSchedule()).isEqualTo("Wednesday lunch");
+        assertThat(written.getAchievements()).containsExactly("State finalist");
+    }
+
+    // Clearing an optional field is a real edit the admin form performs (it sends null), and
+    // must stay distinguishable from not mentioning the field at all.
+    @Test
+    void updateStillClearsAFieldThatIsExplicitlyNull() {
+        when(clubMapper.findById(7L)).thenReturn(storedClub());
+
+        clubService.update(7L, json("{\"advisor\":null}"));
+
+        assertThat(captureUpdatedClub().getAdvisor()).isNull();
+    }
+
+    // status/visibility/approval decide whether a club is listed and published at all, and slug
+    // is its public URL. A club president reaches this method through PUT /api/clubs/{id}, so
+    // these must be carried over from the stored row no matter what the body contains.
+    @Test
+    void updateIgnoresStatusVisibilityApprovalAndSlugFromTheRequestBody() {
+        when(clubMapper.findById(7L)).thenReturn(storedClub());
+
+        clubService.update(7L, json("""
+            {"name":"Chess Team","slug":"hijacked","status":"archived","visibility":"private",
+             "approvedByOauthUserId":99,"imageUrl":"/uploads/club-posts/someone-elses.jpg"}"""));
+
+        Club written = captureUpdatedClub();
+        assertThat(written.getSlug()).isEqualTo("chess-club");
+        assertThat(written.getStatus()).isEqualTo("active");
+        assertThat(written.getVisibility()).isEqualTo("public");
+        assertThat(written.getApprovedByOauthUserId()).isEqualTo(11L);
+        assertThat(written.getImageUrl()).isEqualTo("/uploads/club-posts/original.jpg");
+    }
+
+    @Test
+    void updateRejectsAnUnknownCategoryEvenWhenEveryOtherFieldIsOmitted() {
+        when(clubMapper.findById(7L)).thenReturn(storedClub());
+
+        try {
+            clubService.update(7L, json("{\"category\":\"Not A Category\"}"));
+            assertThat(false).as("expected an IllegalArgumentException").isTrue();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessage("Invalid category");
+        }
+        verify(clubMapper, never()).update(any());
+    }
+
+    private Club captureUpdatedClub() {
+        ArgumentCaptor<Club> captor = ArgumentCaptor.forClass(Club.class);
+        verify(clubMapper).update(captor.capture());
+        return captor.getValue();
+    }
+
+    private JsonNode json(String body) {
+        return objectMapper.readTree(body);
+    }
+
+    private static Club storedClub() {
+        Club club = new Club();
+        club.setId(7L);
+        club.setName("Chess Club");
+        club.setSlug("chess-club");
+        club.setDescription("Weekly chess practice");
+        club.setCategory("Competition & Strategy");
+        club.setMeetingSchedule("Wednesday lunch");
+        club.setAdvisor("Ms. Lee");
+        club.setContactEmail("chess@example.com");
+        club.setAchievements(List.of("State finalist"));
+        club.setStatus("active");
+        club.setVisibility("public");
+        club.setApprovedByOauthUserId(11L);
+        club.setImageUrl("/uploads/club-posts/original.jpg");
+        return club;
     }
 }

--- a/backend/src/test/java/com/example/demo/club/service/ClubServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.demo.club.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -169,12 +170,21 @@ class ClubServiceTest {
     void updateRejectsAnUnknownCategoryEvenWhenEveryOtherFieldIsOmitted() {
         when(clubMapper.findById(7L)).thenReturn(storedClub());
 
-        try {
-            clubService.update(7L, json("{\"category\":\"Not A Category\"}"));
-            assertThat(false).as("expected an IllegalArgumentException").isTrue();
-        } catch (IllegalArgumentException expected) {
-            assertThat(expected).hasMessage("Invalid category");
-        }
+        assertThatThrownBy(() -> clubService.update(7L, json("{\"category\":\"Not A Category\"}")))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid category");
+
+        verify(clubMapper, never()).update(any());
+    }
+
+    // The endpoint takes raw JSON, so a body that is valid JSON but not an object reaches the
+    // service instead of failing during binding. It must be a 400 (IllegalArgumentException,
+    // which the controller maps) rather than an unhandled 500.
+    @Test
+    void updateRejectsABodyThatIsNotAJsonObject() {
+        assertThatThrownBy(() -> clubService.update(7L, json("[1, 2, 3]")))
+            .isInstanceOf(IllegalArgumentException.class);
+
         verify(clubMapper, never()).update(any());
     }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -96,6 +96,22 @@ Get club detail. Accepts numeric ID or slug string. Viewer permissions (viewerIs
 ### PUT /api/clubs/{clubSlugOrId}
 Update club. Requires: platform_owner, or club president.
 
+The body is applied as a partial edit: only the fields it actually contains are written, so a
+form that submits one field leaves the rest of the club as it was, while a field sent
+explicitly as `null` is cleared. (Before this was true, the update statement wrote every
+column from the request body, so a partial edit blanked out everything it omitted.)
+
+Editable fields: `name`, `aliasName`, `description`, `category`, `meetingSchedule`,
+`scheduleNote`, `location`, `contactEmail`, `advisor`, `achievements`. Anything else in the
+body is ignored, including `slug` (the club's public URL), `status`, `visibility`,
+`approvedAt`, `approvedByOauthUserId`, and `imageUrl` -- the first five decide whether a club
+is listed and published at all and are not a club president's to change, and `imageUrl` only
+ever changes through the authenticated upload flow. There is currently no endpoint that
+changes a club's status or visibility; add a platform-owner-only one when that workflow is
+needed rather than reopening this body.
+
+`category` must be one of the six allowed categories, otherwise 400.
+
 ### DELETE /api/clubs/{clubSlugOrId}
 Delete club. Requires: platform_owner. Status: 204
 


### PR DESCRIPTION
Closes #101.

`ClubMapper.update` writes every column, and `ClubController.update` bound the request body into a fresh `Club`, so the body *was* the new row.

## What was broken

- **Partial edits wiped data.** Not hypothetical: `ClubAdminView`'s save payload never sends `slug`, `status`, or `visibility`, so every save from the club admin form nulled the club's public URL slug and reset status/visibility to the `normalizeClub` defaults.
- **A president could write privileged columns.** `status`, `visibility`, `approved_at`, and `approved_by_oauth_user_id` were all reachable from the body, and a club president gets here through `requireManageAccess`.

## Change

- The controller takes the body as raw JSON instead of binding it into a `Club`. That is what makes "field omitted" distinguishable from "field explicitly null" -- binding collapses both into null, and clearing an optional field is a real edit the admin form performs.
- `ClubService.update` applies only `MANAGER_EDITABLE_FIELDS` onto the **stored** row through `readerForUpdating`, so omitted fields keep their value, explicit nulls still clear, and `slug`/`status`/`visibility`/`approved_*`/`imageUrl` are always carried over from the database.
- Uses Jackson 3 (`tools.jackson`) deliberately: that is the mapper Spring Boot 4 auto-configures. The Jackson 2 `ObjectMapper` is still on the classpath but has no bean, which fails context startup.

## Verification

- Four new `ClubServiceTest` cases: omitted fields preserved, explicit null still clears, privileged fields ignored even when present in the body, and an invalid category still 400s without touching the mapper.
- Full `mvnw test`: 395 tests, only the 8 pre-existing Windows-only `InstagramAvatarCacheServiceTest` failures (#109).

## Note

No endpoint changes a club's status or visibility today, so nothing loses a capability here. `docs/API.md` records that a platform-owner-only endpoint is the right shape when that workflow is needed, rather than reopening this body.