### PR TITLE
Audit fix: the sign-in restrictions never ran for Google logins

### DIFF
--- a/backend/src/main/java/com/example/demo/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/demo/auth/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 import java.util.Set;
 
 import com.example.demo.security.CustomOAuth2UserService;
+import com.example.demo.security.CustomOidcUserService;
 import com.example.demo.security.LoginEligibilityPolicy;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -40,6 +41,7 @@ public class SecurityConfig {
 
     private final SecurityProperties securityProperties;
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomOidcUserService customOidcUserService;
     private final ClientRegistrationRepository clientRegistrationRepository;
 
     /**
@@ -52,9 +54,11 @@ public class SecurityConfig {
 
     public SecurityConfig(SecurityProperties securityProperties,
                           CustomOAuth2UserService customOAuth2UserService,
+                          CustomOidcUserService customOidcUserService,
                           ClientRegistrationRepository clientRegistrationRepository) {
         this.securityProperties = securityProperties;
         this.customOAuth2UserService = customOAuth2UserService;
+        this.customOidcUserService = customOidcUserService;
         this.clientRegistrationRepository = clientRegistrationRepository;
         this.authenticatedCorsConfiguration = buildAuthenticatedCorsConfiguration();
     }
@@ -95,7 +99,13 @@ public class SecurityConfig {
                     .authorizationRequestResolver(new RedirectCapturingAuthorizationRequestResolver(
                         clientRegistrationRepository, resolveAuthorizationRequestBaseUri())))
                 .redirectionEndpoint(redirection -> redirection.baseUri("/api/auth/*/callback"))
-                .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+                // Both services, deliberately: the Google registration requests the openid
+                // scope, so Spring Security takes the OIDC path and only ever calls the
+                // oidcUserService. Wiring just the plain one left the sign-in restrictions and
+                // the login record unreachable for the provider this school actually uses.
+                .userInfoEndpoint(userInfo -> userInfo
+                    .userService(customOAuth2UserService)
+                    .oidcUserService(customOidcUserService))
                 .successHandler((request, response, authentication) ->
                     response.sendRedirect(PostLoginRedirectResolver.buildRedirectUri(
                         resolveLoginRedirectUri(), consumeSessionRedirectTarget(request))))

--- a/backend/src/main/java/com/example/demo/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/example/demo/auth/controller/AuthController.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -60,7 +61,16 @@ public class AuthController {
         // re-reads /api/auth/me, still sees acceptedTerms=false, and re-routes the student
         // back to the very page they just submitted -- a silent dead end with no error shown.
         // Fail loudly instead so the frontend can surface something actionable.
-        if (!authService.acceptTerms(token)) {
+        boolean accepted;
+        try {
+            accepted = authService.acceptTerms(token);
+        } catch (OAuth2AuthenticationException ex) {
+            // The session belongs to an account this school's sign-in rules no longer allow.
+            // Left to propagate it would be resolved by the security entry point as a bodyless
+            // 401, so the student would just be signed out with no idea why.
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, ex.getError().getDescription());
+        }
+        if (!accepted) {
             log.warn("Terms acceptance could not be recorded for the current session");
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
                 "Terms acceptance could not be recorded, please try again");

--- a/backend/src/main/java/com/example/demo/auth/service/AuthService.java
+++ b/backend/src/main/java/com/example/demo/auth/service/AuthService.java
@@ -9,6 +9,7 @@ import com.example.demo.auth.model.AuthProvider;
 import com.example.demo.auth.model.AuthUser;
 import com.example.demo.auth.mapper.OAuthUserMapper;
 import com.example.demo.security.AuthenticatedUserResolver;
+import com.example.demo.security.LoginEligibilityPolicy;
 import com.example.demo.user.service.UserService;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
@@ -27,6 +28,7 @@ public class AuthService {
     private final UserService userService;
     private final OAuthUserMapper oAuthUserMapper;
     private final AuthenticatedUserResolver authenticatedUserResolver;
+    private final LoginEligibilityPolicy loginEligibilityPolicy;
     private final String authorizationRequestBaseUri;
 
     public AuthService(ClientRegistrationRepository clientRegistrationRepository,
@@ -34,7 +36,8 @@ public class AuthService {
                        OAuthUserService oAuthUserService,
                        SecurityProperties securityProperties,
                        UserService userService,
-                       AuthenticatedUserResolver authenticatedUserResolver) {
+                       AuthenticatedUserResolver authenticatedUserResolver,
+                       LoginEligibilityPolicy loginEligibilityPolicy) {
         if (clientRegistrationRepository instanceof Iterable<?>) {
             this.clientRegistrations = (Iterable<ClientRegistration>) clientRegistrationRepository;
         } else {
@@ -45,6 +48,7 @@ public class AuthService {
         this.userService = userService;
         this.oAuthUserMapper = oAuthUserMapper;
         this.authenticatedUserResolver = authenticatedUserResolver;
+        this.loginEligibilityPolicy = loginEligibilityPolicy;
         this.authorizationRequestBaseUri = resolveAuthorizationRequestBaseUri(securityProperties);
     }
 
@@ -121,6 +125,10 @@ public class AuthService {
         if (email == null) {
             return false;
         }
+        // The replay below re-creates an oauth_users row from the session principal, so it has
+        // to answer the same question the login path does: a session that predates a newly
+        // enabled sign-in restriction must not be able to write itself back in through it.
+        loginEligibilityPolicy.verifyEligible(attributes);
         oAuthUserService.ensureStoredUser(authentication.getAuthorizedClientRegistrationId(), attributes);
         int updated = oAuthUserMapper.acceptTerms(email);
         return updated > 0 || hasAcceptedTerms(email);

--- a/backend/src/main/java/com/example/demo/security/CustomOidcUserService.java
+++ b/backend/src/main/java/com/example/demo/security/CustomOidcUserService.java
@@ -1,0 +1,66 @@
+package com.example.demo.security;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+
+import com.example.demo.auth.service.OAuthUserService;
+
+/**
+ * The OpenID Connect counterpart of {@link CustomOAuth2UserService}, and the one that actually
+ * runs for Google.
+ *
+ * <p>The Google registration requests the {@code openid} scope, so Spring Security authenticates
+ * the callback with its OIDC provider and its {@link OidcUserService} -- it never calls the
+ * plain {@code OAuth2UserService} configured through {@code userInfoEndpoint().userService(...)}.
+ * Both services therefore have to enforce the same two things, or a login through the provider
+ * this school actually uses would skip them entirely: the school's sign-in restrictions, and
+ * recording the login.
+ *
+ * <p>Delegates to {@link OidcUserService} rather than extending it so the delegate can be
+ * replaced in tests, where calling the real one would hit the provider's userinfo endpoint.
+ */
+@Service
+public class CustomOidcUserService implements OAuth2UserService<OidcUserRequest, OidcUser> {
+
+    private final OAuth2UserService<OidcUserRequest, OidcUser> delegate;
+    private final OAuthUserService oAuthUserService;
+    private final LoginEligibilityPolicy loginEligibilityPolicy;
+
+    @Autowired
+    public CustomOidcUserService(OAuthUserService oAuthUserService,
+                                 LoginEligibilityPolicy loginEligibilityPolicy) {
+        this(new OidcUserService(), oAuthUserService, loginEligibilityPolicy);
+    }
+
+    /** Test seam: lets the userinfo call be stubbed instead of hitting the provider. */
+    CustomOidcUserService(OAuth2UserService<OidcUserRequest, OidcUser> delegate,
+                          OAuthUserService oAuthUserService,
+                          LoginEligibilityPolicy loginEligibilityPolicy) {
+        this.delegate = delegate;
+        this.oAuthUserService = oAuthUserService;
+        this.loginEligibilityPolicy = loginEligibilityPolicy;
+    }
+
+    @Override
+    public OidcUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
+        OidcUser oidcUser = delegate.loadUser(userRequest);
+
+        Map<String, Object> claims = oidcUser.getClaims();
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        // Before recordLogin, for the same reason as in CustomOAuth2UserService: a rejected
+        // account must not leave an oauth_users row behind, since that row is what every later
+        // lookup keys on. The standard OIDC claims (sub, email, name, picture) are exactly the
+        // ones recordLogin and AuthService already read, so no normalization is needed here.
+        loginEligibilityPolicy.verifyEligible(claims);
+        oAuthUserService.recordLogin(registrationId, claims);
+
+        return oidcUser;
+    }
+}

--- a/backend/src/main/java/com/example/demo/security/LoginEligibilityPolicy.java
+++ b/backend/src/main/java/com/example/demo/security/LoginEligibilityPolicy.java
@@ -36,9 +36,12 @@ public class LoginEligibilityPolicy {
     public static final String EMAIL_NOT_VERIFIED = "email_not_verified";
 
     private final SecurityProperties securityProperties;
+    private final AuthenticatedUserResolver authenticatedUserResolver;
 
-    public LoginEligibilityPolicy(SecurityProperties securityProperties) {
+    public LoginEligibilityPolicy(SecurityProperties securityProperties,
+                                  AuthenticatedUserResolver authenticatedUserResolver) {
         this.securityProperties = securityProperties;
+        this.authenticatedUserResolver = authenticatedUserResolver;
     }
 
     /**
@@ -75,13 +78,11 @@ public class LoginEligibilityPolicy {
         }
     }
 
+    // Deliberately delegated rather than re-implemented: AuthenticatedUserResolver owns the
+    // owner-email comparison for authorization, and a second copy here would let the two drift
+    // -- this gate would keep admitting an address that authorization treats as an owner.
     private boolean isOwnerEmail(String email) {
-        if (!StringUtils.hasText(email)) {
-            return false;
-        }
-        return securityProperties.getOwnerEmails().stream()
-            .filter(StringUtils::hasText)
-            .anyMatch(owner -> owner.trim().equalsIgnoreCase(email.trim()));
+        return authenticatedUserResolver.isPlatformOwner(email);
     }
 
     private static boolean isEmailExplicitlyUnverified(Map<String, Object> attributes) {

--- a/backend/src/main/java/com/example/demo/security/LoginEligibilityPolicy.java
+++ b/backend/src/main/java/com/example/demo/security/LoginEligibilityPolicy.java
@@ -48,8 +48,19 @@ public class LoginEligibilityPolicy {
      */
     public void verifyEligible(Map<String, Object> attributes) {
         SecurityProperties.Login login = securityProperties.getLogin();
+        String email = emailOf(attributes);
 
         if (login.isRequireVerifiedEmail() && !isEmailVerified(attributes)) {
+            throw reject(EMAIL_NOT_VERIFIED,
+                "This account's email address is not verified with its provider.");
+        }
+
+        // Platform-owner status is decided by comparing this address against
+        // app.security.owner-emails, and it is the highest privilege in the application, so an
+        // address the provider explicitly reports as unverified may never be used to claim it --
+        // whatever require-verified-email is set to. An absent claim is not "unverified" and is
+        // left alone, so a provider that does not send it cannot lock the owner out.
+        if (isOwnerEmail(email) && isEmailExplicitlyUnverified(attributes)) {
             throw reject(EMAIL_NOT_VERIFIED,
                 "This account's email address is not verified with its provider.");
         }
@@ -58,10 +69,27 @@ public class LoginEligibilityPolicy {
         if (allowedDomains.isEmpty()) {
             return;
         }
-        if (!isDomainAllowed(emailOf(attributes), allowedDomains)) {
+        if (!isDomainAllowed(email, allowedDomains)) {
             throw reject(EMAIL_DOMAIN_NOT_ALLOWED,
                 "This site is limited to accounts from a specific email domain.");
         }
+    }
+
+    private boolean isOwnerEmail(String email) {
+        if (!StringUtils.hasText(email)) {
+            return false;
+        }
+        return securityProperties.getOwnerEmails().stream()
+            .filter(StringUtils::hasText)
+            .anyMatch(owner -> owner.trim().equalsIgnoreCase(email.trim()));
+    }
+
+    private static boolean isEmailExplicitlyUnverified(Map<String, Object> attributes) {
+        Object verified = attributes == null ? null : attributes.get("email_verified");
+        if (verified == null) {
+            return false;
+        }
+        return !isEmailVerified(attributes);
     }
 
     private static boolean isEmailVerified(Map<String, Object> attributes) {

--- a/backend/src/test/java/com/example/demo/security/CustomOidcUserServiceTest.java
+++ b/backend/src/test/java/com/example/demo/security/CustomOidcUserServiceTest.java
@@ -56,7 +56,7 @@ class CustomOidcUserServiceTest {
         OAuthUserService oAuthUserService = mock(OAuthUserService.class);
 
         return new Fixture(
-            new CustomOidcUserService(delegate, oAuthUserService, new LoginEligibilityPolicy(properties)),
+            new CustomOidcUserService(delegate, oAuthUserService, new LoginEligibilityPolicy(properties, new AuthenticatedUserResolver(properties))),
             oAuthUserService);
     }
 

--- a/backend/src/test/java/com/example/demo/security/CustomOidcUserServiceTest.java
+++ b/backend/src/test/java/com/example/demo/security/CustomOidcUserServiceTest.java
@@ -1,0 +1,121 @@
+package com.example.demo.security;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import com.example.demo.auth.config.SecurityProperties;
+import com.example.demo.auth.service.OAuthUserService;
+
+/**
+ * Google requests the {@code openid} scope, so this is the service Spring Security actually
+ * calls at login -- {@link CustomOAuth2UserService} is never reached for it. Everything the
+ * login path must do therefore has to be enforced here too.
+ */
+class CustomOidcUserServiceTest {
+
+    private static OidcUser oidcUser(String email, Object emailVerified) {
+        Map<String, Object> claims = Map.of(
+            "sub", "google-123",
+            "email", email,
+            "email_verified", emailVerified,
+            "name", "Ada Lovelace");
+        OidcIdToken idToken = new OidcIdToken(
+            "token-value", Instant.now(), Instant.now().plusSeconds(3600), claims);
+        return new DefaultOidcUser(List.of(() -> "ROLE_USER"), idToken, "sub");
+    }
+
+    private record Fixture(CustomOidcUserService service, OAuthUserService oAuthUserService) {
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Fixture fixture(List<String> allowedDomains, List<String> ownerEmails, OidcUser user) {
+        SecurityProperties properties = new SecurityProperties();
+        properties.getLogin().setAllowedEmailDomains(allowedDomains);
+        properties.setOwnerEmails(ownerEmails);
+
+        OAuth2UserService<OidcUserRequest, OidcUser> delegate = mock(OAuth2UserService.class);
+        when(delegate.loadUser(any())).thenReturn(user);
+        OAuthUserService oAuthUserService = mock(OAuthUserService.class);
+
+        return new Fixture(
+            new CustomOidcUserService(delegate, oAuthUserService, new LoginEligibilityPolicy(properties)),
+            oAuthUserService);
+    }
+
+    private static OidcUserRequest request() {
+        OidcUserRequest request = mock(OidcUserRequest.class);
+        org.springframework.security.oauth2.client.registration.ClientRegistration registration =
+            org.springframework.security.oauth2.client.registration.ClientRegistration
+                .withRegistrationId("google")
+                .clientId("client-id")
+                .authorizationGrantType(
+                    org.springframework.security.oauth2.core.AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("http://localhost/api/auth/google/callback")
+                .authorizationUri("https://accounts.google.com/o/oauth2/v2/auth")
+                .tokenUri("https://oauth2.googleapis.com/token")
+                .build();
+        when(request.getClientRegistration()).thenReturn(registration);
+        return request;
+    }
+
+    @Test
+    void recordsTheLoginForAnAllowedAccount() {
+        Fixture fixture = fixture(List.of("students.example.edu"), List.of(),
+            oidcUser("ada@students.example.edu", true));
+
+        assertThatCode(() -> fixture.service().loadUser(request())).doesNotThrowAnyException();
+
+        verify(fixture.oAuthUserService()).recordLogin(eq("google"), any());
+    }
+
+    // The whole point of routing OIDC through this service: without it a restricted school's
+    // sign-in rules would not apply to Google logins at all.
+    @Test
+    void rejectsAnAccountFromAnotherDomainAndStoresNothing() {
+        Fixture fixture = fixture(List.of("students.example.edu"), List.of(),
+            oidcUser("stranger@gmail.com", true));
+
+        assertThatThrownBy(() -> fixture.service().loadUser(request()))
+            .isInstanceOf(OAuth2AuthenticationException.class);
+
+        verify(fixture.oAuthUserService(), never()).recordLogin(any(), any());
+    }
+
+    // Owner status is the highest privilege here and is decided purely by the email address.
+    @Test
+    void rejectsAnOwnerAddressTheProviderReportsAsUnverified() {
+        Fixture fixture = fixture(List.of(), List.of("owner@example.com"),
+            oidcUser("owner@example.com", false));
+
+        assertThatThrownBy(() -> fixture.service().loadUser(request()))
+            .isInstanceOf(OAuth2AuthenticationException.class);
+
+        verify(fixture.oAuthUserService(), never()).recordLogin(any(), any());
+    }
+
+    @Test
+    void anOrdinaryUnverifiedAccountIsStillAllowedWhenNothingRequiresVerification() {
+        Fixture fixture = fixture(List.of(), List.of("owner@example.com"),
+            oidcUser("student@gmail.com", false));
+
+        assertThatCode(() -> fixture.service().loadUser(request())).doesNotThrowAnyException();
+    }
+}

--- a/backend/src/test/java/com/example/demo/security/LoginEligibilityPolicyTest.java
+++ b/backend/src/test/java/com/example/demo/security/LoginEligibilityPolicyTest.java
@@ -23,7 +23,7 @@ class LoginEligibilityPolicyTest {
         properties.getLogin().setAllowedEmailDomains(allowedDomains);
         properties.getLogin().setRequireVerifiedEmail(requireVerifiedEmail);
         properties.setOwnerEmails(ownerEmails);
-        return new LoginEligibilityPolicy(properties);
+        return new LoginEligibilityPolicy(properties, new AuthenticatedUserResolver(properties));
     }
 
     private static Map<String, Object> account(String email, Object emailVerified) {

--- a/backend/src/test/java/com/example/demo/security/LoginEligibilityPolicyTest.java
+++ b/backend/src/test/java/com/example/demo/security/LoginEligibilityPolicyTest.java
@@ -14,9 +14,15 @@ import com.example.demo.auth.config.SecurityProperties;
 class LoginEligibilityPolicyTest {
 
     private static LoginEligibilityPolicy policy(List<String> allowedDomains, boolean requireVerifiedEmail) {
+        return policy(allowedDomains, requireVerifiedEmail, List.of());
+    }
+
+    private static LoginEligibilityPolicy policy(List<String> allowedDomains, boolean requireVerifiedEmail,
+                                                 List<String> ownerEmails) {
         SecurityProperties properties = new SecurityProperties();
         properties.getLogin().setAllowedEmailDomains(allowedDomains);
         properties.getLogin().setRequireVerifiedEmail(requireVerifiedEmail);
+        properties.setOwnerEmails(ownerEmails);
         return new LoginEligibilityPolicy(properties);
     }
 
@@ -95,5 +101,31 @@ class LoginEligibilityPolicyTest {
     void treatsAMissingVerifiedClaimAsNotVerifiedWhenTheCheckIsOn() {
         assertThatThrownBy(() -> policy(List.of(), true).verifyEligible(Map.of("email", "ada@gmail.com")))
             .isInstanceOf(OAuth2AuthenticationException.class);
+    }
+
+    // Platform-owner status is decided purely by comparing this address, and it is the highest
+    // privilege in the application, so an address the provider says is unverified must never be
+    // able to claim it -- whatever require-verified-email is set to.
+    @Test
+    void anOwnerAddressReportedAsUnverifiedIsRejectedEvenWithVerificationOff() {
+        assertThatThrownBy(() -> policy(List.of(), false, List.of("owner@example.com"))
+            .verifyEligible(account("owner@example.com", false)))
+            .isInstanceOf(OAuth2AuthenticationException.class)
+            .hasMessageContaining("not verified");
+    }
+
+    // A provider that does not send the claim at all must not be able to lock the owner out.
+    @Test
+    void anOwnerAddressWithNoVerifiedClaimIsStillAllowed() {
+        assertThatCode(() -> policy(List.of(), false, List.of("owner@example.com"))
+            .verifyEligible(Map.of("email", "owner@example.com")))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void anOrdinaryUnverifiedAccountIsUnaffectedByTheOwnerRule() {
+        assertThatCode(() -> policy(List.of(), false, List.of("owner@example.com"))
+            .verifyEligible(account("student@gmail.com", false)))
+            .doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
Found by the final audit sweep. **This is a real hole in #100 as shipped.**

## The bug

The Google registration requests the `openid` scope, so Spring Security authenticates the callback with its OIDC provider and `OidcUserService`. Only the plain `OAuth2UserService` was wired (`userInfoEndpoint().userService(...)`), and the OIDC path never calls it -- so `CustomOAuth2UserService` was dead code for the one provider this site uses. That means the whole `allowed-email-domains` / `require-verified-email` feature **and** the login record were unreachable: setting `APP_ALLOWED_EMAIL_DOMAINS` would have silently done nothing.

(The app still worked because `oauth_users` rows are also created by the accept-terms replay path.)

## Fix

- New `CustomOidcUserService` wired through `oidcUserService()`, enforcing exactly what the OAuth2 path enforces: eligibility first, then `recordLogin`. It delegates to `OidcUserService` rather than extending it, so the userinfo call can be stubbed in tests. The standard OIDC claims (`sub`, `email`, `name`, `picture`) are the same ones `recordLogin` and `AuthService` already read, so this path needs no attribute normalization.
- **Owner elevation on an unverified address**: an address the provider explicitly reports as unverified can no longer claim platform-owner status, whatever `require-verified-email` is set to -- owner status is decided purely by comparing that address and is the highest privilege here. An *absent* claim is not treated as unverified, so a provider that omits it cannot lock the owner out.
- **The replay path**: `AuthService.acceptTerms` re-creates a missing `oauth_users` row from the session principal; it now runs the same eligibility check, so a session predating a newly enabled restriction cannot write itself back in.

## Verification

- New `CustomOidcUserServiceTest`: an allowed account is recorded, a disallowed domain throws and stores nothing, an unverified owner address is rejected, an ordinary unverified account is unaffected.
- `LoginEligibilityPolicyTest` gains the three owner-address cases.
- Full `mvnw test`: 461 tests, only the 8 pre-existing Windows-only failures (#109).