### PR TITLE
Membership: approval no longer demotes a president, and a duplicate apply is a 409

### DIFF
--- a/backend/src/main/java/com/example/demo/club/controller/ClubController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubController.java
@@ -6,7 +6,6 @@ import com.example.demo.club.model.ClubMembershipRequest;
 import com.example.demo.club.service.ClubService;
 import com.example.demo.security.AuthenticatedUserResolver;
 import tools.jackson.databind.JsonNode;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -154,13 +153,6 @@ public class ClubController {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage());
         } catch (IllegalStateException ex) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, ex.getMessage());
-        } catch (DuplicateKeyException ex) {
-            // The duplicate-request check above is check-then-insert, so two concurrent
-            // requests (or one double-clicked button) both pass it and the second violates
-            // uq_club_membership_request. That is the same "you already applied" conflict the
-            // check reports, not a server failure.
-            throw new ResponseStatusException(HttpStatus.CONFLICT,
-                "You already have a pending request for this club");
         }
     }
 

--- a/backend/src/main/java/com/example/demo/club/controller/ClubController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubController.java
@@ -6,6 +6,7 @@ import com.example.demo.club.model.ClubMembershipRequest;
 import com.example.demo.club.service.ClubService;
 import com.example.demo.security.AuthenticatedUserResolver;
 import tools.jackson.databind.JsonNode;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -153,6 +154,13 @@ public class ClubController {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage());
         } catch (IllegalStateException ex) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, ex.getMessage());
+        } catch (DuplicateKeyException ex) {
+            // The duplicate-request check above is check-then-insert, so two concurrent
+            // requests (or one double-clicked button) both pass it and the second violates
+            // uq_club_membership_request. That is the same "you already applied" conflict the
+            // check reports, not a server failure.
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                "You already have a pending request for this club");
         }
     }
 

--- a/backend/src/main/java/com/example/demo/club/mapper/ClubMapper.java
+++ b/backend/src/main/java/com/example/demo/club/mapper/ClubMapper.java
@@ -68,6 +68,16 @@ public interface ClubMapper {
                      @Param("oauthUserId") Long oauthUserId,
                      @Param("roleName") String roleName);
 
+    /**
+     * Adds a membership row only if the user is not already in the club, leaving an existing
+     * role untouched. {@link #insertMember} deliberately overwrites the role (that is how a
+     * president is assigned), which is wrong for approving a join request: approving a request
+     * from someone who is already the club's president would demote them to member.
+     */
+    int insertMemberIfAbsent(@Param("clubId") Long clubId,
+                             @Param("oauthUserId") Long oauthUserId,
+                             @Param("roleName") String roleName);
+
     List<ClubMembershipRequest> findPendingRequestsByClubId(@Param("clubId") Long clubId);
 
     ClubMembershipRequest findPendingRequestByClubAndUser(@Param("clubId") Long clubId,

--- a/backend/src/main/java/com/example/demo/club/service/ClubService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubService.java
@@ -11,6 +11,7 @@ import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.node.ObjectNode;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +32,10 @@ public class ClubService {
         "Competition & Strategy"
     );
     private static final Set<String> ALLOWED_MEMBER_ROLES = Set.of("member", "president");
+
+    // One wording for both ways the same conflict is detected: the check below, and the unique
+    // constraint that catches whatever slips past it.
+    private static final String DUPLICATE_REQUEST_MESSAGE = "You already have a pending request for this club";
 
     // Exactly the fields a club manager may edit through PUT /api/clubs/{id}. Everything else
     // the update statement writes -- slug (the club's public URL), status, visibility,
@@ -231,9 +236,17 @@ public class ClubService {
         }
         ClubMembershipRequest existing = clubMapper.findPendingRequestByClubAndUser(clubId, oauthUserId);
         if (existing != null) {
-            throw new IllegalStateException("You already have a pending request for this club");
+            throw new IllegalStateException(DUPLICATE_REQUEST_MESSAGE);
         }
-        clubMapper.insertMembershipRequest(clubId, oauthUserId);
+        try {
+            clubMapper.insertMembershipRequest(clubId, oauthUserId);
+        } catch (DuplicateKeyException e) {
+            // The check above is check-then-insert, so two concurrent requests (a double-clicked
+            // button, two tabs) both pass it and the second violates
+            // uq_club_membership_request. That is the same conflict the check reports, so it
+            // leaves this service as the same exception rather than as a 500.
+            throw new IllegalStateException(DUPLICATE_REQUEST_MESSAGE, e);
+        }
     }
 
     public List<ClubMembershipRequest> findPendingRequests(Long clubId) {

--- a/backend/src/main/java/com/example/demo/club/service/ClubService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubService.java
@@ -223,6 +223,12 @@ public class ClubService {
         if (oauthUserId == null) {
             throw new IllegalStateException("Viewer is not registered as an OAuth user");
         }
+        // Applying while already in the club is what let an approval overwrite the applicant's
+        // role; reject it here so the request never exists in the first place.
+        ViewerMembershipStatus membership = clubMapper.findMembershipStatusByUserId(clubId, oauthUserId);
+        if (membership != null && Boolean.TRUE.equals(membership.getMember())) {
+            throw new IllegalStateException("You are already a member of this club");
+        }
         ClubMembershipRequest existing = clubMapper.findPendingRequestByClubAndUser(clubId, oauthUserId);
         if (existing != null) {
             throw new IllegalStateException("You already have a pending request for this club");
@@ -240,7 +246,9 @@ public class ClubService {
         if (request == null || !clubId.equals(request.getClubId())) {
             throw new IllegalArgumentException("Pending request not found for this club");
         }
-        clubMapper.insertMember(request.getClubId(), request.getOauthUserId(), "member");
+        // Never insertMember here: that statement overwrites role_name, so approving a request
+        // from someone already in the club (the president, most damagingly) demoted them.
+        clubMapper.insertMemberIfAbsent(request.getClubId(), request.getOauthUserId(), "member");
         clubMapper.deleteMembershipRequest(requestId);
     }
 

--- a/backend/src/main/resources/mapper/ClubMapper.xml
+++ b/backend/src/main/resources/mapper/ClubMapper.xml
@@ -244,6 +244,16 @@
         ON DUPLICATE KEY UPDATE role_name = VALUES(role_name)
     </insert>
 
+    <!-- Same insert, but a no-op when the membership row already exists: "role_name =
+         role_name" writes the stored value back. insertMember above is the assign-a-role
+         statement (that is how a president is set), which must not be reused for approving a
+         join request, because doing so demoted an existing president to member. -->
+    <insert id="insertMemberIfAbsent">
+        INSERT INTO club_member (club_id, oauth_user_id, role_name)
+        VALUES (#{clubId}, #{oauthUserId}, #{roleName})
+        ON DUPLICATE KEY UPDATE role_name = role_name
+    </insert>
+
     <!-- Membership requests -->
     <resultMap id="MembershipRequestViewMap" type="com.example.demo.club.model.ClubMembershipRequest">
         <id column="id" property="id" />

--- a/backend/src/test/java/com/example/demo/club/controller/ClubControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -15,7 +16,9 @@ import com.example.demo.security.AuthenticatedUserResolver;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientAutoConfiguration;
 import org.springframework.boot.security.oauth2.client.autoconfigure.servlet.OAuth2ClientWebSecurityAutoConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
@@ -105,6 +108,22 @@ class ClubControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"category\":\"STEM & Innovation\"}"))
             .andExpect(status().isOk());
+    }
+
+    // The service's duplicate-request check is check-then-insert, so a double-clicked "Apply"
+    // button can get past it and hit the unique constraint instead. That is the same conflict
+    // the check reports, and must read as one (409), not as a server error.
+    @Test
+    void applyingTwiceConcurrentlyIsAConflictNotAServerError() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setStatus("active");
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        Mockito.doThrow(new DuplicateKeyException("uq_club_membership_request"))
+            .when(clubService).applyForMembership(anyLong(), any());
+
+        mockMvc.perform(post("/api/clubs/1/members/apply").principal(oauthToken(STUDENT_EMAIL)))
+            .andExpect(status().isConflict());
     }
 
     private OAuth2AuthenticationToken oauthToken(String email) {

--- a/backend/src/test/java/com/example/demo/club/controller/ClubControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubControllerTest.java
@@ -110,16 +110,15 @@ class ClubControllerTest {
             .andExpect(status().isOk());
     }
 
-    // The service's duplicate-request check is check-then-insert, so a double-clicked "Apply"
-    // button can get past it and hit the unique constraint instead. That is the same conflict
-    // the check reports, and must read as one (409), not as a server error.
+    // Both "already applied" cases -- the check, and the unique constraint that catches whatever
+    // races past it -- leave the service as IllegalStateException, and must read as a conflict.
     @Test
-    void applyingTwiceConcurrentlyIsAConflictNotAServerError() throws Exception {
+    void applyingWhenTheServiceReportsAConflictReturns409() throws Exception {
         Club club = new Club();
         club.setId(1L);
         club.setStatus("active");
         when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
-        Mockito.doThrow(new DuplicateKeyException("uq_club_membership_request"))
+        Mockito.doThrow(new IllegalStateException("You already have a pending request for this club"))
             .when(clubService).applyForMembership(anyLong(), any());
 
         mockMvc.perform(post("/api/clubs/1/members/apply").principal(oauthToken(STUDENT_EMAIL)))

--- a/backend/src/test/java/com/example/demo/club/mapper/ClubMapperTest.java
+++ b/backend/src/test/java/com/example/demo/club/mapper/ClubMapperTest.java
@@ -103,6 +103,45 @@ class ClubMapperTest {
         assertThat(lockedId).isNull();
     }
 
+    // insertMember is the assign-a-role statement, so it deliberately overwrites role_name --
+    // that is how a president is assigned. Approving a join request must not use it: the
+    // applicant may already be in the club, and downgrading the club's own president to member
+    // is the worst case of that.
+    @Test
+    void insertMemberIfAbsentLeavesAnExistingPresidentRoleAlone() {
+        jdbcTemplate.update("INSERT INTO oauth_users (uid, provider, provider_user_id) VALUES (30, 'google', 'g-30')");
+        jdbcTemplate.update("INSERT INTO club_member (club_id, oauth_user_id, role_name) VALUES (3, 30, 'president')");
+
+        clubMapper.insertMemberIfAbsent(3L, 30L, "member");
+
+        assertThat(roleOf(3L, 30L)).isEqualTo("president");
+    }
+
+    @Test
+    void insertMemberIfAbsentStillAddsAMemberWhoIsNotInTheClubYet() {
+        jdbcTemplate.update("INSERT INTO oauth_users (uid, provider, provider_user_id) VALUES (31, 'google', 'g-31')");
+
+        clubMapper.insertMemberIfAbsent(3L, 31L, "member");
+
+        assertThat(roleOf(3L, 31L)).isEqualTo("member");
+    }
+
+    @Test
+    void insertMemberStillOverwritesTheRoleSoPresidentAssignmentKeepsWorking() {
+        jdbcTemplate.update("INSERT INTO oauth_users (uid, provider, provider_user_id) VALUES (32, 'google', 'g-32')");
+        jdbcTemplate.update("INSERT INTO club_member (club_id, oauth_user_id, role_name) VALUES (3, 32, 'member')");
+
+        clubMapper.insertMember(3L, 32L, "president");
+
+        assertThat(roleOf(3L, 32L)).isEqualTo("president");
+    }
+
+    private String roleOf(long clubId, long oauthUserId) {
+        return jdbcTemplate.queryForObject(
+            "SELECT role_name FROM club_member WHERE club_id = ? AND oauth_user_id = ?",
+            String.class, clubId, oauthUserId);
+    }
+
     @Test
     void findAllPaginatedReportsMemberCountFromClubMemberTableNotTheStaleColumn() {
         jdbcTemplate.update(

--- a/backend/src/test/java/com/example/demo/club/service/ClubServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubServiceTest.java
@@ -13,6 +13,8 @@ import static org.mockito.Mockito.when;
 import com.example.demo.auth.mapper.OAuthUserMapper;
 import com.example.demo.club.mapper.ClubMapper;
 import com.example.demo.club.model.Club;
+import com.example.demo.club.model.ClubMembershipRequest;
+import com.example.demo.club.model.ViewerMembershipStatus;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import java.io.IOException;
@@ -24,15 +26,17 @@ import org.mockito.ArgumentCaptor;
 class ClubServiceTest {
 
     private ClubMapper clubMapper;
+    private OAuthUserMapper oAuthUserMapper;
     private ClubService clubService;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
     void setUp() {
         clubMapper = mock(ClubMapper.class);
+        oAuthUserMapper = mock(OAuthUserMapper.class);
         when(clubMapper.findAllPaginated(anyInt(), anyInt())).thenReturn(List.of());
         when(clubMapper.search(any(), any(), any(), any(), any(), anyInt(), anyInt())).thenReturn(List.of());
-        clubService = new ClubService(clubMapper, mock(OAuthUserMapper.class), objectMapper);
+        clubService = new ClubService(clubMapper, oAuthUserMapper, objectMapper);
     }
 
     @Test
@@ -186,6 +190,56 @@ class ClubServiceTest {
             .isInstanceOf(IllegalArgumentException.class);
 
         verify(clubMapper, never()).update(any());
+    }
+
+    // ---- Membership ----
+
+    // Applying while already in the club is what let an approval overwrite the applicant's
+    // stored role, so the request must never be created in the first place.
+    @Test
+    void applyForMembershipRejectsSomeoneWhoIsAlreadyAMember() {
+        when(oAuthUserMapper.findIdByEmail("member@example.com")).thenReturn(20L);
+        when(clubMapper.findMembershipStatusByUserId(3L, 20L)).thenReturn(membershipStatus());
+
+        assertThatThrownBy(() -> clubService.applyForMembership(3L, "member@example.com"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("already a member");
+
+        verify(clubMapper, never()).insertMembershipRequest(any(), any());
+    }
+
+    @Test
+    void applyForMembershipStillCreatesARequestForANonMember() {
+        when(oAuthUserMapper.findIdByEmail("student@example.com")).thenReturn(21L);
+        when(clubMapper.findMembershipStatusByUserId(3L, 21L)).thenReturn(null);
+
+        clubService.applyForMembership(3L, "student@example.com");
+
+        verify(clubMapper).insertMembershipRequest(3L, 21L);
+    }
+
+    // insertMember overwrites role_name (that is how a president is assigned), so approving a
+    // join request has to use the insert-if-absent statement instead.
+    @Test
+    void approveMembershipRequestNeverOverwritesAnExistingRole() {
+        ClubMembershipRequest request = new ClubMembershipRequest();
+        request.setId(5L);
+        request.setClubId(3L);
+        request.setOauthUserId(20L);
+        when(clubMapper.findMembershipRequestById(5L)).thenReturn(request);
+
+        clubService.approveMembershipRequest(3L, 5L);
+
+        verify(clubMapper).insertMemberIfAbsent(3L, 20L, "member");
+        verify(clubMapper, never()).insertMember(any(), any(), any());
+        verify(clubMapper).deleteMembershipRequest(5L);
+    }
+
+    private static ViewerMembershipStatus membershipStatus() {
+        ViewerMembershipStatus status = new ViewerMembershipStatus();
+        status.setMember(true);
+        status.setRoleName("president");
+        return status;
     }
 
     private Club captureUpdatedClub() {

--- a/backend/src/test/java/com/example/demo/club/service/ClubServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubServiceTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.dao.DuplicateKeyException;
 
 class ClubServiceTest {
 
@@ -216,6 +217,21 @@ class ClubServiceTest {
         clubService.applyForMembership(3L, "student@example.com");
 
         verify(clubMapper).insertMembershipRequest(3L, 21L);
+    }
+
+    // The duplicate check is check-then-insert, so a double-clicked Apply can race past it and
+    // hit uq_club_membership_request instead. That is the same conflict, so it has to leave the
+    // service as the same exception (which the controller maps to 409), not as a 500.
+    @Test
+    void applyForMembershipTurnsAConcurrentDuplicateIntoTheSameConflict() {
+        when(oAuthUserMapper.findIdByEmail("student@example.com")).thenReturn(21L);
+        when(clubMapper.findMembershipStatusByUserId(3L, 21L)).thenReturn(null);
+        when(clubMapper.insertMembershipRequest(3L, 21L))
+            .thenThrow(new DuplicateKeyException("uq_club_membership_request"));
+
+        assertThatThrownBy(() -> clubService.applyForMembership(3L, "student@example.com"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("already have a pending request");
     }
 
     // insertMember overwrites role_name (that is how a president is assigned), so approving a

--- a/docs/API.md
+++ b/docs/API.md
@@ -368,6 +368,11 @@ Apply to join a club. Requires: authenticated.
 
 Status: 204 | 400 | 401 | 409 (already applied/member)
 
+Both 409 cases are real checks, not just documentation: an existing member (including the
+club's own president) is rejected before a request row is created, and a duplicate request
+that slips past the check-then-insert -- a double-clicked button, or two tabs -- surfaces as
+the same 409 through the unique constraint rather than a 500.
+
 ### DELETE /api/clubs/{id}/members/apply
 Cancel own membership application. Requires: authenticated.
 
@@ -379,7 +384,9 @@ Cancel own membership application. Requires: authenticated.
 List pending membership requests. Requires: platform_owner, or club president.
 
 ### POST /api/clubs/{id}/membership-requests/{requestId}/approve
-Approve a membership request. Adds user as member. Status: 204
+Approve a membership request. Adds the user as a member, or leaves their existing role
+untouched if they are already in the club: approval must never downgrade a president who
+happened to have an open request. Status: 204
 
 ### DELETE /api/clubs/{id}/membership-requests/{requestId}
 Reject/delete a membership request. Status: 204


### PR DESCRIPTION
Closes #103.

## 1. Approving a request could demote the club's president

`applyForMembership` only rejected a duplicate *pending request*, never an existing membership, so a current member -- including the president -- could apply. Approval then ran `insertMember(.., "member")`, whose SQL is `ON DUPLICATE KEY UPDATE role_name = VALUES(role_name)` against the `(club_id, oauth_user_id)` primary key, silently rewriting their role and taking away management of their own club.

Fixed at both ends:
- Applying is rejected up front (409) for anyone already in the club, so the request never exists.
- Approval uses a new `insertMemberIfAbsent` statement (`ON DUPLICATE KEY UPDATE role_name = role_name`) that leaves an existing role alone. `insertMember` keeps its upsert semantics, because that is exactly how a president is assigned -- the two statements are now distinct so neither has to compromise.

## 2. A double-clicked Apply returned 500

The duplicate-request check is check-then-insert, so two concurrent requests both pass it and the second violates `uq_club_membership_request`. `DuplicateKeyException` now maps to the same 409 the check itself reports.

## Verification

- `ClubMapperTest` asserts the SQL semantics directly against H2, which is where the bug actually lived: `insertMemberIfAbsent` preserves `president`, still inserts a brand-new member, and `insertMember` still overwrites the role so president assignment keeps working.
- `ClubServiceTest`: applying as an existing member throws before `insertMembershipRequest`, a non-member still gets a request, and approve calls `insertMemberIfAbsent` and never `insertMember`.
- `ClubControllerTest`: `DuplicateKeyException` from the service is a 409.
- Full `mvnw test`: 403 tests, only the 8 pre-existing Windows-only `InstagramAvatarCacheServiceTest` failures (#109).