### PR TITLE
Bound the work the public endpoints do: recommendations, calendar, summary

### DIFF
--- a/backend/src/main/java/com/example/demo/club/controller/ClubController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubController.java
@@ -302,8 +302,8 @@ public class ClubController {
 
     @GetMapping("/calendar")
     public List<Map<String, Object>> calendar() {
-        // findCalendarEntries, not findAll: the response below reads eleven scalar fields, so
-        // there is no reason to select description, schedule_note, and the achievements CLOB
+        // findCalendarEntries, not findAll: the response below reads a fixed set of scalar
+        // fields, so there is no reason to also select description and the achievements CLOB
         // for every club on a public, unauthenticated endpoint.
         List<Club> clubs = clubService.findCalendarEntries();
         List<Map<String, Object>> events = new ArrayList<>();

--- a/backend/src/main/java/com/example/demo/club/controller/ClubController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubController.java
@@ -302,7 +302,10 @@ public class ClubController {
 
     @GetMapping("/calendar")
     public List<Map<String, Object>> calendar() {
-        List<Club> clubs = clubService.findAll();
+        // findCalendarEntries, not findAll: the response below reads eleven scalar fields, so
+        // there is no reason to select description, schedule_note, and the achievements CLOB
+        // for every club on a public, unauthenticated endpoint.
+        List<Club> clubs = clubService.findCalendarEntries();
         List<Map<String, Object>> events = new ArrayList<>();
         for (Club club : clubs) {
             Map<String, Object> event = new HashMap<>();

--- a/backend/src/main/java/com/example/demo/club/mapper/ClubMapper.java
+++ b/backend/src/main/java/com/example/demo/club/mapper/ClubMapper.java
@@ -1,6 +1,7 @@
 package com.example.demo.club.mapper;
 
 import com.example.demo.club.model.Club;
+import com.example.demo.summary.model.ClubSummaryProjection;
 import com.example.demo.club.model.ClubMemberView;
 import com.example.demo.club.model.ClubMembershipRequest;
 import com.example.demo.club.model.ViewerMembershipStatus;
@@ -24,6 +25,24 @@ public interface ClubMapper {
 
     List<Club> findAllPaginated(@Param("offset") int offset,
                                 @Param("limit") int limit);
+
+    /**
+     * Most-joined active clubs, ordered and limited in SQL. The recommendation endpoint is
+     * public and returns at most 20 rows, so sorting and truncating the whole table in Java
+     * made its cost unbounded in table size for a constant-size answer.
+     */
+    List<Club> findPopular(@Param("limit") int limit);
+
+    /** Same, restricted to the given categories and excluding clubs the viewer already joined. */
+    List<Club> findPopularInCategories(@Param("categories") List<String> categories,
+                                       @Param("excludedClubIds") List<Long> excludedClubIds,
+                                       @Param("limit") int limit);
+
+    /** Active clubs with only the columns the calendar renders (no description, no CLOBs). */
+    List<Club> findCalendarEntries();
+
+    /** Narrow projection for {@code /api/summary}; see {@link ClubSummaryProjection}. */
+    List<ClubSummaryProjection> findSummaryProjections();
 
     List<Club> search(@Param("name") String name,
                       @Param("category") String category,

--- a/backend/src/main/java/com/example/demo/club/service/ClubService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubService.java
@@ -83,6 +83,11 @@ public class ClubService {
         return clubMapper.findAll();
     }
 
+    /** Active clubs carrying only the columns the calendar renders. */
+    public List<Club> findCalendarEntries() {
+        return clubMapper.findCalendarEntries();
+    }
+
     public List<Club> findAllPaginated(int page, int size) {
         int limit = PaginationClamps.clampPageSize(size);
         int offset = PaginationClamps.clampOffset(page, limit);
@@ -364,8 +369,6 @@ public class ClubService {
      * Falls back to popular clubs (highest member count) for cold start.
      */
     public List<Club> getRecommendations(String viewerEmail, int limit) {
-        List<Club> allClubs = clubMapper.findAll();
-
         if (viewerEmail != null && !viewerEmail.isBlank()) {
             Long userId = oAuthUserMapper.findIdByEmail(viewerEmail);
             if (userId != null) {
@@ -373,14 +376,12 @@ public class ClubService {
                 List<String> userCategories = clubMapper.findCategoriesByOauthUserId(userId);
                 if (!userCategories.isEmpty()) {
                     List<Long> joinedClubIds = clubMapper.findClubIdsByOauthUserId(userId);
-                    List<Club> personalized = allClubs.stream()
-                        .filter(c -> userCategories.contains(c.getCategory()))
-                        .filter(c -> !joinedClubIds.contains(c.getId()))
-                        .sorted((a, b) -> Integer.compare(
-                            b.getMemberCount() != null ? b.getMemberCount() : 0,
-                            a.getMemberCount() != null ? a.getMemberCount() : 0))
-                        .limit(limit)
-                        .toList();
+                    // Filtering, ordering and limiting all happen in SQL: this endpoint is
+                    // public and returns at most 20 rows, so reading every club to sort and
+                    // truncate in Java made the work unbounded in table size for a
+                    // constant-size answer.
+                    List<Club> personalized =
+                        clubMapper.findPopularInCategories(userCategories, joinedClubIds, limit);
                     if (!personalized.isEmpty()) {
                         return personalized;
                     }
@@ -390,12 +391,7 @@ public class ClubService {
         }
 
         // Cold start: return most popular clubs
-        return allClubs.stream()
-            .sorted((a, b) -> Integer.compare(
-                b.getMemberCount() != null ? b.getMemberCount() : 0,
-                a.getMemberCount() != null ? a.getMemberCount() : 0))
-            .limit(limit)
-            .toList();
+        return clubMapper.findPopular(limit);
     }
 
     // ---- President management ----

--- a/backend/src/main/java/com/example/demo/summary/model/ClubSummaryProjection.java
+++ b/backend/src/main/java/com/example/demo/summary/model/ClubSummaryProjection.java
@@ -1,0 +1,59 @@
+package com.example.demo.summary.model;
+
+import java.time.LocalDateTime;
+
+/**
+ * The narrow slice of a club row that {@code /api/summary} needs: enough to count clubs and
+ * members, group by category, find the newest update, and fingerprint the directory.
+ *
+ * <p>Exists so that endpoint stops selecting whole {@code Club} rows -- description,
+ * {@code schedule_note}, and the {@code achievements} CLOB -- for every club on every request.
+ */
+public class ClubSummaryProjection {
+
+    private Long id;
+    private String name;
+    private String category;
+    private Integer memberCount;
+    private LocalDateTime updatedAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public Integer getMemberCount() {
+        return memberCount;
+    }
+
+    public void setMemberCount(Integer memberCount) {
+        this.memberCount = memberCount;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/com/example/demo/summary/service/SummaryService.java
+++ b/backend/src/main/java/com/example/demo/summary/service/SummaryService.java
@@ -1,7 +1,7 @@
 package com.example.demo.summary.service;
 
 import com.example.demo.club.mapper.ClubMapper;
-import com.example.demo.club.model.Club;
+import com.example.demo.summary.model.ClubSummaryProjection;
 import com.example.demo.summary.model.SummaryResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -9,13 +9,24 @@ import org.springframework.stereotype.Service;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+/**
+ * Builds the public school summary the future aggregator repo consumes.
+ *
+ * <p>Two things keep this endpoint cheap, because it is unauthenticated and therefore the
+ * easiest thing on the site to hammer: it reads a narrow projection rather than whole club rows
+ * (no description, no {@code achievements} CLOB), and the assembled response is cached for a
+ * short TTL so a burst of requests collapses onto one query. The TTL is small enough that the
+ * aggregator still sees a change promptly.
+ */
 @Service
 public class SummaryService {
 
@@ -23,24 +34,38 @@ public class SummaryService {
     private final String schoolName;
     private final String shortName;
     private final String slug;
+    private final Duration cacheTtl;
+    private final AtomicReference<CachedSummary> cached = new AtomicReference<>();
 
     public SummaryService(ClubMapper clubMapper,
                           @Value("${app.summary.school-name:HS Clubs}") String schoolName,
                           @Value("${app.summary.short-name:HS Clubs}") String shortName,
-                          @Value("${app.summary.slug:hsclubs}") String slug) {
+                          @Value("${app.summary.slug:hsclubs}") String slug,
+                          @Value("${app.summary.cache-ttl-ms:60000}") long cacheTtlMillis) {
         this.clubMapper = clubMapper;
         this.schoolName = schoolName;
         this.shortName = shortName;
         this.slug = slug;
+        this.cacheTtl = Duration.ofMillis(Math.max(0, cacheTtlMillis));
     }
 
     public SummaryResponse buildSummary() {
-        List<Club> clubs = clubMapper.findAll();
+        CachedSummary snapshot = cached.get();
+        if (snapshot != null && !snapshot.isExpired(cacheTtl)) {
+            return snapshot.summary();
+        }
+        SummaryResponse summary = computeSummary();
+        cached.set(new CachedSummary(summary, System.nanoTime()));
+        return summary;
+    }
+
+    private SummaryResponse computeSummary() {
+        List<ClubSummaryProjection> clubs = clubMapper.findSummaryProjections();
 
         Map<String, Integer> categoryCounts = clubs.stream()
             .filter(c -> c.getCategory() != null && !c.getCategory().isBlank())
             .collect(Collectors.groupingBy(
-                Club::getCategory,
+                ClubSummaryProjection::getCategory,
                 LinkedHashMap::new,
                 Collectors.collectingAndThen(Collectors.counting(), Long::intValue)
             ));
@@ -50,7 +75,7 @@ public class SummaryService {
             .sum();
 
         LocalDateTime lastUpdated = clubs.stream()
-            .map(Club::getUpdatedAt)
+            .map(ClubSummaryProjection::getUpdatedAt)
             .filter(t -> t != null)
             .max(LocalDateTime::compareTo)
             .orElse(null);
@@ -74,7 +99,7 @@ public class SummaryService {
      * The 2nd repo can compare this hash to detect changes without
      * re-fetching all club data.
      */
-    private String computeHash(List<Club> clubs) {
+    private String computeHash(List<ClubSummaryProjection> clubs) {
         String payload = clubs.stream()
             .sorted((a, b) -> Long.compare(a.getId() != null ? a.getId() : 0,
                                            b.getId() != null ? b.getId() : 0))
@@ -90,6 +115,12 @@ public class SummaryService {
             return HexFormat.of().formatHex(hash);
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException("SHA-256 not available", e);
+        }
+    }
+
+    private record CachedSummary(SummaryResponse summary, long builtAtNanos) {
+        boolean isExpired(Duration ttl) {
+            return System.nanoTime() - builtAtNanos >= ttl.toNanos();
         }
     }
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -95,6 +95,10 @@ app:
     school-name: ${APP_SUMMARY_SCHOOL_NAME:HS Clubs}
     short-name: ${APP_SUMMARY_SHORT_NAME:HS Clubs}
     slug: ${APP_SUMMARY_SLUG:hsclubs}
+    # /api/summary is unauthenticated, so a burst of requests is the cheapest way to make the
+    # site work. The assembled response is cached for this long; short enough that the future
+    # aggregator still sees a change promptly, long enough that a flood collapses onto one query.
+    cache-ttl-ms: ${APP_SUMMARY_CACHE_TTL_MS:60000}
 
 spring:
   config:

--- a/backend/src/main/resources/mapper/ClubMapper.xml
+++ b/backend/src/main/resources/mapper/ClubMapper.xml
@@ -46,10 +46,10 @@
         status = 'active'
     </sql>
 
-    <!-- Everything the calendar and the recommendation list actually render. Deliberately not
-         BaseColumnList: that one carries description and the achievements CLOB, which no
-         caller of these two endpoints ever reads, on every row of the table. -->
-    <sql id="SummaryColumnList">
+    <!-- Everything the calendar response renders. Deliberately not BaseColumnList: that one
+         also carries description and the achievements CLOB, which the calendar never reads,
+         for every club in the table. -->
+    <sql id="CalendarColumnList">
         id, name, slug, alias_name, category, meeting_schedule, schedule_note, location,
         contact_email, advisor, image_url,
         (SELECT link_url
@@ -61,19 +61,29 @@
         status, visibility, created_at, updated_at
     </sql>
 
+    <!-- Live member count, spelled out rather than referencing the member_count select alias:
+         clubs also has a real (stale, never read) member_count column, and relying on the alias
+         shadowing it in ORDER BY is exactly the kind of silent fallback that would leave this
+         sorting by the wrong number. -->
+    <sql id="LiveMemberCount">
+        (SELECT COUNT(*) FROM club_member WHERE club_id = clubs.id)
+    </sql>
+
     <!-- Popularity ordering and the row limit both live in SQL: this endpoint is public and
          returns at most 20 clubs, so reading the whole table to sort and truncate it in Java
-         made the work unbounded in table size for a constant-size answer. -->
+         made the work unbounded in table size for a constant-size answer. The full column list
+         is deliberate here, unlike the calendar: these rows are serialized to the client as
+         ordinary Club objects, and dropping columns would quietly change that payload. -->
     <select id="findPopular" resultMap="ClubResultMap">
-        SELECT <include refid="SummaryColumnList" />
+        SELECT <include refid="BaseColumnList" />
         FROM clubs
         WHERE <include refid="ActiveClause" />
-        ORDER BY member_count DESC, name ASC
+        ORDER BY <include refid="LiveMemberCount" /> DESC, name ASC
         LIMIT #{limit}
     </select>
 
     <select id="findPopularInCategories" resultMap="ClubResultMap">
-        SELECT <include refid="SummaryColumnList" />
+        SELECT <include refid="BaseColumnList" />
         FROM clubs
         WHERE <include refid="ActiveClause" />
         AND category IN
@@ -86,12 +96,12 @@
                 #{clubId}
             </foreach>
         </if>
-        ORDER BY member_count DESC, name ASC
+        ORDER BY <include refid="LiveMemberCount" /> DESC, name ASC
         LIMIT #{limit}
     </select>
 
     <select id="findCalendarEntries" resultMap="ClubResultMap">
-        SELECT <include refid="SummaryColumnList" />
+        SELECT <include refid="CalendarColumnList" />
         FROM clubs
         WHERE <include refid="ActiveClause" />
         ORDER BY name ASC
@@ -103,7 +113,7 @@
         SELECT id,
                name,
                category,
-               (SELECT COUNT(*) FROM club_member WHERE club_id = clubs.id) AS memberCount,
+               <include refid="LiveMemberCount" /> AS memberCount,
                updated_at AS updatedAt
         FROM clubs
         WHERE <include refid="ActiveClause" />

--- a/backend/src/main/resources/mapper/ClubMapper.xml
+++ b/backend/src/main/resources/mapper/ClubMapper.xml
@@ -46,6 +46,70 @@
         status = 'active'
     </sql>
 
+    <!-- Everything the calendar and the recommendation list actually render. Deliberately not
+         BaseColumnList: that one carries description and the achievements CLOB, which no
+         caller of these two endpoints ever reads, on every row of the table. -->
+    <sql id="SummaryColumnList">
+        id, name, slug, alias_name, category, meeting_schedule, schedule_note, location,
+        contact_email, advisor, image_url,
+        (SELECT link_url
+         FROM club_social_medias
+         WHERE club_id = clubs.id
+           AND social_type = 'instagram'
+         LIMIT 1) AS instagram_url,
+        (SELECT COUNT(*) FROM club_member WHERE club_id = clubs.id) AS member_count,
+        status, visibility, created_at, updated_at
+    </sql>
+
+    <!-- Popularity ordering and the row limit both live in SQL: this endpoint is public and
+         returns at most 20 clubs, so reading the whole table to sort and truncate it in Java
+         made the work unbounded in table size for a constant-size answer. -->
+    <select id="findPopular" resultMap="ClubResultMap">
+        SELECT <include refid="SummaryColumnList" />
+        FROM clubs
+        WHERE <include refid="ActiveClause" />
+        ORDER BY member_count DESC, name ASC
+        LIMIT #{limit}
+    </select>
+
+    <select id="findPopularInCategories" resultMap="ClubResultMap">
+        SELECT <include refid="SummaryColumnList" />
+        FROM clubs
+        WHERE <include refid="ActiveClause" />
+        AND category IN
+        <foreach collection="categories" item="category" open="(" separator="," close=")">
+            #{category}
+        </foreach>
+        <if test="excludedClubIds != null and excludedClubIds.size() > 0">
+            AND id NOT IN
+            <foreach collection="excludedClubIds" item="clubId" open="(" separator="," close=")">
+                #{clubId}
+            </foreach>
+        </if>
+        ORDER BY member_count DESC, name ASC
+        LIMIT #{limit}
+    </select>
+
+    <select id="findCalendarEntries" resultMap="ClubResultMap">
+        SELECT <include refid="SummaryColumnList" />
+        FROM clubs
+        WHERE <include refid="ActiveClause" />
+        ORDER BY name ASC
+    </select>
+
+    <!-- Just enough to count clubs and members, find the newest update, and fingerprint the
+         directory for /api/summary. No CLOBs, no description. -->
+    <select id="findSummaryProjections" resultType="com.example.demo.summary.model.ClubSummaryProjection">
+        SELECT id,
+               name,
+               category,
+               (SELECT COUNT(*) FROM club_member WHERE club_id = clubs.id) AS memberCount,
+               updated_at AS updatedAt
+        FROM clubs
+        WHERE <include refid="ActiveClause" />
+        ORDER BY id ASC
+    </select>
+
     <select id="findAll" resultMap="ClubResultMap">
         SELECT <include refid="BaseColumnList" />
         FROM clubs

--- a/backend/src/test/java/com/example/demo/club/mapper/ClubMapperTest.java
+++ b/backend/src/test/java/com/example/demo/club/mapper/ClubMapperTest.java
@@ -207,6 +207,99 @@ class ClubMapperTest {
         assertThat(clubMapper.findAllPaginated(0, 10)).hasSize(1);
     }
 
+    // ---- Bounded public queries (#104) ----
+
+    @Test
+    void findPopularOrdersByMemberCountAndLimitsInSql() {
+        insertClub(10, "Quiet Club", "STEM & Innovation");
+        insertClub(11, "Busy Club", "STEM & Innovation");
+        insertMembers(11, 100, 3);
+        insertMembers(10, 200, 1);
+
+        List<Club> popular = clubMapper.findPopular(1);
+
+        assertThat(popular).extracting(Club::getName).containsExactly("Busy Club");
+        assertThat(popular.get(0).getMemberCount()).isEqualTo(3);
+    }
+
+    @Test
+    void findPopularInCategoriesFiltersByCategoryAndExcludesJoinedClubs() {
+        insertClub(10, "Robotics", "STEM & Innovation");
+        insertClub(11, "Chess", "Competition & Strategy");
+        insertClub(12, "Rocketry", "STEM & Innovation");
+
+        List<Club> recommended =
+            clubMapper.findPopularInCategories(List.of("STEM & Innovation"), List.of(10L), 10);
+
+        assertThat(recommended).extracting(Club::getName).containsExactly("Rocketry");
+    }
+
+    @Test
+    void findPopularInCategoriesWorksWhenTheViewerHasJoinedNothingYet() {
+        insertClub(10, "Robotics", "STEM & Innovation");
+
+        List<Club> recommended =
+            clubMapper.findPopularInCategories(List.of("STEM & Innovation"), List.of(), 10);
+
+        assertThat(recommended).hasSize(1);
+    }
+
+    // The calendar renders scalar fields only, so its query must not drag the description and
+    // achievements CLOB along for every club.
+    @Test
+    void findCalendarEntriesReturnsTheRenderedFieldsWithoutTheHeavyOnes() {
+        insertSearchableClub();
+
+        List<Club> entries = clubMapper.findCalendarEntries();
+
+        assertThat(entries).singleElement().satisfies(entry -> {
+            assertThat(entry.getName()).isEqualTo("Chess Club");
+            assertThat(entry.getMeetingSchedule()).isEqualTo("Wednesday lunch");
+            assertThat(entry.getLocation()).isEqualTo("Room 214");
+            assertThat(entry.getAdvisor()).isEqualTo("Ms. Lee");
+            assertThat(entry.getDescription()).isNull();
+        });
+    }
+
+    @Test
+    void findSummaryProjectionsCountsMembersWithoutSelectingWholeClubRows() {
+        insertClub(10, "Robotics", "STEM & Innovation");
+        insertMembers(10, 300, 2);
+
+        assertThat(clubMapper.findSummaryProjections()).singleElement().satisfies(projection -> {
+            assertThat(projection.getName()).isEqualTo("Robotics");
+            assertThat(projection.getCategory()).isEqualTo("STEM & Innovation");
+            assertThat(projection.getMemberCount()).isEqualTo(2);
+        });
+    }
+
+    @Test
+    void theseQueriesAllHideNonActiveClubs() {
+        insertClub(10, "Archived Club", "STEM & Innovation");
+        clubMapper.updateStatus(10L, "archived");
+
+        assertThat(clubMapper.findPopular(10)).isEmpty();
+        assertThat(clubMapper.findPopularInCategories(List.of("STEM & Innovation"), List.of(), 10)).isEmpty();
+        assertThat(clubMapper.findCalendarEntries()).isEmpty();
+        assertThat(clubMapper.findSummaryProjections()).isEmpty();
+    }
+
+    private void insertClub(long id, String name, String category) {
+        jdbcTemplate.update(
+            "INSERT INTO clubs (id, name, category, status) VALUES (?, ?, ?, 'active')", id, name, category);
+    }
+
+    private void insertMembers(long clubId, long firstUserId, int count) {
+        for (int i = 0; i < count; i++) {
+            long userId = firstUserId + i;
+            jdbcTemplate.update(
+                "INSERT INTO oauth_users (uid, provider, provider_user_id) VALUES (?, 'google', ?)",
+                userId, "g-" + userId);
+            jdbcTemplate.update(
+                "INSERT INTO club_member (club_id, oauth_user_id) VALUES (?, ?)", clubId, userId);
+        }
+    }
+
     private void insertSearchableClub() {
         jdbcTemplate.update("""
             INSERT INTO clubs (id, name, category, description, location, advisor,

--- a/backend/src/test/java/com/example/demo/club/mapper/ClubMapperTest.java
+++ b/backend/src/test/java/com/example/demo/club/mapper/ClubMapperTest.java
@@ -211,15 +211,29 @@ class ClubMapperTest {
 
     @Test
     void findPopularOrdersByMemberCountAndLimitsInSql() {
-        insertClub(10, "Quiet Club", "STEM & Innovation");
-        insertClub(11, "Busy Club", "STEM & Innovation");
+        // Names chosen so alphabetical order disagrees with popularity, and stale member_count
+        // values written the wrong way round: clubs still has a real member_count column, so a
+        // query that sorted by it (or by an alias shadowing it) instead of the live count would
+        // return "Alpha Club" here and pass on nothing but the tie-break.
+        insertClub(10, "Alpha Club", "STEM & Innovation", 99);
+        insertClub(11, "Zebra Club", "STEM & Innovation", 0);
         insertMembers(11, 100, 3);
         insertMembers(10, 200, 1);
 
         List<Club> popular = clubMapper.findPopular(1);
 
-        assertThat(popular).extracting(Club::getName).containsExactly("Busy Club");
+        assertThat(popular).extracting(Club::getName).containsExactly("Zebra Club");
         assertThat(popular.get(0).getMemberCount()).isEqualTo(3);
+    }
+
+    @Test
+    void findSummaryProjectionsReportsTheLiveMemberCountNotTheStaleColumn() {
+        insertClub(10, "Robotics", "STEM & Innovation", 99);
+        insertMembers(10, 400, 2);
+
+        assertThat(clubMapper.findSummaryProjections())
+            .singleElement()
+            .satisfies(projection -> assertThat(projection.getMemberCount()).isEqualTo(2));
     }
 
     @Test
@@ -285,8 +299,13 @@ class ClubMapperTest {
     }
 
     private void insertClub(long id, String name, String category) {
+        insertClub(id, name, category, 0);
+    }
+
+    private void insertClub(long id, String name, String category, int staleMemberCount) {
         jdbcTemplate.update(
-            "INSERT INTO clubs (id, name, category, status) VALUES (?, ?, ?, 'active')", id, name, category);
+            "INSERT INTO clubs (id, name, category, member_count, status) VALUES (?, ?, ?, ?, 'active')",
+            id, name, category, staleMemberCount);
     }
 
     private void insertMembers(long clubId, long firstUserId, int count) {

--- a/backend/src/test/java/com/example/demo/club/service/ClubServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubServiceTest.java
@@ -215,6 +215,43 @@ class ClubServiceTest {
 
     // ---- Membership ----
 
+    // The recommendation endpoint is public and returns at most 20 rows; reading every club to
+    // sort and truncate in Java made that cost unbounded in table size.
+    @Test
+    void recommendationsForASignedOutVisitorAreOrderedAndLimitedInSql() {
+        clubService.getRecommendations(null, 8);
+
+        verify(clubMapper).findPopular(8);
+        verify(clubMapper, never()).findAll();
+    }
+
+    @Test
+    void recommendationsForAMemberAskSqlForTheirCategoriesExcludingClubsTheyJoined() {
+        when(oAuthUserMapper.findIdByEmail("student@example.com")).thenReturn(21L);
+        when(clubMapper.findCategoriesByOauthUserId(21L)).thenReturn(List.of("STEM & Innovation"));
+        when(clubMapper.findClubIdsByOauthUserId(21L)).thenReturn(List.of(3L));
+        when(clubMapper.findPopularInCategories(List.of("STEM & Innovation"), List.of(3L), 8))
+            .thenReturn(List.of(new Club()));
+
+        clubService.getRecommendations("student@example.com", 8);
+
+        verify(clubMapper).findPopularInCategories(List.of("STEM & Innovation"), List.of(3L), 8);
+        verify(clubMapper, never()).findAll();
+    }
+
+    @Test
+    void recommendationsFallBackToPopularClubsWhenNothingMatchesTheirCategories() {
+        when(oAuthUserMapper.findIdByEmail("student@example.com")).thenReturn(21L);
+        when(clubMapper.findCategoriesByOauthUserId(21L)).thenReturn(List.of("STEM & Innovation"));
+        when(clubMapper.findClubIdsByOauthUserId(21L)).thenReturn(List.of(3L));
+        when(clubMapper.findPopularInCategories(any(), any(), anyInt())).thenReturn(List.of());
+
+        clubService.getRecommendations("student@example.com", 8);
+
+        verify(clubMapper).findPopular(8);
+    }
+
+
     // status is deliberately not writable through update(), which a club president can reach,
     // so archiving has to go through the column-scoped statement instead.
     @Test

--- a/backend/src/test/java/com/example/demo/summary/service/SummaryServiceTest.java
+++ b/backend/src/test/java/com/example/demo/summary/service/SummaryServiceTest.java
@@ -1,0 +1,103 @@
+package com.example.demo.summary.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.example.demo.club.mapper.ClubMapper;
+import com.example.demo.summary.model.ClubSummaryProjection;
+import com.example.demo.summary.model.SummaryResponse;
+
+class SummaryServiceTest {
+
+    private static ClubSummaryProjection club(long id, String name, String category, int memberCount,
+                                              LocalDateTime updatedAt) {
+        ClubSummaryProjection projection = new ClubSummaryProjection();
+        projection.setId(id);
+        projection.setName(name);
+        projection.setCategory(category);
+        projection.setMemberCount(memberCount);
+        projection.setUpdatedAt(updatedAt);
+        return projection;
+    }
+
+    private static List<ClubSummaryProjection> directory() {
+        return List.of(
+            club(1L, "Chess Club", "Competition & Strategy", 12, LocalDateTime.of(2026, 1, 2, 3, 4)),
+            club(2L, "Robotics", "STEM & Innovation", 30, LocalDateTime.of(2026, 2, 3, 4, 5)),
+            club(3L, "Debate", "Competition & Strategy", 8, null));
+    }
+
+    private static SummaryService service(ClubMapper clubMapper, long cacheTtlMillis) {
+        return new SummaryService(clubMapper, "Example High School", "EHS", "ehs", cacheTtlMillis);
+    }
+
+    @Test
+    void summarizesClubCountsMembersAndTheNewestUpdate() {
+        ClubMapper clubMapper = mock(ClubMapper.class);
+        when(clubMapper.findSummaryProjections()).thenReturn(directory());
+
+        SummaryResponse summary = service(clubMapper, 0).buildSummary();
+
+        assertThat(summary.getSchoolName()).isEqualTo("Example High School");
+        assertThat(summary.getClubCount()).isEqualTo(3);
+        assertThat(summary.getMemberCount()).isEqualTo(50);
+        assertThat(summary.getCategories())
+            .containsEntry("Competition & Strategy", 2)
+            .containsEntry("STEM & Innovation", 1);
+        assertThat(summary.getLastUpdatedAt()).isEqualTo(LocalDateTime.of(2026, 2, 3, 4, 5));
+        assertThat(summary.getDataHash()).isNotBlank();
+    }
+
+    // The aggregator compares this hash to decide whether to re-fetch, so it has to change when
+    // the directory changes and stay put when it does not.
+    @Test
+    void theDataHashTracksTheDirectoryContents() {
+        ClubMapper clubMapper = mock(ClubMapper.class);
+        when(clubMapper.findSummaryProjections()).thenReturn(directory());
+        String first = service(clubMapper, 0).buildSummary().getDataHash();
+
+        ClubMapper sameContents = mock(ClubMapper.class);
+        when(sameContents.findSummaryProjections()).thenReturn(directory());
+        assertThat(service(sameContents, 0).buildSummary().getDataHash()).isEqualTo(first);
+
+        ClubMapper changed = mock(ClubMapper.class);
+        when(changed.findSummaryProjections()).thenReturn(
+            List.of(club(1L, "Chess Club", "Competition & Strategy", 13, null)));
+        assertThat(service(changed, 0).buildSummary().getDataHash()).isNotEqualTo(first);
+    }
+
+    // This endpoint is unauthenticated, so a burst of requests is the cheapest way to make the
+    // site do work. Within the TTL they must collapse onto a single query.
+    @Test
+    void repeatedRequestsInsideTheTtlReuseOneQuery() {
+        ClubMapper clubMapper = mock(ClubMapper.class);
+        when(clubMapper.findSummaryProjections()).thenReturn(directory());
+        SummaryService service = service(clubMapper, 60_000);
+
+        SummaryResponse first = service.buildSummary();
+        SummaryResponse second = service.buildSummary();
+
+        assertThat(second).isSameAs(first);
+        verify(clubMapper, times(1)).findSummaryProjections();
+    }
+
+    @Test
+    void aZeroTtlDisablesTheCacheSoEveryRequestSeesCurrentData() {
+        ClubMapper clubMapper = mock(ClubMapper.class);
+        when(clubMapper.findSummaryProjections()).thenReturn(directory());
+        SummaryService service = service(clubMapper, 0);
+
+        service.buildSummary();
+        service.buildSummary();
+
+        verify(clubMapper, times(2)).findSummaryProjections();
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -29,6 +29,12 @@ Response:
 
 The `dataHash` is a SHA-256 digest of (clubId|name|category|memberCount) for all clubs. The aggregator compares this hash to detect changes without re-fetching.
 
+The response is assembled from a narrow projection (club id, name, category, member count,
+updated time -- never the description or the achievements CLOB) and cached for
+`app.summary.cache-ttl-ms` (60s by default, 0 disables it). The endpoint is unauthenticated, so
+that cache is what keeps a burst of requests from turning into a burst of full-table reads; an
+aggregator polling on any sane interval still sees changes promptly.
+
 ## Authentication
 
 All endpoints use session-based auth via Spring Security OAuth2. Include credentials (`credentials: 'include'`) in client requests.


### PR DESCRIPTION
Closes #104.

Three unauthenticated endpoints read the whole club table through `findAll()`, whose column list carries `description`, `schedule_note` and the `achievements` CLOB plus two correlated subqueries per row. The cost scaled with the table while the useful output was small or constant -- and being anonymous, they were also the cheapest way for anyone to load the box.

## Change

- **`GET /api/clubs/recommendations`** returns at most 20 rows. Category filtering, the "clubs I already joined" exclusion, popularity ordering and the row limit now all happen in SQL (`findPopular` / `findPopularInCategories`).
- **`GET /api/clubs/calendar`** renders eleven scalar fields per club, so it now uses a projection without `description` or the `achievements` CLOB.
- **`GET /api/summary`** needs counts, the newest update time, and a fingerprint. It reads a narrow projection (`id`, `name`, `category`, member count, `updated_at`), and the assembled response is cached for `app.summary.cache-ttl-ms` (60s default, `0` disables) so a burst of requests collapses onto one query.

**No response body changes**: the recommendation and calendar payloads never read the dropped columns, and the summary is computed from exactly the same four fields per club as before.

## Verification

- `ClubMapperTest` against H2: `findPopular` orders by member count and limits in SQL; `findPopularInCategories` filters by category, excludes joined clubs, and works with an empty exclusion list; `findCalendarEntries` returns the rendered fields and leaves `description` null; `findSummaryProjections` counts members; and all four hide non-active clubs.
- New `SummaryServiceTest`: counts/members/newest-update, the hash tracks contents (same data -> same hash, changed data -> different hash), repeated requests inside the TTL issue one query, `0` disables the cache.
- `ClubServiceTest`: recommendations delegate to the SQL-bounded queries and never call `findAll`.
- Full `mvnw test`: 449 tests, only the 8 pre-existing Windows-only failures (#109).