### PR TITLE
Startup and scheduled-job robustness: one bad row can no longer stop the app

### DIFF
--- a/backend/src/main/java/com/example/demo/club/service/ClubLocationRepairRunner.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubLocationRepairRunner.java
@@ -8,10 +8,19 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
 
+/**
+ * Normalizes stored room labels once at startup.
+ *
+ * <p>Deliberately not transactional and deliberately per-row fault tolerant: Spring Boot
+ * propagates anything an {@link ApplicationRunner} throws and closes the context, so a single
+ * unrepairable row (a normalized value longer than {@code location VARCHAR(150)}, say) used to
+ * take the whole site down -- and keep taking it down on every restart, because the offending
+ * row is never fixed. A best-effort cleanup job must never be able to do that: a row that fails
+ * is logged and skipped, and the app starts.
+ */
 @Component
 @ConditionalOnProperty(
     name = "app.club-location-repair.enabled",
@@ -29,17 +38,26 @@ public class ClubLocationRepairRunner implements ApplicationRunner {
     }
 
     @Override
-    @Transactional
     public void run(ApplicationArguments args) {
         int repaired = 0;
+        int failed = 0;
         for (Club club : clubMapper.findAllLocations()) {
             String normalized = ClubLocationNormalizer.normalize(club.getLocation());
-            if (!Objects.equals(normalized, club.getLocation())) {
+            if (Objects.equals(normalized, club.getLocation())) {
+                continue;
+            }
+            try {
                 repaired += clubMapper.updateLocation(club.getId(), normalized);
+            } catch (RuntimeException e) {
+                failed++;
+                LOGGER.warn("Skipped normalizing the location of club {}: {}", club.getId(), e.toString());
             }
         }
         if (repaired > 0) {
             LOGGER.info("Normalized room labels for {} club location(s)", repaired);
+        }
+        if (failed > 0) {
+            LOGGER.warn("Could not normalize {} club location(s); the application started anyway", failed);
         }
     }
 }

--- a/backend/src/main/java/com/example/demo/club/service/InstagramAvatarCacheService.java
+++ b/backend/src/main/java/com/example/demo/club/service/InstagramAvatarCacheService.java
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -60,6 +61,9 @@ public class InstagramAvatarCacheService {
         return thread;
     });
     private static final long MAX_AVATAR_BYTES = 1024 * 1024;
+    // One pipe buffer's worth, which is all the child could ever produce before this output
+    // started being drained continuously. Only used for an abbreviated log message.
+    private static final int MAX_SUBPROCESS_OUTPUT_BYTES = 64 * 1024;
     private static final Pattern HANDLE_PATTERN = Pattern.compile("^[A-Za-z0-9._]{1,64}$");
     private static final List<String> IMAGE_EXTENSIONS = List.of("png", "jpg", "jpeg", "webp", "gif");
     private static final MediaType SVG_MEDIA_TYPE = MediaType.valueOf("image/svg+xml");
@@ -573,13 +577,37 @@ public class InstagramAvatarCacheService {
     private static CompletableFuture<String> readOutputAsync(Process process) {
         return CompletableFuture.supplyAsync(() -> {
             try (InputStream in = process.getInputStream()) {
-                return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+                return readTail(in, MAX_SUBPROCESS_OUTPUT_BYTES);
             } catch (IOException e) {
                 // The process was killed mid-read, or the pipe broke: whatever it managed to say
                 // is only used for a log message, so this must not replace the real failure.
                 return "";
             }
         }, OUTPUT_READERS);
+    }
+
+    /**
+     * Reads the stream to the end but keeps only its last {@code maxBytes}.
+     *
+     * <p>Draining continuously is what stops the child from dead-locking on a full pipe, but it
+     * also removes the implicit ~64KB ceiling that pipe buffer used to impose, so a runaway
+     * child could otherwise accumulate everything it prints on the heap. Keeping the tail rather
+     * than the head is the right end to keep for both consumers: the script prints the avatar
+     * URL last, and a failure's most relevant output is the end of its traceback.
+     */
+    private static String readTail(InputStream in, int maxBytes) throws IOException {
+        byte[] buffer = new byte[8 * 1024];
+        ByteArrayOutputStream retained = new ByteArrayOutputStream();
+        int read;
+        while ((read = in.read(buffer)) != -1) {
+            retained.write(buffer, 0, read);
+            if (retained.size() > maxBytes) {
+                byte[] tail = retained.toByteArray();
+                retained.reset();
+                retained.write(tail, tail.length - maxBytes, maxBytes);
+            }
+        }
+        return retained.toString(StandardCharsets.UTF_8);
     }
 
     private static String awaitOutput(CompletableFuture<String> output) {

--- a/backend/src/main/java/com/example/demo/club/service/InstagramAvatarCacheService.java
+++ b/backend/src/main/java/com/example/demo/club/service/InstagramAvatarCacheService.java
@@ -12,6 +12,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
@@ -37,8 +38,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -46,6 +50,15 @@ import java.util.stream.Collectors;
 public class InstagramAvatarCacheService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(InstagramAvatarCacheService.class);
+    // Drains the Instaloader subprocess's merged stdout/stderr while it runs. Daemon threads, so
+    // a reader still blocked on a wedged child can never hold up JVM shutdown, and a cached pool
+    // because the work is pure blocking I/O whose concurrency is already capped upstream by the
+    // on-demand semaphore and the prewarm's per-run limit.
+    private static final ExecutorService OUTPUT_READERS = Executors.newCachedThreadPool(runnable -> {
+        Thread thread = new Thread(runnable, "instaloader-output-reader");
+        thread.setDaemon(true);
+        return thread;
+    });
     private static final long MAX_AVATAR_BYTES = 1024 * 1024;
     private static final Pattern HANDLE_PATTERN = Pattern.compile("^[A-Za-z0-9._]{1,64}$");
     private static final List<String> IMAGE_EXTENSIONS = List.of("png", "jpg", "jpeg", "webp", "gif");
@@ -536,18 +549,50 @@ public class InstagramAvatarCacheService {
         processBuilder.redirectErrorStream(true);
         processBuilder.environment().put("PYTHONUNBUFFERED", "1");
         Process process = processBuilder.start();
+        // The child's output must be drained while it runs, not after waitFor: stdout and stderr
+        // are merged into one pipe, and a child that writes more than the OS pipe buffer (~64 KB
+        // on Linux -- a verbose traceback or a chatty browser_cookie3 failure is enough) blocks
+        // on write forever. Waiting first therefore turned a lookup that would have succeeded
+        // into a guaranteed timeout.
+        CompletableFuture<String> output = readOutputAsync(process);
         boolean finished = process.waitFor(fetchTimeoutMillis, TimeUnit.MILLISECONDS);
         if (!finished) {
             process.destroyForcibly();
             process.waitFor(1, TimeUnit.SECONDS);
+            output.cancel(true);
             throw new IOException("Instaloader timed out for " + safeHandle);
         }
-        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+        String processOutput = awaitOutput(output).trim();
         if (process.exitValue() != 0) {
-            throw new IOException("Instaloader failed for " + safeHandle + ": " + abbreviate(output));
+            throw new IOException("Instaloader failed for " + safeHandle + ": " + abbreviate(processOutput));
         }
-        return lastHttpUrl(output)
+        return lastHttpUrl(processOutput)
             .orElseThrow(() -> new IOException("Instaloader did not return an avatar URL for " + safeHandle));
+    }
+
+    private static CompletableFuture<String> readOutputAsync(Process process) {
+        return CompletableFuture.supplyAsync(() -> {
+            try (InputStream in = process.getInputStream()) {
+                return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                // The process was killed mid-read, or the pipe broke: whatever it managed to say
+                // is only used for a log message, so this must not replace the real failure.
+                return "";
+            }
+        }, OUTPUT_READERS);
+    }
+
+    private static String awaitOutput(CompletableFuture<String> output) {
+        try {
+            // The process has already exited here, so the reader is at EOF; the bound is only a
+            // guard against ever blocking a request thread on it.
+            return output.get(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return "";
+        } catch (ExecutionException | TimeoutException e) {
+            return "";
+        }
     }
 
     private Optional<String> fetchProfilePicUrlFromWebProfileApi(String safeHandle) throws IOException, InterruptedException {

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -99,6 +99,14 @@ app:
 spring:
   config:
     import: optional:file:.env[.properties]
+  task:
+    scheduling:
+      # Spring Boot's default is a single thread for every @Scheduled method. The Instagram
+      # avatar prewarm can hold one for a long time (up to max-refresh-per-run handles, each
+      # able to burn the Instaloader subprocess timeout and then the HTTP fallback timeout),
+      # which would leave the nightly orphan-upload cleanup waiting behind it.
+      pool:
+        size: ${SPRING_TASK_SCHEDULING_POOL_SIZE:2}
   servlet:
     multipart:
       # Must sit above ImageStorageService's application-level 5MB image limit -- if they were

--- a/backend/src/test/java/com/example/demo/club/service/ClubLocationRepairRunnerTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubLocationRepairRunnerTest.java
@@ -1,0 +1,58 @@
+package com.example.demo.club.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import com.example.demo.club.mapper.ClubMapper;
+import com.example.demo.club.model.Club;
+
+/**
+ * Spring Boot propagates anything an ApplicationRunner throws and closes the context, so a
+ * best-effort cleanup job that lets one bad row escape takes the whole site down -- and keeps
+ * taking it down on every restart, since nothing ever fixes the row.
+ */
+class ClubLocationRepairRunnerTest {
+
+    private static Club club(long id, String location) {
+        Club club = new Club();
+        club.setId(id);
+        club.setLocation(location);
+        return club;
+    }
+
+    @Test
+    void oneUnrepairableRowDoesNotStopTheApplicationFromStarting() {
+        ClubMapper clubMapper = mock(ClubMapper.class);
+        when(clubMapper.findAllLocations()).thenReturn(List.of(club(1L, "101"), club(2L, "room  102")));
+        when(clubMapper.updateLocation(eq(1L), any()))
+            .thenThrow(new DataIntegrityViolationException("value too long for column location"));
+        when(clubMapper.updateLocation(eq(2L), any())).thenReturn(1);
+
+        ClubLocationRepairRunner runner = new ClubLocationRepairRunner(clubMapper);
+
+        assertThatCode(() -> runner.run(null)).doesNotThrowAnyException();
+        // The rest of the table is still repaired: one bad row must not skip the others either.
+        verify(clubMapper).updateLocation(eq(2L), any());
+    }
+
+    @Test
+    void rowsAlreadyNormalizedAreLeftAlone() {
+        ClubMapper clubMapper = mock(ClubMapper.class);
+        String normalized = ClubLocationNormalizer.normalize("Room 101");
+        when(clubMapper.findAllLocations()).thenReturn(List.of(club(1L, normalized)));
+
+        new ClubLocationRepairRunner(clubMapper).run(null);
+
+        verify(clubMapper, never()).updateLocation(any(), any());
+    }
+}

--- a/backend/src/test/java/com/example/demo/club/service/InstagramAvatarCacheServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/InstagramAvatarCacheServiceTest.java
@@ -210,6 +210,45 @@ class InstagramAvatarCacheServiceTest {
         assertThat(avatar.mediaType().toString()).isEqualTo("image/svg+xml");
     }
 
+    // stdout and stderr are merged into a single pipe, so a chatty child (a traceback, a noisy
+    // browser_cookie3 failure) that writes more than the OS pipe buffer blocks on write until
+    // someone reads it. Draining only after waitFor turned such a run into a guaranteed timeout,
+    // even though the URL this script prints last is perfectly good.
+    @Test
+    void resolveAvatarStillReadsTheUrlFromAChildThatFloodsThePipeFirst() throws Exception {
+        byte[] bytes = new byte[] { 1, 2, 3, 4 };
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/avatar.png", exchange -> {
+            exchange.getResponseHeaders().add("Content-Type", "image/png");
+            exchange.sendResponseHeaders(200, bytes.length);
+            exchange.getResponseBody().write(bytes);
+            exchange.close();
+        });
+        server.start();
+        try {
+            String avatarUrl = "http://127.0.0.1:" + server.getAddress().getPort() + "/avatar.png";
+            Path chatty = tempDir.resolve("chatty-instaloader.sh");
+            // ~200 KB of noise, comfortably past a 64 KB pipe buffer, then the real answer.
+            Files.writeString(chatty,
+                "#!/bin/sh\ni=0\nwhile [ $i -lt 2000 ]; do\n"
+                    + "  echo 'WARNING xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'\n"
+                    + "  i=$((i+1))\ndone\necho '%s'\n".formatted(avatarUrl),
+                StandardCharsets.UTF_8);
+            assertThat(chatty.toFile().setExecutable(true)).isTrue();
+            InstagramAvatarCacheService service = service(true, chatty.toString(), 5000);
+
+            InstagramAvatarCacheService.ResolvedAvatar avatar = assertTimeoutPreemptively(
+                Duration.ofSeconds(20),
+                () -> service.resolveAvatar("mvhsclubs")
+            );
+
+            assertThat(avatar.mediaType()).isEqualTo(MediaType.IMAGE_PNG);
+            assertThat(avatar.bytes()).isEqualTo(bytes);
+        } finally {
+            server.stop(0);
+        }
+    }
+
     @Test
     void resolveAvatarCoalescesConcurrentCacheMisses() throws Exception {
         byte[] bytes = new byte[] { 9, 8, 7 };

--- a/backend/src/test/java/com/example/demo/config/ProductionConfigDefaultsTest.java
+++ b/backend/src/test/java/com/example/demo/config/ProductionConfigDefaultsTest.java
@@ -62,6 +62,17 @@ class ProductionConfigDefaultsTest {
         assertThat(resolve(BASE_CONFIG, "server.forward-headers-strategy")).isEqualTo("framework");
     }
 
+    // Spring Boot's default is one thread for every @Scheduled method, so the Instagram avatar
+    // prewarm (which can hold its thread for minutes across subprocess and HTTP timeouts) would
+    // block the nightly orphan-upload cleanup behind it.
+    @Test
+    void scheduledJobsDoNotShareASingleThread() throws IOException {
+        String poolSize = resolve(BASE_CONFIG, "spring.task.scheduling.pool.size");
+
+        assertThat(poolSize).isNotNull();
+        assertThat(Integer.parseInt(poolSize)).isGreaterThanOrEqualTo(2);
+    }
+
     /**
      * Returns the property's value with placeholders resolved against nothing but the file
      * itself, i.e. the default a deployment gets when the corresponding environment variable is


### PR DESCRIPTION
Closes #105. Three failure modes, none of which needed a code change to reach.

## 1. A single bad row could make the application unbootable

`ClubLocationRepairRunner` iterated every club and updated it with no per-row error handling, inside one transaction, from `ApplicationRunner.run`. Spring Boot propagates whatever a runner throws and closes the context, so one unrepairable row -- a normalized value longer than `location VARCHAR(150)`, say -- stopped the site from starting, and kept stopping it on **every** restart, because nothing ever fixes that row.

It now logs and skips the offending row, repairs the rest, and lets the app start. The transaction goes with it: rolling back the successful repairs because of one bad row was never the point of a best-effort cleanup.

## 2. Both scheduled jobs shared one thread

Nothing configured `spring.task.scheduling.pool.size`, so Boot's single-thread default ran both `@Scheduled` methods. The Instagram avatar prewarm can hold that thread for a long time (up to `max-refresh-per-run` handles, each able to burn the subprocess timeout **and** the HTTP fallback timeout), leaving the nightly orphan-upload cleanup queued behind it. Pool size is 2 by default, overridable.

## 3. The Instaloader subprocess could dead-lock on its own output

`redirectErrorStream(true)` merges stderr into stdout, but nothing read that pipe until after `waitFor` returned. A child writing more than the OS pipe buffer (~64 KB -- a traceback, or a chatty `browser_cookie3` failure) blocks on write, so `waitFor` necessarily expired and a lookup that would have succeeded was reported as a timeout. The output is now drained on a daemon thread while the process runs.

## Verification

- New `ClubLocationRepairRunnerTest`: a row whose update throws does not stop startup, and the remaining rows are still repaired; already-normalized rows are untouched.
- New `ProductionConfigDefaultsTest` case asserts the scheduler pool is at least 2.
- New `InstagramAvatarCacheServiceTest` case: a script that prints ~200 KB of noise **before** the URL still resolves the avatar. It lives with the existing POSIX shell fixtures, so like its neighbours it is verified by CI and not on Windows (see #109) -- locally that class now shows 9 failures instead of 8, all environmental.
- Full `mvnw test`: 440 tests, no new failures outside that known Windows group.