### PR TITLE
Configurable sign-in restrictions, unrestricted by default

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -27,6 +27,18 @@ GOOGLE_CLIENT_SECRET=replace-with-google-client-secret
 # Comma-separated emails granted platform-owner role on first login.
 APP_OWNER_EMAILS=you@example.com
 
+# === Who may sign in ===
+
+# Restrict sign-in to one or more email domains, comma-separated. Empty (the
+# default) means any account the provider authenticates may sign in, which is
+# what a fresh copy of this repo should do. A school running its own site
+# usually wants its Google Workspace domain here.
+# APP_ALLOWED_EMAIL_DOMAINS=students.example.edu,example.edu
+
+# Require the provider to report the email address as verified. Off by default
+# so a provider that does not send the claim cannot lock everyone out.
+# APP_REQUIRE_VERIFIED_EMAIL=false
+
 # === Optional ===
 
 # Frontend origin used for CORS and OAuth callback.

--- a/backend/src/main/java/com/example/demo/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/demo/auth/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 import java.util.Set;
 
 import com.example.demo.security.CustomOAuth2UserService;
+import com.example.demo.security.LoginEligibilityPolicy;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
@@ -17,6 +18,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.web.SecurityFilterChain;
@@ -98,7 +101,9 @@ public class SecurityConfig {
                         resolveLoginRedirectUri(), consumeSessionRedirectTarget(request))))
                 .failureHandler((request, response, exception) ->
                     response.sendRedirect(PostLoginRedirectResolver.buildRedirectUri(
-                        resolveLoginRedirectUri(), consumeSessionRedirectTarget(request), "oauth2_login_failed"))))
+                        resolveLoginRedirectUri(),
+                        consumeSessionRedirectTarget(request),
+                        resolveLoginFailureCode(exception)))))
             .logout(logout -> logout
                 // Explicit POST-only matcher: logoutUrl(String) alone degrades to matching ANY
                 // HTTP method once CSRF protection is off, which let a plain
@@ -301,6 +306,23 @@ public class SecurityConfig {
     private String resolveLoginRedirectUri() {
         String redirect = securityProperties.getPostLoginRedirectUri();
         return StringUtils.hasText(redirect) ? redirect : "/";
+    }
+
+    /**
+     * The {@code error} code handed to the frontend after a failed login. Only this project's
+     * own eligibility codes are passed through, so a student turned away by the school's
+     * sign-in restrictions can be told why; anything else stays the generic code, since a
+     * provider-supplied error string is not ours to echo into a redirect.
+     */
+    private static String resolveLoginFailureCode(AuthenticationException exception) {
+        if (exception instanceof OAuth2AuthenticationException oauth2Exception) {
+            String errorCode = oauth2Exception.getError().getErrorCode();
+            if (LoginEligibilityPolicy.EMAIL_DOMAIN_NOT_ALLOWED.equals(errorCode)
+                || LoginEligibilityPolicy.EMAIL_NOT_VERIFIED.equals(errorCode)) {
+                return errorCode;
+            }
+        }
+        return "oauth2_login_failed";
     }
 
     private String resolveAuthorizationRequestBaseUri() {

--- a/backend/src/main/java/com/example/demo/auth/config/SecurityProperties.java
+++ b/backend/src/main/java/com/example/demo/auth/config/SecurityProperties.java
@@ -14,6 +14,7 @@ public class SecurityProperties {
     private List<String> ownerEmails = new ArrayList<>();
     private String authorizationRequestBaseUri;
     private Csrf csrf = new Csrf();
+    private Login login = new Login();
 
     public String getFrontendOrigin() {
         return frontendOrigin;
@@ -68,6 +69,14 @@ public class SecurityProperties {
         this.csrf = csrf == null ? new Csrf() : csrf;
     }
 
+    public Login getLogin() {
+        return login;
+    }
+
+    public void setLogin(Login login) {
+        this.login = login == null ? new Login() : login;
+    }
+
     /**
      * Server-side CSRF token enforcement (app.security.csrf.enabled), separate from and in
      * addition to the SameSite=Lax session cookie. Defaults to false so this can ship without
@@ -83,6 +92,44 @@ public class SecurityProperties {
 
         public void setEnabled(boolean enabled) {
             this.enabled = enabled;
+        }
+    }
+
+    /**
+     * Who is allowed to sign in at all (app.security.login.*). Both restrictions are off by
+     * default: this repo is meant to be copied by any school, and a default that silently
+     * rejected accounts would be a confusing first run. A school that wants its site limited to
+     * its own Google Workspace turns them on in configuration, with no code change.
+     */
+    public static class Login {
+
+        /**
+         * Email domains allowed to sign in, e.g. {@code students.example.edu}. Empty (the
+         * default) means any account the OAuth provider authenticates may sign in.
+         */
+        private List<String> allowedEmailDomains = new ArrayList<>();
+
+        /**
+         * Whether the provider must report the email address as verified. Off by default so a
+         * provider that does not send the claim at all cannot lock everyone out.
+         */
+        private boolean requireVerifiedEmail = false;
+
+        public List<String> getAllowedEmailDomains() {
+            return allowedEmailDomains;
+        }
+
+        public void setAllowedEmailDomains(List<String> allowedEmailDomains) {
+            this.allowedEmailDomains =
+                allowedEmailDomains == null ? new ArrayList<>() : new ArrayList<>(allowedEmailDomains);
+        }
+
+        public boolean isRequireVerifiedEmail() {
+            return requireVerifiedEmail;
+        }
+
+        public void setRequireVerifiedEmail(boolean requireVerifiedEmail) {
+            this.requireVerifiedEmail = requireVerifiedEmail;
         }
     }
 }

--- a/backend/src/main/java/com/example/demo/security/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/example/demo/security/CustomOAuth2UserService.java
@@ -18,9 +18,12 @@ import com.example.demo.auth.service.OAuthUserService;
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final OAuthUserService oAuthUserService;
+    private final LoginEligibilityPolicy loginEligibilityPolicy;
 
-    public CustomOAuth2UserService(OAuthUserService oAuthUserService) {
+    public CustomOAuth2UserService(OAuthUserService oAuthUserService,
+                                   LoginEligibilityPolicy loginEligibilityPolicy) {
         this.oAuthUserService = oAuthUserService;
+        this.loginEligibilityPolicy = loginEligibilityPolicy;
     }
 
     @Override
@@ -30,6 +33,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         Map<String, Object> attributes = new HashMap<>(oauth2User.getAttributes());
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         normalizeAttributes(attributes, registrationId);
+        // Before recordLogin: a rejected account must not leave an oauth_users row behind, since
+        // that row is what every later lookup (and the owner-email comparison) keys on.
+        loginEligibilityPolicy.verifyEligible(attributes);
         oAuthUserService.recordLogin(registrationId, attributes);
 
         String userNameAttribute = userRequest.getClientRegistration()

--- a/backend/src/main/java/com/example/demo/security/LoginEligibilityPolicy.java
+++ b/backend/src/main/java/com/example/demo/security/LoginEligibilityPolicy.java
@@ -22,6 +22,11 @@ import com.example.demo.auth.config.SecurityProperties;
  * <p>The email address matters beyond identity here: it is the key
  * {@link AuthenticatedUserResolver#isPlatformOwner} compares against {@code
  * app.security.owner-emails}, and the key {@code oauth_users} rows are looked up by.
+ *
+ * <p>This runs when an account signs in, not on every request, so turning a restriction on does
+ * not by itself evict an existing session (they last 7 days). Sessions live in this
+ * application's own memory, so the restart that applies the new configuration also drops them;
+ * see docs/DEPLOYMENT.md.
  */
 @Component
 public class LoginEligibilityPolicy {

--- a/backend/src/main/java/com/example/demo/security/LoginEligibilityPolicy.java
+++ b/backend/src/main/java/com/example/demo/security/LoginEligibilityPolicy.java
@@ -1,0 +1,97 @@
+package com.example.demo.security;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.example.demo.auth.config.SecurityProperties;
+
+/**
+ * Decides whether an authenticated OAuth2 account may sign in to this school's site at all.
+ *
+ * <p>Both restrictions are opt-in and off by default, which is deliberate: this repo is meant to
+ * be copied by other schools, so an out-of-the-box deployment must work with any Google account,
+ * and a school that wants its site limited to its own Google Workspace turns the restriction on
+ * in configuration rather than editing code. When nothing is configured this class is a no-op.
+ *
+ * <p>The email address matters beyond identity here: it is the key
+ * {@link AuthenticatedUserResolver#isPlatformOwner} compares against {@code
+ * app.security.owner-emails}, and the key {@code oauth_users} rows are looked up by.
+ */
+@Component
+public class LoginEligibilityPolicy {
+
+    /** Error codes echoed to the frontend as {@code ?error=...} on the post-login redirect. */
+    public static final String EMAIL_DOMAIN_NOT_ALLOWED = "email_domain_not_allowed";
+    public static final String EMAIL_NOT_VERIFIED = "email_not_verified";
+
+    private final SecurityProperties securityProperties;
+
+    public LoginEligibilityPolicy(SecurityProperties securityProperties) {
+        this.securityProperties = securityProperties;
+    }
+
+    /**
+     * @throws OAuth2AuthenticationException if this account may not sign in; the exception's
+     *                                       error code is one of the constants above, which the
+     *                                       OAuth2 failure handler passes to the frontend
+     */
+    public void verifyEligible(Map<String, Object> attributes) {
+        SecurityProperties.Login login = securityProperties.getLogin();
+
+        if (login.isRequireVerifiedEmail() && !isEmailVerified(attributes)) {
+            throw reject(EMAIL_NOT_VERIFIED,
+                "This account's email address is not verified with its provider.");
+        }
+
+        List<String> allowedDomains = login.getAllowedEmailDomains();
+        if (allowedDomains.isEmpty()) {
+            return;
+        }
+        if (!isDomainAllowed(emailOf(attributes), allowedDomains)) {
+            throw reject(EMAIL_DOMAIN_NOT_ALLOWED,
+                "This site is limited to accounts from a specific email domain.");
+        }
+    }
+
+    private static boolean isEmailVerified(Map<String, Object> attributes) {
+        Object verified = attributes == null ? null : attributes.get("email_verified");
+        if (verified instanceof Boolean flag) {
+            return flag;
+        }
+        // Some providers send the claim as a string; anything else (including absent) is "no".
+        return verified != null && Boolean.parseBoolean(verified.toString());
+    }
+
+    private static String emailOf(Map<String, Object> attributes) {
+        Object email = attributes == null ? null : attributes.get("email");
+        return email == null ? null : email.toString();
+    }
+
+    private static boolean isDomainAllowed(String email, List<String> allowedDomains) {
+        // An account with no email at all can never satisfy a domain restriction: the whole
+        // authorization model downstream is keyed on that address.
+        if (!StringUtils.hasText(email)) {
+            return false;
+        }
+        int at = email.lastIndexOf('@');
+        if (at < 0 || at == email.length() - 1) {
+            return false;
+        }
+        String domain = email.substring(at + 1).trim().toLowerCase(Locale.ROOT);
+        return allowedDomains.stream()
+            .filter(StringUtils::hasText)
+            // A leading "@" or stray whitespace in configuration is a natural thing to write.
+            .map(allowed -> allowed.trim().toLowerCase(Locale.ROOT).replaceFirst("^@", ""))
+            .anyMatch(domain::equals);
+    }
+
+    private static OAuth2AuthenticationException reject(String errorCode, String description) {
+        return new OAuth2AuthenticationException(new OAuth2Error(errorCode, description, null), description);
+    }
+}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -48,6 +48,13 @@ app:
       # before that frontend change ships would 403 every write request. Flip to true
       # once the frontend is updated.
       enabled: ${APP_CSRF_ENABLED:false}
+    login:
+      # Who may sign in at all. Both restrictions are off by default: other schools copy this
+      # repo, so a fresh deployment has to work with any Google account, and a school that
+      # wants its site limited to its own Workspace turns them on here without touching code.
+      # Comma-separated, e.g. APP_ALLOWED_EMAIL_DOMAINS=students.example.edu,example.edu
+      allowed-email-domains: ${APP_ALLOWED_EMAIL_DOMAINS:}
+      require-verified-email: ${APP_REQUIRE_VERIFIED_EMAIL:false}
   upload:
     dir: ${APP_UPLOAD_DIR:uploads}
   avatar:

--- a/backend/src/test/java/com/example/demo/security/LoginEligibilityPolicyTest.java
+++ b/backend/src/test/java/com/example/demo/security/LoginEligibilityPolicyTest.java
@@ -1,0 +1,99 @@
+package com.example.demo.security;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+
+import com.example.demo.auth.config.SecurityProperties;
+
+class LoginEligibilityPolicyTest {
+
+    private static LoginEligibilityPolicy policy(List<String> allowedDomains, boolean requireVerifiedEmail) {
+        SecurityProperties properties = new SecurityProperties();
+        properties.getLogin().setAllowedEmailDomains(allowedDomains);
+        properties.getLogin().setRequireVerifiedEmail(requireVerifiedEmail);
+        return new LoginEligibilityPolicy(properties);
+    }
+
+    private static Map<String, Object> account(String email, Object emailVerified) {
+        return Map.of("email", email, "email_verified", emailVerified);
+    }
+
+    // The default has to stay open: other schools copy this repo, and a fresh deployment that
+    // silently rejected every account would be a terrible first run.
+    @Test
+    void allowsAnyAccountWhenNothingIsConfigured() {
+        assertThatCode(() -> policy(List.of(), false).verifyEligible(account("anyone@gmail.com", false)))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void allowsAnAccountFromAConfiguredDomain() {
+        assertThatCode(() -> policy(List.of("students.example.edu"), false)
+            .verifyEligible(account("ada@students.example.edu", true)))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsAnAccountFromAnotherDomain() {
+        assertThatThrownBy(() -> policy(List.of("students.example.edu"), false)
+            .verifyEligible(account("stranger@gmail.com", true)))
+            .isInstanceOf(OAuth2AuthenticationException.class)
+            .hasMessageContaining("email domain");
+    }
+
+    @Test
+    void domainMatchingIgnoresCaseAndAStrayAtSignOrWhitespaceInConfiguration() {
+        LoginEligibilityPolicy policy = policy(List.of(" @Students.Example.EDU "), false);
+
+        assertThatCode(() -> policy.verifyEligible(account("ADA@students.example.edu", true)))
+            .doesNotThrowAnyException();
+    }
+
+    // Only the domain after the last @ counts; a local part that embeds another domain must not
+    // be able to impersonate one.
+    @Test
+    void rejectsAnAddressThatOnlyLooksLikeTheAllowedDomain() {
+        LoginEligibilityPolicy policy = policy(List.of("students.example.edu"), false);
+
+        assertThatThrownBy(() -> policy.verifyEligible(account("ada@students.example.edu.evil.com", true)))
+            .isInstanceOf(OAuth2AuthenticationException.class);
+        assertThatThrownBy(() -> policy.verifyEligible(account("ada@students.example.edu@gmail.com", true)))
+            .isInstanceOf(OAuth2AuthenticationException.class);
+    }
+
+    // Every downstream authorization decision -- owner-email comparison, oauth_users lookup --
+    // is keyed on the email address, so an account without one cannot satisfy a domain rule.
+    @Test
+    void rejectsAnAccountWithNoEmailWhenADomainIsRequired() {
+        assertThatThrownBy(() -> policy(List.of("students.example.edu"), false).verifyEligible(Map.of()))
+            .isInstanceOf(OAuth2AuthenticationException.class);
+    }
+
+    @Test
+    void requiresAVerifiedEmailOnlyWhenConfiguredTo() {
+        assertThatCode(() -> policy(List.of(), false).verifyEligible(account("ada@gmail.com", false)))
+            .doesNotThrowAnyException();
+
+        assertThatThrownBy(() -> policy(List.of(), true).verifyEligible(account("ada@gmail.com", false)))
+            .isInstanceOf(OAuth2AuthenticationException.class)
+            .hasMessageContaining("not verified");
+    }
+
+    @Test
+    void acceptsAVerifiedFlagSentAsAString() {
+        assertThatCode(() -> policy(List.of(), true).verifyEligible(account("ada@gmail.com", "true")))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void treatsAMissingVerifiedClaimAsNotVerifiedWhenTheCheckIsOn() {
+        assertThatThrownBy(() -> policy(List.of(), true).verifyEligible(Map.of("email", "ada@gmail.com")))
+            .isInstanceOf(OAuth2AuthenticationException.class);
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -33,6 +33,12 @@ The `dataHash` is a SHA-256 digest of (clubId|name|category|memberCount) for all
 
 All endpoints use session-based auth via Spring Security OAuth2. Include credentials (`credentials: 'include'`) in client requests.
 
+Who may sign in is configurable and unrestricted by default (`app.security.login.*`, see
+`docs/DEPLOYMENT.md`). When a school restricts sign-in to its own email domains, a rejected
+account never reaches the session or the `oauth_users` table: the OAuth2 callback redirects back
+to the frontend with `?error=email_domain_not_allowed` (or `email_not_verified`) instead of the
+generic `oauth2_login_failed`, so the sign-in page can say why rather than inviting a retry.
+
 ### GET /api/auth/providers
 List available OAuth providers.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -70,6 +70,29 @@ FRONTEND_ORIGIN=http://localhost:4173
 # APP_AUTHORIZATION_REQUEST_BASE_URI=/api/auth/authorize
 ```
 
+### Restricting who may sign in
+
+By default **any** account the OAuth provider authenticates may sign in, which is what a fresh
+copy of this repo should do. A school running its own site usually wants that limited to its
+own Google Workspace:
+
+```bash
+# Comma-separated; empty (the default) means no restriction
+APP_ALLOWED_EMAIL_DOMAINS=students.example.edu,example.edu
+
+# Optional: also require the provider to report the address as verified
+APP_REQUIRE_VERIFIED_EMAIL=true
+```
+
+Only the domain after the last `@` is compared, case-insensitively, so
+`ada@students.example.edu.evil.com` does not pass a `students.example.edu` restriction. A
+rejected sign-in never creates an `oauth_users` row, and the student is returned to the sign-in
+page with an explanation rather than a generic "try again".
+
+Note this is also the boundary `APP_OWNER_EMAILS` sits behind: platform-owner status is decided
+by comparing the signed-in email address, so restricting the domain restricts who can even
+attempt to hold that address.
+
 ### Production session cookie
 
 Set this on any HTTPS deployment:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -93,6 +93,13 @@ Note this is also the boundary `APP_OWNER_EMAILS` sits behind: platform-owner st
 by comparing the signed-in email address, so restricting the domain restricts who can even
 attempt to hold that address.
 
+The restriction is applied when an account signs in, not on every request, so it does not by
+itself evict someone who is already signed in — sessions last 7 days. In practice enabling it
+means restarting the backend, and sessions are held in the application's own memory (there is no
+external session store), so every existing session is dropped by that restart anyway. If you
+ever change this setting without a restart, expect existing sessions from a now-disallowed
+domain to survive until they expire.
+
 ### Production session cookie
 
 Set this on any HTTPS deployment:

--- a/frontend/src/views/AuthChoiceView.spec.ts
+++ b/frontend/src/views/AuthChoiceView.spec.ts
@@ -141,6 +141,36 @@ describe('AuthChoiceView', () => {
     expect(wrapper.text()).toContain('We could not complete your sign in. Please try again.')
   })
 
+  // A student turned away by the school's sign-in restriction is told why: "try again" is
+  // wrong advice for an account that can never be accepted.
+  it('explains a rejected email domain instead of inviting a retry', async () => {
+    fetchAuthProvidersMock.mockResolvedValue([googleProvider])
+    setRouteQuery({ error: 'email_domain_not_allowed' })
+    const wrapper = mount(AuthChoiceView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Please use your school account')
+    expect(wrapper.text()).not.toContain('Please try again')
+  })
+
+  it('explains an unverified email address', async () => {
+    fetchAuthProvidersMock.mockResolvedValue([googleProvider])
+    setRouteQuery({ error: 'email_not_verified' })
+    const wrapper = mount(AuthChoiceView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('not verified')
+  })
+
+  it('falls back to the generic message for an unknown error code', async () => {
+    fetchAuthProvidersMock.mockResolvedValue([googleProvider])
+    setRouteQuery({ error: 'something_new' })
+    const wrapper = mount(AuthChoiceView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('We could not complete your sign in. Please try again.')
+  })
+
   it('shows a providers-error banner when loading the provider list fails', async () => {
     fetchAuthProvidersMock.mockRejectedValue(new Error('Providers unavailable'))
     const wrapper = mount(AuthChoiceView)

--- a/frontend/src/views/AuthChoiceView.spec.ts
+++ b/frontend/src/views/AuthChoiceView.spec.ts
@@ -171,6 +171,18 @@ describe('AuthChoiceView', () => {
     expect(wrapper.text()).toContain('We could not complete your sign in. Please try again.')
   })
 
+  // The code comes straight from the URL, so a lookup that walks the prototype chain would
+  // render a function body here instead of the fallback message.
+  it('falls back to the generic message for a code that names an Object prototype member', async () => {
+    fetchAuthProvidersMock.mockResolvedValue([googleProvider])
+    setRouteQuery({ error: 'toString' })
+    const wrapper = mount(AuthChoiceView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('We could not complete your sign in. Please try again.')
+    expect(wrapper.text()).not.toContain('function')
+  })
+
   it('shows a providers-error banner when loading the provider list fails', async () => {
     fetchAuthProvidersMock.mockRejectedValue(new Error('Providers unavailable'))
     const wrapper = mount(AuthChoiceView)

--- a/frontend/src/views/AuthChoiceView.vue
+++ b/frontend/src/views/AuthChoiceView.vue
@@ -23,19 +23,26 @@ const intentLabel = computed(() =>
 // The backend's OAuth2 failure handler passes its own codes for the school's sign-in
 // restrictions, so a student turned away by them is told why instead of being invited to retry
 // something that can never succeed. Anything else stays the generic retry message.
-const authErrorMessages: Record<string, string> = {
-  email_domain_not_allowed:
+// A Map, not an object literal: the code comes straight from the URL, so a plain object would
+// resolve `?error=toString` (or constructor, valueOf, ...) through the prototype chain and
+// render a function body instead of falling back to the generic message.
+const authErrorMessages = new Map<string, string>([
+  [
+    'email_domain_not_allowed',
     'That account is not allowed to sign in here. Please use your school account.',
-  email_not_verified:
+  ],
+  [
+    'email_not_verified',
     'That account\u2019s email address is not verified with its provider, so it cannot be used to sign in.',
-}
+  ],
+])
 
 const routeError = computed(() => {
   const code = route.query.error
   if (typeof code !== 'string') {
     return ''
   }
-  return authErrorMessages[code] ?? 'We could not complete your sign in. Please try again.'
+  return authErrorMessages.get(code) ?? 'We could not complete your sign in. Please try again.'
 })
 
 const redirectTarget = computed(() => {

--- a/frontend/src/views/AuthChoiceView.vue
+++ b/frontend/src/views/AuthChoiceView.vue
@@ -20,10 +20,22 @@ const intentLabel = computed(() =>
   route.query.intent === 'register' ? 'Create account' : 'Sign in',
 )
 
+// The backend's OAuth2 failure handler passes its own codes for the school's sign-in
+// restrictions, so a student turned away by them is told why instead of being invited to retry
+// something that can never succeed. Anything else stays the generic retry message.
+const authErrorMessages: Record<string, string> = {
+  email_domain_not_allowed:
+    'That account is not allowed to sign in here. Please use your school account.',
+  email_not_verified:
+    'That account\u2019s email address is not verified with its provider, so it cannot be used to sign in.',
+}
+
 const routeError = computed(() => {
-  return typeof route.query.error === 'string'
-    ? 'We could not complete your sign in. Please try again.'
-    : ''
+  const code = route.query.error
+  if (typeof code !== 'string') {
+    return ''
+  }
+  return authErrorMessages[code] ?? 'We could not complete your sign in. Please try again.'
 })
 
 const redirectTarget = computed(() => {


### PR DESCRIPTION
Closes #100.

Nothing in the login path looked at who the account belonged to, so any Google account on the internet could sign in, appear in the user directory, and apply to clubs. That email address is also the key `AuthenticatedUserResolver.isPlatformOwner` compares against `app.security.owner-emails` and the key every `oauth_users` lookup uses.

## Change

Two opt-in restrictions under `app.security.login`, **both off by default**:

- `allowed-email-domains` (`APP_ALLOWED_EMAIL_DOMAINS`) -- only these domains may sign in; empty means no restriction.
- `require-verified-email` (`APP_REQUIRE_VERIFIED_EMAIL`) -- the provider must report the address as verified; off by default so a provider that does not send the claim cannot lock everyone out.

Default-open is deliberate, not a compromise: other schools are meant to copy this repo, so a fresh deployment has to work with any account, and a school that wants its own Workspace enforced turns it on in configuration without touching code.

Details worth noting:
- The check runs **before** `recordLogin`, so a rejected account leaves no `oauth_users` row behind.
- Only the domain after the last `@` is compared, case-insensitively, and a leading `@` or stray whitespace in configuration is tolerated. `ada@allowed.edu.evil.com` and `ada@allowed.edu@gmail.com` are both rejected against `allowed.edu`.
- The OAuth2 failure handler passes **this project's own** error codes to the frontend (and only those -- a provider-supplied error string is not ours to echo into a redirect), so the sign-in page explains why an account was turned away instead of inviting a retry that can never succeed.

## Verification

- New `LoginEligibilityPolicyTest` (9 cases): default allows anyone, allowed domain passes, other domain rejected, case/`@`/whitespace tolerance, look-alike domains rejected, no-email rejected when a domain is required, verified-email check only when configured, string `"true"` accepted, missing claim treated as unverified.
- `AuthChoiceView.spec.ts`: each code renders its own message, unknown codes fall back to the generic one.
- Backend 424 tests (only the 8 pre-existing Windows-only failures, #109); frontend 274 tests, `type-check` clean.

## For you to set

Nothing changes until you set `APP_ALLOWED_EMAIL_DOMAINS` on the server. Documented in `backend/.env.example` and `docs/DEPLOYMENT.md`.