### PR TITLE
Platform-owner archive/restore for clubs (status only, no visibility endpoint)

### DIFF
--- a/backend/src/main/java/com/example/demo/club/controller/ClubController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubController.java
@@ -143,7 +143,15 @@ public class ClubController {
         if (existing == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
         }
-        return archived ? clubService.archive(existing.getId()) : clubService.restore(existing.getId());
+        try {
+            return archived ? clubService.archive(existing.getId()) : clubService.restore(existing.getId());
+        } catch (IllegalArgumentException ex) {
+            // The club was resolved a moment ago, so this means it disappeared in between.
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage());
+        } catch (IllegalStateException ex) {
+            // Restoring something that was never archived (e.g. a pending club).
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ex.getMessage());
+        }
     }
 
     // ---- Members ----

--- a/backend/src/main/java/com/example/demo/club/controller/ClubController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubController.java
@@ -119,6 +119,33 @@ public class ClubController {
         clubService.delete(existing.getId());
     }
 
+    // ---- Archive / restore (platform owner only) ----
+    //
+    // The reversible alternative to DELETE: an archived club keeps its rows, its posts, and its
+    // roster, but drops out of every listing, search result, and calendar entry, and its detail
+    // endpoint answers 404 for anyone but a member, its president, or a platform owner
+    // (ClubVisibilityPolicy). Status is not editable through PUT, so this is the only way to
+    // change it -- a club president must not be able to publish or hide their own club.
+
+    @PostMapping("/{clubSlugOrId}/archive")
+    public Club archive(@PathVariable String clubSlugOrId, Authentication authentication) {
+        return setArchived(clubSlugOrId, authentication, true);
+    }
+
+    @DeleteMapping("/{clubSlugOrId}/archive")
+    public Club restore(@PathVariable String clubSlugOrId, Authentication authentication) {
+        return setArchived(clubSlugOrId, authentication, false);
+    }
+
+    private Club setArchived(String clubSlugOrId, Authentication authentication, boolean archived) {
+        requirePlatformOwner(authentication);
+        Club existing = resolveClub(clubSlugOrId, resolveViewerEmail(authentication));
+        if (existing == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
+        }
+        return archived ? clubService.archive(existing.getId()) : clubService.restore(existing.getId());
+    }
+
     // ---- Members ----
 
     @GetMapping("/{clubSlugOrId}/members")

--- a/backend/src/main/java/com/example/demo/club/mapper/ClubMapper.java
+++ b/backend/src/main/java/com/example/demo/club/mapper/ClubMapper.java
@@ -50,6 +50,12 @@ public interface ClubMapper {
     // club's imageUrl to another club's real /uploads/club-posts/<uuid>.jpg path via PUT.
     int updateImageUrl(@Param("id") Long id, @Param("imageUrl") String imageUrl);
 
+    /**
+     * Column-scoped status write for the platform-owner archive/restore endpoints. Status is
+     * deliberately not writable through {@link #update(Club)}, which a club president can reach.
+     */
+    int updateStatus(@Param("id") Long id, @Param("status") String status);
+
     int updateLocation(@Param("id") Long id, @Param("location") String location);
 
     int delete(@Param("id") Long id);

--- a/backend/src/main/java/com/example/demo/club/service/ClubService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubService.java
@@ -42,6 +42,12 @@ public class ClubService {
     // bounds how many OR groups one statement can grow.
     private static final int MAX_SEARCH_TOKENS = 10;
 
+    // The only two club statuses this application writes. 'active' is what every listing query
+    // filters on (ActiveClause) and what ClubVisibilityPolicy treats as publicly readable;
+    // 'archived' is the reversible alternative to deleting a club outright.
+    static final String ACTIVE_STATUS = "active";
+    static final String ARCHIVED_STATUS = "archived";
+
     // Exactly the fields a club manager may edit through PUT /api/clubs/{id}. Everything else
     // the update statement writes -- slug (the club's public URL), status, visibility,
     // approved_at, approved_by_oauth_user_id -- is carried over from the stored row instead:
@@ -235,6 +241,32 @@ public class ClubService {
         return clubMapper.findById(id);
     }
 
+    /**
+     * Archives a club: it disappears from every listing, search result, calendar entry, and the
+     * public detail endpoint, but keeps its rows so the decision is reversible with
+     * {@link #restore(Long)} -- unlike delete(), which removes the club outright.
+     *
+     * <p>Platform-owner only, enforced by the controller. Status is written through its own
+     * column-scoped statement rather than the general update(), which a club president can
+     * reach: a president must not be able to publish or hide their own club.
+     */
+    public Club archive(Long id) {
+        return setStatus(id, ARCHIVED_STATUS);
+    }
+
+    /** Puts an archived club back into the directory. */
+    public Club restore(Long id) {
+        return setStatus(id, ACTIVE_STATUS);
+    }
+
+    private Club setStatus(Long id, String status) {
+        if (clubMapper.findById(id) == null) {
+            throw new IllegalArgumentException("Club not found");
+        }
+        clubMapper.updateStatus(id, status);
+        return clubMapper.findById(id);
+    }
+
     public void delete(Long id) {
         clubMapper.delete(id);
     }
@@ -399,7 +431,7 @@ public class ClubService {
             club.setAchievements(Collections.emptyList());
         }
         if (!StringUtils.hasText(club.getStatus())) {
-            club.setStatus("active");
+            club.setStatus(ACTIVE_STATUS);
         }
         if (!StringUtils.hasText(club.getVisibility())) {
             club.setVisibility("public");

--- a/backend/src/main/java/com/example/demo/club/service/ClubService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubService.java
@@ -251,19 +251,26 @@ public class ClubService {
      * reach: a president must not be able to publish or hide their own club.
      */
     public Club archive(Long id) {
-        return setStatus(id, ARCHIVED_STATUS);
-    }
-
-    /** Puts an archived club back into the directory. */
-    public Club restore(Long id) {
-        return setStatus(id, ACTIVE_STATUS);
-    }
-
-    private Club setStatus(Long id, String status) {
-        if (clubMapper.findById(id) == null) {
+        if (clubMapper.updateStatus(id, ARCHIVED_STATUS) == 0) {
             throw new IllegalArgumentException("Club not found");
         }
-        clubMapper.updateStatus(id, status);
+        return clubMapper.findById(id);
+    }
+
+    /**
+     * Puts an archived club back into the directory. Deliberately refuses any other non-active
+     * status: no previous status is recorded anywhere, so activating (say) a pending club here
+     * would publish something that was never approved and lose that state for good.
+     */
+    public Club restore(Long id) {
+        Club existing = clubMapper.findById(id);
+        if (existing == null) {
+            throw new IllegalArgumentException("Club not found");
+        }
+        if (!ARCHIVED_STATUS.equalsIgnoreCase(existing.getStatus())) {
+            throw new IllegalStateException("Only an archived club can be restored");
+        }
+        clubMapper.updateStatus(id, ACTIVE_STATUS);
         return clubMapper.findById(id);
     }
 

--- a/backend/src/main/resources/mapper/ClubMapper.xml
+++ b/backend/src/main/resources/mapper/ClubMapper.xml
@@ -184,6 +184,17 @@
         WHERE id = #{id}
     </update>
 
+    <!-- Column-scoped on purpose, like updateImageUrl above: status decides whether a club is
+         listed and readable at all, so it is deliberately not writable through the general
+         update() statement a club president can reach. Only the platform-owner archive and
+         restore endpoints use this. -->
+    <update id="updateStatus">
+        UPDATE clubs
+        SET status = #{status},
+            updated_at = CURRENT_TIMESTAMP
+        WHERE id = #{id}
+    </update>
+
     <update id="updateLocation">
         UPDATE clubs
         SET location = #{location},

--- a/backend/src/test/java/com/example/demo/club/controller/ClubControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubControllerTest.java
@@ -243,6 +243,18 @@ class ClubControllerTest {
             .andExpect(status().isNotFound());
     }
 
+    @Test
+    void restoringAClubThatWasNeverArchivedIsAConflict() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(clubService.restore(1L))
+            .thenThrow(new IllegalStateException("Only an archived club can be restored"));
+
+        mockMvc.perform(delete("/api/clubs/1/archive").principal(oauthToken(OWNER_EMAIL)))
+            .andExpect(status().isConflict());
+    }
+
     private static Club nonActiveClub() {
         Club club = new Club();
         club.setId(7L);

--- a/backend/src/test/java/com/example/demo/club/controller/ClubControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubControllerTest.java
@@ -3,6 +3,7 @@ package com.example.demo.club.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -186,6 +187,60 @@ class ClubControllerTest {
 
         mockMvc.perform(get("/api/clubs/7"))
             .andExpect(status().isOk());
+    }
+
+    // ---- Archive / restore ----
+
+    @Test
+    void archivingAClubRequiresPlatformOwner() throws Exception {
+        mockMvc.perform(post("/api/clubs/1/archive").principal(oauthToken(STUDENT_EMAIL)))
+            .andExpect(status().isForbidden());
+    }
+
+    // A club president manages their own club, but publishing or hiding it is not theirs to do.
+    @Test
+    void archivingAClubIsNotAvailableToTheClubPresident() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setCanManage(true);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+
+        mockMvc.perform(post("/api/clubs/1/archive").principal(oauthToken(PRESIDENT_EMAIL)))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void archivingAClubSucceedsForPlatformOwner() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(clubService.archive(1L)).thenReturn(club);
+
+        mockMvc.perform(post("/api/clubs/1/archive").principal(oauthToken(OWNER_EMAIL)))
+            .andExpect(status().isOk());
+
+        verify(clubService).archive(1L);
+    }
+
+    @Test
+    void restoringAnArchivedClubSucceedsForPlatformOwner() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        when(clubService.resolveBySlugOrId(eq("1"), any())).thenReturn(club);
+        when(clubService.restore(1L)).thenReturn(club);
+
+        mockMvc.perform(delete("/api/clubs/1/archive").principal(oauthToken(OWNER_EMAIL)))
+            .andExpect(status().isOk());
+
+        verify(clubService).restore(1L);
+    }
+
+    @Test
+    void archivingAMissingClubIsANotFound() throws Exception {
+        when(clubService.resolveBySlugOrId(eq("999"), any())).thenReturn(null);
+
+        mockMvc.perform(post("/api/clubs/999/archive").principal(oauthToken(OWNER_EMAIL)))
+            .andExpect(status().isNotFound());
     }
 
     private static Club nonActiveClub() {

--- a/backend/src/test/java/com/example/demo/club/mapper/ClubMapperTest.java
+++ b/backend/src/test/java/com/example/demo/club/mapper/ClubMapperTest.java
@@ -179,6 +179,34 @@ class ClubMapperTest {
         assertThat(clubMapper.search(null, null, null, null, List.of(), 0, 10)).hasSize(1);
     }
 
+    // Archiving must be a status-only write and must take the club out of every listing, while
+    // leaving the row (and its posts and roster) intact so the decision stays reversible.
+    @Test
+    void updateStatusChangesOnlyTheStatusColumnAndHidesTheClubFromListings() {
+        insertSearchableClub();
+
+        clubMapper.updateStatus(4L, "archived");
+
+        assertThat(clubMapper.findAllPaginated(0, 10)).isEmpty();
+        assertThat(clubMapper.search(null, null, null, null, List.of("chess"), 0, 10)).isEmpty();
+        Club stored = clubMapper.findById(4L);
+        assertThat(stored).isNotNull();
+        assertThat(stored.getStatus()).isEqualTo("archived");
+        assertThat(stored.getName()).isEqualTo("Chess Club");
+        assertThat(stored.getDescription()).isEqualTo("Casual and competitive play");
+        assertThat(stored.getAdvisor()).isEqualTo("Ms. Lee");
+    }
+
+    @Test
+    void updateStatusCanPutAnArchivedClubBackIntoTheDirectory() {
+        insertSearchableClub();
+        clubMapper.updateStatus(4L, "archived");
+
+        clubMapper.updateStatus(4L, "active");
+
+        assertThat(clubMapper.findAllPaginated(0, 10)).hasSize(1);
+    }
+
     private void insertSearchableClub() {
         jdbcTemplate.update("""
             INSERT INTO clubs (id, name, category, description, location, advisor,

--- a/backend/src/test/java/com/example/demo/club/service/ClubServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubServiceTest.java
@@ -219,7 +219,7 @@ class ClubServiceTest {
     // so archiving has to go through the column-scoped statement instead.
     @Test
     void archiveWritesOnlyTheStatusColumnAndNeverTheGeneralUpdate() {
-        when(clubMapper.findById(7L)).thenReturn(storedClub());
+        when(clubMapper.updateStatus(7L, "archived")).thenReturn(1);
 
         clubService.archive(7L);
 
@@ -229,19 +229,34 @@ class ClubServiceTest {
 
     @Test
     void restorePutsTheClubBackIntoTheDirectory() {
-        when(clubMapper.findById(7L)).thenReturn(storedClub());
+        Club archived = storedClub();
+        archived.setStatus("archived");
+        when(clubMapper.findById(7L)).thenReturn(archived);
 
         clubService.restore(7L);
 
         verify(clubMapper).updateStatus(7L, "active");
     }
 
+    // No previous status is recorded anywhere, so activating something that was never archived
+    // would publish an unapproved club and lose its pending state for good.
+    @Test
+    void restoreRefusesAClubThatWasNeverArchived() {
+        Club pending = storedClub();
+        pending.setStatus("pending");
+        when(clubMapper.findById(7L)).thenReturn(pending);
+
+        assertThatThrownBy(() -> clubService.restore(7L))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("archived");
+
+        verify(clubMapper, never()).updateStatus(any(), any());
+    }
+
     @Test
     void archivingAMissingClubIsRejectedBeforeAnyWrite() {
         assertThatThrownBy(() -> clubService.archive(404L))
             .isInstanceOf(IllegalArgumentException.class);
-
-        verify(clubMapper, never()).updateStatus(any(), any());
     }
 
 

--- a/backend/src/test/java/com/example/demo/club/service/ClubServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubServiceTest.java
@@ -215,6 +215,36 @@ class ClubServiceTest {
 
     // ---- Membership ----
 
+    // status is deliberately not writable through update(), which a club president can reach,
+    // so archiving has to go through the column-scoped statement instead.
+    @Test
+    void archiveWritesOnlyTheStatusColumnAndNeverTheGeneralUpdate() {
+        when(clubMapper.findById(7L)).thenReturn(storedClub());
+
+        clubService.archive(7L);
+
+        verify(clubMapper).updateStatus(7L, "archived");
+        verify(clubMapper, never()).update(any());
+    }
+
+    @Test
+    void restorePutsTheClubBackIntoTheDirectory() {
+        when(clubMapper.findById(7L)).thenReturn(storedClub());
+
+        clubService.restore(7L);
+
+        verify(clubMapper).updateStatus(7L, "active");
+    }
+
+    @Test
+    void archivingAMissingClubIsRejectedBeforeAnyWrite() {
+        assertThatThrownBy(() -> clubService.archive(404L))
+            .isInstanceOf(IllegalArgumentException.class);
+
+        verify(clubMapper, never()).updateStatus(any(), any());
+    }
+
+
     // Applying while already in the club is what let an approval overwrite the applicant's
     // stored role, so the request must never be created in the first place.
     @Test

--- a/docs/API.md
+++ b/docs/API.md
@@ -152,7 +152,11 @@ Status: 200 | 403 (not a platform owner) | 404 (club not found)
 Put an archived club back into the directory (sets its status back to `active`). Requires:
 platform_owner. Returns the updated club.
 
-Status: 200 | 403 | 404
+Only an `archived` club can be restored: no previous status is recorded anywhere, so
+activating a club in some other non-active state (a `pending` one, say) would publish something
+that was never approved and lose that state for good. Anything else is a 409.
+
+Status: 200 | 403 | 404 | 409 (the club is not archived)
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -126,14 +126,33 @@ Editable fields: `name`, `aliasName`, `description`, `category`, `meetingSchedul
 body is ignored, including `slug` (the club's public URL), `status`, `visibility`,
 `approvedAt`, `approvedByOauthUserId`, and `imageUrl` -- the first five decide whether a club
 is listed and published at all and are not a club president's to change, and `imageUrl` only
-ever changes through the authenticated upload flow. There is currently no endpoint that
-changes a club's status or visibility; add a platform-owner-only one when that workflow is
-needed rather than reopening this body.
+ever changes through the authenticated upload flow. `status` changes only through the
+platform-owner archive endpoints below; `visibility` has no endpoint at all, since that column
+has no semantics yet.
 
 `category` must be one of the six allowed categories, otherwise 400.
 
 ### DELETE /api/clubs/{clubSlugOrId}
 Delete club. Requires: platform_owner. Status: 204
+
+### POST /api/clubs/{clubSlugOrId}/archive
+Archive a club. Requires: platform_owner. Returns the updated club.
+
+The reversible alternative to `DELETE`: the club keeps its row, its posts, and its roster, but
+drops out of every listing, search result, and calendar entry, and its detail endpoint answers
+404 for anyone but a member, its president, or a platform owner (`ClubVisibilityPolicy`).
+
+This is the only way to change a club's status: `PUT` deliberately ignores the field, because a
+club president can reach that endpoint and publishing or hiding a club is not theirs to do.
+There is no equivalent endpoint for `visibility` -- that column has no semantics yet.
+
+Status: 200 | 403 (not a platform owner) | 404 (club not found)
+
+### DELETE /api/clubs/{clubSlugOrId}/archive
+Put an archived club back into the directory (sets its status back to `active`). Requires:
+platform_owner. Returns the updated club.
+
+Status: 200 | 403 | 404
 
 ---
 


### PR DESCRIPTION
Follow-up to #111, which removed `status` from the fields a club `PUT` can write (a club president reaches that endpoint, and publishing or hiding a club is not theirs to do). That left no way to take a club out of the directory short of `DELETE`, which removes it outright.

## Change

Platform-owner only:

```
POST   /api/clubs/{idOrSlug}/archive   -> status = archived
DELETE /api/clubs/{idOrSlug}/archive   -> status = active
```

An archived club keeps its row, its posts, and its roster, but drops out of every listing, search result, and calendar entry, and its detail endpoint answers 404 for anyone but a member, its president, or a platform owner (`ClubVisibilityPolicy`, from #102).

The status write goes through its own column-scoped mapper statement -- the same treatment `image_url` already gets -- so the general `update()` a president can reach still cannot touch it.

**No endpoint for `visibility`**, per your call: that column has no semantics yet, so there is nothing for one to mean.

## Verification

- `ClubControllerTest`: 403 for a student, **403 for the club's own president**, 200 + delegation for a platform owner on both verbs, 404 for a missing club.
- `ClubServiceTest`: archive/restore write through `updateStatus` and never the general `update`, and a missing club is rejected before any write.
- `ClubMapperTest`: against H2, archiving removes the club from listings and search while leaving name/description/advisor intact, and restoring brings it back.
- Full `mvnw test`: 425 tests, only the 8 pre-existing Windows-only failures (#109).

No frontend surface yet -- the owner dashboard can gain a button in a follow-up if you want one.