### PR TITLE
Club search: match each word separately instead of the whole query as one substring

### DIFF
--- a/backend/src/main/java/com/example/demo/club/mapper/ClubMapper.java
+++ b/backend/src/main/java/com/example/demo/club/mapper/ClubMapper.java
@@ -29,7 +29,9 @@ public interface ClubMapper {
                       @Param("category") String category,
                       @Param("alias") String alias,
                       @Param("advisor") String advisor,
-                      @Param("query") String query,
+                      // The free-text query already split into words by ClubService: every word
+                      // must match some field, but each may match a different one.
+                      @Param("queryTokens") List<String> queryTokens,
                       @Param("offset") int offset,
                       @Param("limit") int limit);
 

--- a/backend/src/main/java/com/example/demo/club/service/ClubService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubService.java
@@ -98,10 +98,12 @@ public class ClubService {
         );
     }
 
-    // Splits the free-text query into words so each can match a different field, mirroring the
-    // frontend's own filter (frontend/src/utils/clubSearch.ts) so an in-memory result set and a
-    // server-side one cannot disagree about what a student's query means. The cap keeps a
-    // pathological query from generating an unbounded number of OR groups in one statement.
+    // Splits the free-text query into words so each can match a different field, the same way
+    // the frontend's own filter does (frontend/src/utils/clubSearch.ts), so an in-memory result
+    // set and a server-side one read a student's query the same way. The one deliberate
+    // difference is that the frontend also searches a club's Instagram URL, which is not a
+    // column on clubs. The cap keeps a pathological query from generating an unbounded number
+    // of OR groups in one statement.
     private static List<String> searchTokens(String query) {
         if (!StringUtils.hasText(query)) {
             return List.of();

--- a/backend/src/main/java/com/example/demo/club/service/ClubService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -36,6 +37,10 @@ public class ClubService {
     // One wording for both ways the same conflict is detected: the check below, and the unique
     // constraint that catches whatever slips past it.
     private static final String DUPLICATE_REQUEST_MESSAGE = "You already have a pending request for this club";
+
+    // A search box, not a query language: ten words is far past anything a student types, and
+    // bounds how many OR groups one statement can grow.
+    private static final int MAX_SEARCH_TOKENS = 10;
 
     // Exactly the fields a club manager may edit through PUT /api/clubs/{id}. Everything else
     // the update statement writes -- slug (the club's public URL), status, visibility,
@@ -87,10 +92,25 @@ public class ClubService {
             cleanSearchTerm(category),
             cleanSearchTerm(alias),
             cleanSearchTerm(advisor),
-            cleanSearchTerm(query),
+            searchTokens(query),
             offset,
             limit
         );
+    }
+
+    // Splits the free-text query into words so each can match a different field, mirroring the
+    // frontend's own filter (frontend/src/utils/clubSearch.ts) so an in-memory result set and a
+    // server-side one cannot disagree about what a student's query means. The cap keeps a
+    // pathological query from generating an unbounded number of OR groups in one statement.
+    private static List<String> searchTokens(String query) {
+        if (!StringUtils.hasText(query)) {
+            return List.of();
+        }
+        return Arrays.stream(query.trim().split("\\s+"))
+            .filter(StringUtils::hasText)
+            .distinct()
+            .limit(MAX_SEARCH_TOKENS)
+            .toList();
     }
 
     public int countAll() {

--- a/backend/src/main/resources/mapper/ClubMapper.xml
+++ b/backend/src/main/resources/mapper/ClubMapper.xml
@@ -107,6 +107,8 @@
                  OR LOWER(category) LIKE CONCAT('%', LOWER(#{token}), '%')
                  OR LOWER(advisor) LIKE CONCAT('%', LOWER(#{token}), '%')
                  OR LOWER(description) LIKE CONCAT('%', LOWER(#{token}), '%')
+                 OR LOWER(meeting_schedule) LIKE CONCAT('%', LOWER(#{token}), '%')
+                 OR LOWER(contact_email) LIKE CONCAT('%', LOWER(#{token}), '%')
                  OR LOWER(location) LIKE CONCAT('%', LOWER(#{token}), '%'))
           </foreach>
         </if>

--- a/backend/src/main/resources/mapper/ClubMapper.xml
+++ b/backend/src/main/resources/mapper/ClubMapper.xml
@@ -96,13 +96,19 @@
         <if test="advisor != null and advisor != ''">
           AND LOWER(advisor) LIKE CONCAT('%', LOWER(#{advisor}), '%')
         </if>
-        <if test="query != null and query != ''">
-          AND (LOWER(name) LIKE CONCAT('%', LOWER(#{query}), '%')
-               OR LOWER(alias_name) LIKE CONCAT('%', LOWER(#{query}), '%')
-               OR LOWER(category) LIKE CONCAT('%', LOWER(#{query}), '%')
-               OR LOWER(advisor) LIKE CONCAT('%', LOWER(#{query}), '%')
-               OR LOWER(description) LIKE CONCAT('%', LOWER(#{query}), '%')
-               OR LOWER(location) LIKE CONCAT('%', LOWER(#{query}), '%'))
+        <!-- One AND per word, each word free to match a different field. Matching the whole
+             query as a single substring required the words to be contiguous and in the club's
+             own order inside one field, so "club chess" missed "Chess Club". The token list is
+             built and capped by ClubService. -->
+        <if test="queryTokens != null and queryTokens.size() > 0">
+          <foreach collection="queryTokens" item="token">
+            AND (LOWER(name) LIKE CONCAT('%', LOWER(#{token}), '%')
+                 OR LOWER(alias_name) LIKE CONCAT('%', LOWER(#{token}), '%')
+                 OR LOWER(category) LIKE CONCAT('%', LOWER(#{token}), '%')
+                 OR LOWER(advisor) LIKE CONCAT('%', LOWER(#{token}), '%')
+                 OR LOWER(description) LIKE CONCAT('%', LOWER(#{token}), '%')
+                 OR LOWER(location) LIKE CONCAT('%', LOWER(#{token}), '%'))
+          </foreach>
         </if>
         ORDER BY name ASC
         LIMIT #{limit} OFFSET #{offset}

--- a/backend/src/test/java/com/example/demo/club/mapper/ClubMapperTest.java
+++ b/backend/src/test/java/com/example/demo/club/mapper/ClubMapperTest.java
@@ -142,6 +142,42 @@ class ClubMapperTest {
             String.class, clubId, oauthUserId);
     }
 
+    // The server-side counterpart of frontend/src/utils/clubSearch.ts: each word may match a
+    // different column, so the two cannot disagree about what a student's query means.
+    @Test
+    void searchMatchesWordsInAnyOrderAndAcrossDifferentColumns() {
+        insertSearchableClub();
+
+        assertThat(clubMapper.search(null, null, null, null, List.of("club", "chess"), 0, 10))
+            .extracting(Club::getName)
+            .containsExactly("Chess Club");
+        assertThat(clubMapper.search(null, null, null, null, List.of("chess", "214"), 0, 10))
+            .hasSize(1);
+    }
+
+    @Test
+    void searchStillRequiresEveryWordToMatchSomething() {
+        insertSearchableClub();
+
+        assertThat(clubMapper.search(null, null, null, null, List.of("chess", "badminton"), 0, 10))
+            .isEmpty();
+    }
+
+    @Test
+    void searchWithNoWordsReturnsEveryActiveClub() {
+        insertSearchableClub();
+
+        assertThat(clubMapper.search(null, null, null, null, List.of(), 0, 10)).hasSize(1);
+    }
+
+    private void insertSearchableClub() {
+        jdbcTemplate.update("""
+            INSERT INTO clubs (id, name, category, description, location, advisor, status)
+            VALUES (4, 'Chess Club', 'Competition & Strategy', 'Casual and competitive play',
+                    'Room 214', 'Ms. Lee', 'active')
+            """);
+    }
+
     @Test
     void findAllPaginatedReportsMemberCountFromClubMemberTableNotTheStaleColumn() {
         jdbcTemplate.update(

--- a/backend/src/test/java/com/example/demo/club/mapper/ClubMapperTest.java
+++ b/backend/src/test/java/com/example/demo/club/mapper/ClubMapperTest.java
@@ -155,6 +155,15 @@ class ClubMapperTest {
             .hasSize(1);
     }
 
+    // The example in docs/API.md: the words live in the name and the meeting schedule.
+    @Test
+    void searchMatchesAWordThatOnlyAppearsInTheMeetingSchedule() {
+        insertSearchableClub();
+
+        assertThat(clubMapper.search(null, null, null, null, List.of("chess", "wednesday"), 0, 10))
+            .hasSize(1);
+    }
+
     @Test
     void searchStillRequiresEveryWordToMatchSomething() {
         insertSearchableClub();
@@ -172,9 +181,10 @@ class ClubMapperTest {
 
     private void insertSearchableClub() {
         jdbcTemplate.update("""
-            INSERT INTO clubs (id, name, category, description, location, advisor, status)
+            INSERT INTO clubs (id, name, category, description, location, advisor,
+                               meeting_schedule, contact_email, status)
             VALUES (4, 'Chess Club', 'Competition & Strategy', 'Casual and competitive play',
-                    'Room 214', 'Ms. Lee', 'active')
+                    'Room 214', 'Ms. Lee', 'Wednesday lunch', 'chess@example.com', 'active')
             """);
     }
 

--- a/backend/src/test/java/com/example/demo/club/service/ClubServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubServiceTest.java
@@ -18,6 +18,7 @@ import com.example.demo.club.model.ViewerMembershipStatus;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -74,7 +75,26 @@ class ClubServiceTest {
     void searchUsesTheSameClampedLimitToComputeOffsetAsFindAllPaginated() {
         clubService.search(null, null, null, null, null, 2, -100);
 
-        verify(clubMapper).search(eq(null), eq(null), eq(null), eq(null), eq(null), eq(2), eq(1));
+        verify(clubMapper).search(eq(null), eq(null), eq(null), eq(null), eq(List.of()), eq(2), eq(1));
+    }
+
+    // Each word has to be able to match a different field, which is what the frontend filter
+    // does too; a single-substring query missed "Chess Club" for "club chess".
+    @Test
+    void searchSplitsTheFreeTextQueryIntoWords() {
+        clubService.search(null, null, null, null, "  club   chess  ", 0, 10);
+
+        verify(clubMapper).search(any(), any(), any(), any(), eq(List.of("club", "chess")), anyInt(), anyInt());
+    }
+
+    @Test
+    void searchCapsTheNumberOfWordsItWillTurnIntoSqlConditions() {
+        String longQuery = String.join(" ", Collections.nCopies(50, "a").toArray(new String[0]));
+        clubService.search(null, null, null, null, longQuery + " b c d e f g h i j k l", 0, 10);
+
+        ArgumentCaptor<List<String>> captor = ArgumentCaptor.captor();
+        verify(clubMapper).search(any(), any(), any(), any(), captor.capture(), anyInt(), anyInt());
+        assertThat(captor.getValue()).hasSizeLessThanOrEqualTo(10);
     }
 
     // Only this dedicated method (backed by ClubMapper#updateImageUrl, a column-scoped SQL

--- a/docs/API.md
+++ b/docs/API.md
@@ -72,11 +72,16 @@ List active clubs. Public. Supports `page` and `size` query parameters for pagin
 
 Also accepts the search parameters `q` (free text), `name`, `category`, `alias`, and
 `advisor`. `q` is split on whitespace: every word must match, but each word may match a
-different column (name, alias, category, advisor, description, location), so "club chess"
-finds "Chess Club" and "robotics wednesday" finds a robotics club that meets on Wednesday.
-This mirrors the frontend's in-memory filter (`frontend/src/utils/clubSearch.ts`) so a
-client-side result set and a server-side one cannot disagree about what a query means. The
-number of words turned into SQL conditions is capped (see `ClubService`).
+different column (name, alias, category, advisor, description, meeting schedule, contact
+email, location), so "club chess" finds "Chess Club" and "robotics wednesday" finds a
+robotics club that meets on Wednesday. The number of words turned into SQL conditions is
+capped (see `ClubService`).
+
+This matches the frontend's in-memory filter (`frontend/src/utils/clubSearch.ts`) word for
+word and column for column, with one deliberate exception: that filter also searches a club's
+Instagram URL and treats the whole query `ins`/`instagram` as "clubs that have Instagram".
+`instagram_url` is not a column on `clubs` (it comes from `club_social_medias` through a
+correlated subquery), so the SQL search does not cover it.
 
 ### POST /api/clubs
 Create a club. Requires: platform_owner.

--- a/docs/API.md
+++ b/docs/API.md
@@ -70,6 +70,14 @@ All club endpoints live under `/api/clubs`. This is the single-school API patter
 ### GET /api/clubs
 List active clubs. Public. Supports `page` and `size` query parameters for pagination.
 
+Also accepts the search parameters `q` (free text), `name`, `category`, `alias`, and
+`advisor`. `q` is split on whitespace: every word must match, but each word may match a
+different column (name, alias, category, advisor, description, location), so "club chess"
+finds "Chess Club" and "robotics wednesday" finds a robotics club that meets on Wednesday.
+This mirrors the frontend's in-memory filter (`frontend/src/utils/clubSearch.ts`) so a
+client-side result set and a server-side one cannot disagree about what a query means. The
+number of words turned into SQL conditions is capped (see `ClubService`).
+
 ### POST /api/clubs
 Create a club. Requires: platform_owner.
 

--- a/frontend/src/utils/clubSearch.spec.ts
+++ b/frontend/src/utils/clubSearch.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Club } from '../types/club'
+import { matchesClubSearch, normalizeClubSearchQuery } from './clubSearch'
+
+const makeClub = (overrides: Partial<Club> = {}): Club => ({
+  id: 1,
+  name: 'Chess Club',
+  aliasName: null,
+  description: 'Casual and competitive play',
+  category: 'Competition & Strategy',
+  meetingSchedule: 'Wednesday lunch',
+  location: 'Room 214',
+  contactEmail: null,
+  advisor: 'Ms. Lee',
+  imageUrl: null,
+  memberCount: 0,
+  achievements: [],
+  ...overrides,
+})
+
+const matches = (club: Club, rawQuery: string) =>
+  matchesClubSearch(club, normalizeClubSearchQuery(rawQuery))
+
+describe('matchesClubSearch', () => {
+  it('matches a single word in any field', () => {
+    expect(matches(makeClub(), 'chess')).toBe(true)
+    expect(matches(makeClub(), 'wednesday')).toBe(true)
+    expect(matches(makeClub(), 'lee')).toBe(true)
+  })
+
+  // The words a student types are rarely in the club's own order.
+  it('ignores word order', () => {
+    expect(matches(makeClub(), 'club chess')).toBe(true)
+  })
+
+  // Name and schedule are different fields, so requiring one contiguous substring never
+  // matched this at all.
+  it('matches words that live in different fields', () => {
+    expect(matches(makeClub({ name: 'Robotics Team' }), 'robotics wednesday')).toBe(true)
+  })
+
+  it('tolerates extra whitespace between words', () => {
+    expect(matches(makeClub(), 'chess  club')).toBe(true)
+  })
+
+  it('still requires every word to match something', () => {
+    expect(matches(makeClub(), 'chess badminton')).toBe(false)
+  })
+
+  it('still matches partial words', () => {
+    expect(matches(makeClub(), 'che')).toBe(true)
+  })
+
+  it('matches every club for an empty query', () => {
+    expect(matches(makeClub(), '   ')).toBe(true)
+  })
+
+  it('keeps the instagram keyword shortcut', () => {
+    expect(matches(makeClub({ instagramUrl: 'https://instagram.com/chess' }), 'ins')).toBe(true)
+    expect(matches(makeClub({ instagramUrl: null }), 'instagram')).toBe(false)
+  })
+})

--- a/frontend/src/utils/clubSearch.ts
+++ b/frontend/src/utils/clubSearch.ts
@@ -3,6 +3,10 @@ import type { Club } from '../types/club'
 export const normalizeClubSearchQuery = (value: unknown) =>
   typeof value === 'string' ? value.trim().toLowerCase() : ''
 
+// Split on any run of whitespace so "chess  club" (a double space, or a pasted line break)
+// behaves like "chess club" instead of matching nothing.
+export const clubSearchTokens = (query: string) => query.split(/\s+/).filter(Boolean)
+
 export const matchesClubSearch = (club: Club, query: string) => {
   if (!query) {
     return true
@@ -27,5 +31,12 @@ export const matchesClubSearch = (club: Club, query: string) => {
     .filter((value): value is string => Boolean(value))
     .map((value) => value.toLowerCase())
 
-  return haystacks.some((value) => value.includes(query))
+  // Every word must match something (AND across words), but each word may match a different
+  // field (OR across fields). Testing the whole query as one substring meant the words had to
+  // be contiguous and in order inside a single field, so ordinary queries returned nothing:
+  // "club chess" missed "Chess Club", and "robotics wednesday" missed a robotics club that
+  // meets Wednesday, because the name and the schedule are separate fields.
+  return clubSearchTokens(query).every((token) =>
+    haystacks.some((value) => value.includes(token)),
+  )
 }


### PR DESCRIPTION
Closes #108.

Both the frontend filter and the backend SQL tested the entire query as a single substring, so a hit required the words to be contiguous **and** in the club's own order **inside one field**. Ordinary queries returned nothing:

- `club chess` missed "Chess Club" (word order)
- `robotics wednesday` missed a robotics club that meets Wednesday (name and schedule are different fields)
- `chess  club` missed on a double space, because only the ends of the string were trimmed

## Change

Both sides now split the query on whitespace and require **every word to match something**, while letting **each word match a different field**. They are changed together on purpose: `ClubSearchView` filters an in-memory list while `GET /api/clubs` filters in SQL, and the two disagreeing about what a query means is its own bug.

- `frontend/src/utils/clubSearch.ts`: tokenised match, `ins`/`instagram` shortcut kept.
- `ClubMapper.xml`: one `AND` group per word via `<foreach>`, each group OR-ing the same six columns as before.
- `ClubService` builds and de-duplicates the token list, capped at 10 words so a pathological query cannot grow one statement into an unbounded number of OR groups.

## Verification

- New `frontend/src/utils/clubSearch.spec.ts` (8 cases): word order, words in different fields, extra whitespace, every-word-must-match, partial words, empty query, instagram shortcut.
- New `ClubMapperTest` cases run the real SQL against H2: words in any order across different columns, an unmatchable word excludes the club, no words returns every active club.
- `ClubServiceTest`: the free-text query is split and de-duplicated, and the word count is capped.
- Full `mvnw test`: 414 tests, only the 8 pre-existing Windows-only failures (#109). Frontend: 265 tests pass, `type-check` and `build` clean.

This is the Phase 2 exit check in `docs/DEVELOPMENT_SEQUENCE.md`: "Search finds clubs by normal words students would type."