### PR TITLE
Frontend: keep auth state in sync with the server, fix the dead owner link, gate the club editor

### DIFF
--- a/frontend/src/services/clubService.ts
+++ b/frontend/src/services/clubService.ts
@@ -1,5 +1,5 @@
 import type { Club, ClubMember, ClubMembershipRequest } from '../types/club'
-import { buildApiUrl } from './httpClient'
+import { buildApiUrl, notifyIfUnauthorized } from './httpClient'
 
 type FetchClubsOptions = {
   force?: boolean
@@ -30,6 +30,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     credentials: init?.credentials ?? 'include',
     headers})
   if (!response.ok) {
+    notifyIfUnauthorized(response)
     const message = await response.text()
     throw new Error(message || `Request failed with status ${response.status}`)
   }

--- a/frontend/src/services/httpClient.ts
+++ b/frontend/src/services/httpClient.ts
@@ -31,3 +31,31 @@ export const buildApiUrl = (path: string) => {
 }
 
 export const getApiBaseUrl = () => apiBaseUrl
+
+// A 401 from any data endpoint means the session died while the tab was open. Without a shared
+// place to say so, each service turned it into a plain Error and the auth store went on
+// reporting the user as signed in, so the router guards kept letting them into pages where
+// every request then failed the same way. Services report it here; the auth store is what
+// listens and clears itself (frontend/src/stores/auth.ts).
+type UnauthorizedHandler = () => void
+
+let unauthorizedHandler: UnauthorizedHandler | null = null
+
+export const setUnauthorizedHandler = (handler: UnauthorizedHandler | null) => {
+  unauthorizedHandler = handler
+}
+
+export const reportUnauthorized = () => {
+  unauthorizedHandler?.()
+}
+
+/**
+ * Call for every non-ok API response. Returns the response so callers can keep their own
+ * error handling unchanged.
+ */
+export const notifyIfUnauthorized = (response: Response) => {
+  if (response.status === 401) {
+    reportUnauthorized()
+  }
+  return response
+}

--- a/frontend/src/services/userService.ts
+++ b/frontend/src/services/userService.ts
@@ -1,11 +1,12 @@
 import type { Club, ClubMembershipRequest } from '../types/club'
-import { buildApiUrl } from './httpClient'
+import { buildApiUrl, notifyIfUnauthorized } from './httpClient'
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const url = buildApiUrl(path)
   const headers = new Headers(init?.headers as HeadersInit | undefined)
   if (!headers.has('Content-Type')) headers.set('Content-Type', 'application/json')
   const response = await fetch(url, { ...init, credentials: 'include', headers })
   if (!response.ok) {
+    notifyIfUnauthorized(response)
     const message = await response.text()
     throw new Error(message || `Request failed with status ${response.status}`)
   }
@@ -36,6 +37,7 @@ export const updateGraduationYear = async (graduationYear: number): Promise<void
   )
 
   if (!response.ok) {
+    notifyIfUnauthorized(response)
     throw new Error(await readErrorMessage(response))
   }
 }

--- a/frontend/src/stores/auth.spec.ts
+++ b/frontend/src/stores/auth.spec.ts
@@ -17,12 +17,14 @@ vi.mock('../utils/authRedirect', async (importOriginal) => {
   }
 })
 
-import { fetchAuthenticatedUser, fetchAuthProviders } from '../services/authService'
+import { fetchAuthenticatedUser, fetchAuthProviders, logout as apiLogout } from '../services/authService'
+import { reportUnauthorized } from '../services/httpClient'
 import { savePendingAuthRedirect } from '../utils/authRedirect'
 import { useAuthStore } from './auth'
 
 const fetchAuthenticatedUserMock = vi.mocked(fetchAuthenticatedUser)
 const fetchAuthProvidersMock = vi.mocked(fetchAuthProviders)
+const apiLogoutMock = vi.mocked(apiLogout)
 const savePendingAuthRedirectMock = vi.mocked(savePendingAuthRedirect)
 
 const knownUser: AuthUser = {
@@ -97,6 +99,61 @@ describe('refreshUser', () => {
     expect(fetchAuthenticatedUserMock).toHaveBeenCalledTimes(2)
     expect(store.currentUser?.id).toBe('user-1')
     expect(store.userError).toBeNull()
+  })
+
+  // fetchAuthenticatedUser returns null for a real 401 and only throws for a network error or
+  // a 5xx. Collapsing both into "signed out" meant one blip on cold load kicked a student with
+  // a perfectly valid session off whatever page they were on.
+  it('keeps the signed-in user when the session check fails for a transient reason', async () => {
+    fetchAuthenticatedUserMock.mockResolvedValueOnce(knownUser)
+    const store = useAuthStore()
+    await store.refreshUser()
+
+    fetchAuthenticatedUserMock.mockRejectedValueOnce(new Error('Failed to fetch'))
+    await store.refreshUser()
+
+    expect(store.currentUser?.id).toBe('user-1')
+    expect(store.userError).toBe('Failed to fetch')
+  })
+
+  it('still clears the user when the server actually reports no session', async () => {
+    fetchAuthenticatedUserMock.mockResolvedValueOnce(knownUser)
+    const store = useAuthStore()
+    await store.refreshUser()
+
+    fetchAuthenticatedUserMock.mockResolvedValueOnce(null)
+    await store.refreshUser()
+
+    expect(store.currentUser).toBeNull()
+  })
+})
+
+describe('logout', () => {
+  it('clears the local session even when the server call fails, without rejecting', async () => {
+    fetchAuthenticatedUserMock.mockResolvedValueOnce(knownUser)
+    const store = useAuthStore()
+    await store.refreshUser()
+
+    apiLogoutMock.mockRejectedValueOnce(new Error('401 Unauthorized'))
+    await expect(store.logout()).resolves.toBeUndefined()
+
+    expect(store.currentUser).toBeNull()
+  })
+})
+
+describe('unauthorized responses from other endpoints', () => {
+  // Any data endpoint answering 401 means this session is gone. Without this the store went on
+  // reporting the user as signed in, so the router guards kept letting them into pages where
+  // every request then failed with a raw server error body.
+  it('clears the signed-in user', async () => {
+    fetchAuthenticatedUserMock.mockResolvedValueOnce(knownUser)
+    const store = useAuthStore()
+    await store.refreshUser()
+
+    reportUnauthorized()
+
+    expect(store.currentUser).toBeNull()
+    expect(store.isAuthenticated).toBe(false)
   })
 })
 

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -7,7 +7,7 @@ import {
   fetchAuthenticatedUser,
   logout as apiLogout,
 } from '../services/authService'
-import { buildApiUrl } from '../services/httpClient'
+import { buildApiUrl, setUnauthorizedHandler } from '../services/httpClient'
 import { localAvatar, userAvatar } from '../utils/avatarImages'
 import { normalizeAuthRedirect, savePendingAuthRedirect } from '../utils/authRedirect'
 
@@ -65,9 +65,13 @@ export const useAuthStore = defineStore('auth', () => {
       currentUser.value = normalizeUser(fetched)
       userError.value = null
     } catch (error) {
+      // fetchAuthenticatedUser already separates the two cases: it returns null for a real 401
+      // and only throws for a network error or a 5xx. Treating a throw as "signed out" meant one
+      // failed request on cold load (offline blip, backend restart, proxy 502) logged the
+      // student out of a still-valid session and bounced them off the page they were on, so the
+      // previous user is deliberately kept here.
       userError.value =
         error instanceof Error ? error.message : 'Unable to verify session'
-      currentUser.value = null
     } finally {
       userLoading.value = false
       hasCheckedSession.value = true
@@ -129,9 +133,30 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   const logout = async () => {
-    await apiLogout()
-    currentUser.value = null
+    try {
+      await apiLogout()
+      userError.value = null
+    } catch (error) {
+      // Neither caller catches (App.vue's header button, ProfileView's), so rethrowing here
+      // only produced an unhandled rejection. The local session is cleared either way below;
+      // record why the server call failed instead of crashing the handler.
+      userError.value =
+        error instanceof Error ? error.message : 'Sign-out request failed'
+    } finally {
+      // Signing out must always work client-side. Clearing only on success meant a 401 on an
+      // already-dead session, or any network blip, left the app showing the user as signed in
+      // as well.
+      currentUser.value = null
+    }
   }
+
+  // A 401 from any other endpoint means this session is gone; drop the user so the router
+  // guards and the header stop treating it as live. Registered once, when the store is first
+  // used, since the services have no access to the store themselves.
+  setUnauthorizedHandler(() => {
+    currentUser.value = null
+    hasCheckedSession.value = true
+  })
 
   return {
     currentUser,

--- a/frontend/src/views/ClubAdminView.spec.ts
+++ b/frontend/src/views/ClubAdminView.spec.ts
@@ -61,7 +61,10 @@ const buildClub = (overrides: Partial<Club> = {}): Club => ({
   imageUrl: null,
   memberCount: 42,
   achievements: [],
-  canManage: false,
+  // The default fixture is what a *manager* of this club sees, because that is the only viewer
+  // the editor renders for now (see the canManageClub gate in the view); a visitor without
+  // manage rights gets the read-only notice instead, covered by its own test below.
+  canManage: true,
   ...overrides,
 })
 
@@ -110,6 +113,36 @@ describe('ClubAdminView member count', () => {
     expect(updateClubMock).toHaveBeenCalledTimes(1)
     const [, payload] = updateClubMock.mock.calls[0]!
     expect(payload).not.toHaveProperty('memberCount')
+  })
+
+  // /clubs/:id/admin is only guarded by requiresAuth and fetchClubById is a public endpoint, so
+  // the editor used to render for any signed-in visitor and only fail once they pressed Save.
+  // The backend was always enforced; this is about not inviting the edit in the first place.
+  it('renders a read-only notice instead of the editor for someone who does not manage the club', async () => {
+    const club = buildClub({ canManage: false })
+
+    const wrapper = await mountView(club)
+
+    expect(wrapper.find('form.admin-form').exists()).toBe(false)
+    expect(wrapper.find('input[type="file"]').exists()).toBe(false)
+    expect(wrapper.text()).toContain('You do not manage Chess Club')
+  })
+
+  it('still renders the editor for a platform owner who is not a club member', async () => {
+    const club = buildClub({ canManage: false })
+    const authStore = useAuthStore()
+    authStore.currentUser = {
+      id: '1',
+      email: 'owner@example.com',
+      displayName: 'Owner',
+      avatarUrl: '',
+      provider: 'google',
+      isOwner: true,
+    }
+
+    const wrapper = await mountView(club)
+
+    expect(wrapper.find('form.admin-form').exists()).toBe(true)
   })
 
   it('refreshes the club snapshot and invalidates list caches after assigning a president', async () => {

--- a/frontend/src/views/ClubAdminView.vue
+++ b/frontend/src/views/ClubAdminView.vue
@@ -154,6 +154,11 @@ const hydrateForm = (data: Club) => {
 const authStore = useAuthStore()
 const { currentUser } = storeToRefs(authStore)
 const canManageMembers = computed(() => Boolean(club.value?.canManage) || Boolean(currentUser.value?.isOwner))
+// Same rule the backend enforces on every write here (ClubController#requireManageAccess and
+// ClubImageController). The route itself is only guarded by requiresAuth and fetchClubById is a
+// public endpoint, so without this the whole editor -- form, image upload, Save -- rendered for
+// any signed-in visitor and only failed once they pressed Save.
+const canManageClub = canManageMembers
 const presidents = computed(() => members.value.filter((m) => m.roleName?.toLowerCase() === 'president'))
 
 const loadClub = async (id: string) => {
@@ -348,7 +353,7 @@ watch(
   <section class="club-admin page-shell">
     <div class="admin-toolbar">
       <BackButton>← Back to clubs</BackButton>
-      <div class="toolbar-actions" v-if="!loading">
+      <div class="toolbar-actions" v-if="!loading && canManageClub">
         <RouterLink
           v-if="club"
           :to="`/clubs/${club.id}`"
@@ -367,6 +372,10 @@ watch(
     <div v-else-if="loadError" class="status-card error">
       <p>{{ loadError }}</p>
       <button type="button" class="ghost-btn" @click="retryLoad" :disabled="loading">Try again</button>
+    </div>
+    <div v-else-if="club && !canManageClub" class="status-card muted">
+      <p>You do not manage {{ club.name }}, so its settings are not editable from your account.</p>
+      <RouterLink :to="`/clubs/${club.id}`" class="ghost-btn">View the club page</RouterLink>
     </div>
     <template v-else-if="club">
       <header class="admin-hero">

--- a/frontend/src/views/ClubAdminView.vue
+++ b/frontend/src/views/ClubAdminView.vue
@@ -153,12 +153,12 @@ const hydrateForm = (data: Club) => {
 
 const authStore = useAuthStore()
 const { currentUser } = storeToRefs(authStore)
-const canManageMembers = computed(() => Boolean(club.value?.canManage) || Boolean(currentUser.value?.isOwner))
-// Same rule the backend enforces on every write here (ClubController#requireManageAccess and
-// ClubImageController). The route itself is only guarded by requiresAuth and fetchClubById is a
-// public endpoint, so without this the whole editor -- form, image upload, Save -- rendered for
-// any signed-in visitor and only failed once they pressed Save.
-const canManageClub = canManageMembers
+// Manage rights for this club: the same rule the backend enforces on every write from this page
+// (ClubController#requireManageAccess, ClubImageController), covering both the roster section
+// and the editor itself. The route is only guarded by requiresAuth and fetchClubById is a public
+// endpoint, so without gating on this the whole editor -- form, image upload, Save -- rendered
+// for any signed-in visitor and only failed once they pressed Save.
+const canManageClub = computed(() => Boolean(club.value?.canManage) || Boolean(currentUser.value?.isOwner))
 const presidents = computed(() => members.value.filter((m) => m.roleName?.toLowerCase() === 'president'))
 
 const loadClub = async (id: string) => {
@@ -170,7 +170,7 @@ const loadClub = async (id: string) => {
     const response = await fetchClubById(id)
     club.value = response
     hydrateForm(response)
-    if (canManageMembers.value) {
+    if (canManageClub.value) {
       void loadMembers(id)
     } else {
       members.value = []
@@ -187,7 +187,7 @@ const loadClub = async (id: string) => {
 }
 
 const loadMembers = async (id: string) => {
-  if (!id || !canManageMembers.value) {
+  if (!id || !canManageClub.value) {
     membersLoading.value = false
     members.value = []
     return
@@ -205,13 +205,13 @@ const loadMembers = async (id: string) => {
 }
 
 const refreshMembers = async () => {
-  if (club.value && canManageMembers.value) {
+  if (club.value && canManageClub.value) {
     await loadMembers(String(club.value.id))
   }
 }
 
 const handleMemberRoleChange = async (member: ClubMember, event: Event) => {
-  if (!club.value || !canManageMembers.value || roleSavingMemberId.value) {
+  if (!club.value || !canManageClub.value || roleSavingMemberId.value) {
     return
   }
   const select = event.target as HTMLSelectElement
@@ -338,7 +338,7 @@ watch(
 )
 
 watch(
-  canManageMembers,
+  canManageClub,
   (allowed) => {
     if (allowed && club.value) {
       void loadMembers(String(club.value.id))
@@ -496,19 +496,19 @@ watch(
           </div>
           <div class="member-panel__actions">
             <RouterLink
-              v-if="club && canManageMembers"
+              v-if="club && canManageClub"
               :to="`/clubs/${club.id}/admin/pending`"
               class="ghost-btn"
             >
               Review pending requests
             </RouterLink>
-            <button type="button" class="ghost-btn" @click="refreshMembers" :disabled="membersLoading || !canManageMembers">
+            <button type="button" class="ghost-btn" @click="refreshMembers" :disabled="membersLoading || !canManageClub">
               {{ membersLoading ? 'Refreshing…' : 'Refresh roster' }}
             </button>
           </div>
         </div>
 
-        <p v-if="!canManageMembers" class="member-hint">
+        <p v-if="!canManageClub" class="member-hint">
           Only club leaders or site owners can view the roster.
         </p>
 

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -198,7 +198,7 @@ const handleGraduationYearSave = async () => {
             <RouterLink to="/" class="btn primary">Browse clubs</RouterLink>
             <RouterLink
               v-if="currentUser?.isOwner"
-              to="/platform/admin"
+              to="/admin"
               class="btn ghost"
             >Platform admin</RouterLink>
             <button type="button" class="btn ghost" @click="handleLogout">Sign out</button>


### PR DESCRIPTION
Closes #106. Closes #107.

## Auth state (#106)

- **Failed logout left the user signed in.** `logout()` cleared `currentUser` only after a successful call, so a 401 on an already-dead session or any network blip skipped the reset -- and neither caller catches, so it also became an unhandled rejection. State is cleared in a `finally` now, and the failure is recorded rather than thrown.
- **A transient `/api/auth/me` failure signed the user out.** `fetchAuthenticatedUser` already returns `null` for a real 401 and throws only for a network error or 5xx; the store collapsed both into "signed out", so one blip on cold load bounced a student with a valid session off the page they were on. A thrown error now leaves the previous user in place.
- **A 401 from a data endpoint never reset auth state.** `httpClient` gains a small unauthorized hook that `clubService` and `userService` report to and the auth store listens on (the services have no access to the store). A session that dies with a tab open now clears client-side instead of leaving the guards admitting a user whose every request fails.

## Frontend surfaces (#107)

- `ProfileView`'s owner shortcut pointed at `/platform/admin`, which is not a route -- the dashboard is `/admin`, which `App.vue`'s own nav already uses -- so it landed on the not-found view.
- `ClubAdminView` rendered the entire editor for any signed-in visitor: the route is only guarded by `requiresAuth` and `fetchClubById` is public, so a student could fill in the whole form and only find out on Save. **The backend was always enforced**, so this is a trust/UX fix, not a privilege fix: a viewer without manage rights gets a read-only notice, and a platform owner still gets the editor.

## Verification

- `auth.spec.ts`: transient failure keeps the user, a real 401 still clears it, logout clears without rejecting, and a reported 401 from another endpoint clears the store.
- `ClubAdminView.spec.ts`: non-manager gets the notice and no form or file input; platform owner still gets the form. The default fixture now carries `canManage: true`, since a manager is the only viewer that editor renders for.
- Frontend suite: 263 tests pass; `type-check` and `build` clean.