### PR TITLE
Hide non-active clubs from GET /api/clubs/{idOrSlug}

### DIFF
--- a/backend/src/main/java/com/example/demo/club/controller/ClubController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubController.java
@@ -4,6 +4,7 @@ import com.example.demo.club.model.Club;
 import com.example.demo.club.model.ClubMemberView;
 import com.example.demo.club.model.ClubMembershipRequest;
 import com.example.demo.club.service.ClubService;
+import com.example.demo.club.service.ClubVisibilityPolicy;
 import com.example.demo.security.AuthenticatedUserResolver;
 import tools.jackson.databind.JsonNode;
 import org.springframework.http.HttpStatus;
@@ -32,10 +33,14 @@ public class ClubController {
 
     private final ClubService clubService;
     private final AuthenticatedUserResolver authenticatedUserResolver;
+    private final ClubVisibilityPolicy clubVisibilityPolicy;
 
-    public ClubController(ClubService clubService, AuthenticatedUserResolver authenticatedUserResolver) {
+    public ClubController(ClubService clubService,
+                          AuthenticatedUserResolver authenticatedUserResolver,
+                          ClubVisibilityPolicy clubVisibilityPolicy) {
         this.clubService = clubService;
         this.authenticatedUserResolver = authenticatedUserResolver;
+        this.clubVisibilityPolicy = clubVisibilityPolicy;
     }
 
     // ---- Club listing & detail ----
@@ -63,6 +68,13 @@ public class ClubController {
     public Club get(@PathVariable String clubSlugOrId, Authentication authentication) {
         Club club = resolveClub(clubSlugOrId, resolveViewerEmail(authentication));
         if (club == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
+        }
+        // findById/findBySlug carry no status filter, unlike every listing query, so this is the
+        // one read path that can surface a club the directory deliberately hides. Same policy
+        // and same 404 (never 403) as the post feed and comment list: a hidden club must be
+        // indistinguishable from one that does not exist, or the 403 itself confirms it exists.
+        if (!clubVisibilityPolicy.isVisibleTo(club, authentication)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
         }
         return club;

--- a/backend/src/test/java/com/example/demo/club/controller/ClubControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubControllerTest.java
@@ -5,12 +5,15 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.demo.auth.config.SecurityProperties;
 import com.example.demo.club.model.Club;
 import com.example.demo.club.service.ClubService;
+import com.example.demo.club.service.ClubVisibilityPolicy;
 import com.example.demo.security.AuthenticatedUserResolver;
 import java.util.List;
 import java.util.Map;
@@ -52,6 +55,13 @@ class ClubControllerTest {
         @Bean
         AuthenticatedUserResolver authenticatedUserResolver(SecurityProperties securityProperties) {
             return new AuthenticatedUserResolver(securityProperties);
+        }
+
+        // The real policy, not a mock: this test's whole point for the detail endpoint is which
+        // viewers that policy lets through, so stubbing it would assert nothing.
+        @Bean
+        ClubVisibilityPolicy clubVisibilityPolicy(AuthenticatedUserResolver authenticatedUserResolver) {
+            return new ClubVisibilityPolicy(authenticatedUserResolver);
         }
     }
 
@@ -105,6 +115,67 @@ class ClubControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"category\":\"STEM & Innovation\"}"))
             .andExpect(status().isOk());
+    }
+
+    // ---- Detail visibility ----
+    //
+    // findById/findBySlug carry no status filter (unlike every listing query), so without the
+    // policy check an anonymous caller who guesses an id can read a pending or archived club's
+    // full record -- description, advisor, contact email, approval fields -- while the club is
+    // hidden from every listing.
+
+    @Test
+    void anonymousCallerCannotReadANonActiveClub() throws Exception {
+        when(clubService.resolveBySlugOrId(eq("7"), any())).thenReturn(nonActiveClub());
+
+        mockMvc.perform(get("/api/clubs/7"))
+            .andExpect(status().isNotFound());
+    }
+
+    // 404 rather than 403 on purpose: a 403 would confirm the club exists.
+    @Test
+    void aSignedInNonMemberCannotReadANonActiveClub() throws Exception {
+        when(clubService.resolveBySlugOrId(eq("7"), any())).thenReturn(nonActiveClub());
+
+        mockMvc.perform(get("/api/clubs/7").principal(oauthToken(STUDENT_EMAIL)))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void aMemberCanStillReadTheirOwnNonActiveClub() throws Exception {
+        Club club = nonActiveClub();
+        club.setViewerIsMember(true);
+        when(clubService.resolveBySlugOrId(eq("7"), any())).thenReturn(club);
+
+        mockMvc.perform(get("/api/clubs/7").principal(oauthToken(STUDENT_EMAIL)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(7));
+    }
+
+    @Test
+    void aPlatformOwnerCanStillReadANonActiveClub() throws Exception {
+        when(clubService.resolveBySlugOrId(eq("7"), any())).thenReturn(nonActiveClub());
+
+        mockMvc.perform(get("/api/clubs/7").principal(oauthToken(OWNER_EMAIL)))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void anActiveClubIsStillReadableByAnyone() throws Exception {
+        Club club = nonActiveClub();
+        club.setStatus("active");
+        when(clubService.resolveBySlugOrId(eq("7"), any())).thenReturn(club);
+
+        mockMvc.perform(get("/api/clubs/7"))
+            .andExpect(status().isOk());
+    }
+
+    private static Club nonActiveClub() {
+        Club club = new Club();
+        club.setId(7L);
+        club.setName("Pending Club");
+        club.setStatus("pending");
+        return club;
     }
 
     private OAuth2AuthenticationToken oauthToken(String email) {

--- a/docs/API.md
+++ b/docs/API.md
@@ -93,6 +93,13 @@ Status: 201 | 400 | 403
 ### GET /api/clubs/{clubSlugOrId}
 Get club detail. Accepts numeric ID or slug string. Viewer permissions (viewerIsMember, canManage, viewerHasPendingRequest) included when authenticated.
 
+Visibility follows `ClubVisibilityPolicy`, the same policy the post feed and comment list use:
+an `active` club is readable by anyone, while a non-`active` (pending or archived) club is
+readable only by a member, the club's president, or a platform owner. Everyone else gets 404,
+not 403 -- a 403 would confirm the club exists. This matters because the underlying
+`findById`/`findBySlug` queries carry no status filter, unlike every listing query, so this is
+the one read path that could otherwise surface a club the directory deliberately hides.
+
 ### PUT /api/clubs/{clubSlugOrId}
 Update club. Requires: platform_owner, or club president.
 


### PR DESCRIPTION
Closes #102.

`findById`/`findBySlug` carry no status filter, unlike `findAll`, `findAllPaginated`, `search`, and `countAll`, which all apply `ActiveClause`. The detail endpoint is `permitAll` and did no visibility check of its own, so anyone who guessed or enumerated an id or slug could read a pending or archived club's full record -- description, advisor, contact email, approval fields -- while that club was hidden from every listing.

## Change

- `ClubController.get` now applies `ClubVisibilityPolicy`, the same policy `ClubPostController#feed` and `ClubPostCommentController#list` already use, so the three cannot silently disagree about which clubs the public can see.
- Active clubs stay readable by anyone; a non-active club is readable only by a member, its president, or a platform owner. Everyone else gets **404, not 403** -- a 403 would confirm the club exists, which is the same reasoning the media endpoints use.

## Verification

- 5 new `ClubControllerTest` cases: anonymous and signed-in non-member get 404; member, president-equivalent, and platform owner still get 200; an active club is unaffected. The test wires the **real** `ClubVisibilityPolicy` rather than a mock, since which viewers it admits is exactly what is under test.
- Reverting only `ClubController.java` fails 2 of them.
- Full `mvnw test`: 401 tests, only the 8 pre-existing Windows-only `InstagramAvatarCacheServiceTest` failures (#109).