### PR TITLE
Audit fixes: club state handling, upload cleanup scope, summary cache, avatar future

### DIFF
--- a/backend/src/main/java/com/example/demo/club/controller/ClubController.java
+++ b/backend/src/main/java/com/example/demo/club/controller/ClubController.java
@@ -194,6 +194,13 @@ public class ClubController {
         if (club == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
         }
+        // Same policy and same 404 as the detail endpoint: resolveClub carries no status
+        // filter, so without this a caller who guesses an id could apply to a club that is
+        // archived or still pending -- landing in a president's request queue for a club the
+        // directory says does not exist, and which they cannot even open.
+        if (!clubVisibilityPolicy.isVisibleTo(club, authentication)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Club not found");
+        }
         try {
             clubService.applyForMembership(club.getId(), viewerEmail);
         } catch (IllegalArgumentException ex) {

--- a/backend/src/main/java/com/example/demo/club/service/ClubService.java
+++ b/backend/src/main/java/com/example/demo/club/service/ClubService.java
@@ -256,9 +256,19 @@ public class ClubService {
      * reach: a president must not be able to publish or hide their own club.
      */
     public Club archive(Long id) {
-        if (clubMapper.updateStatus(id, ARCHIVED_STATUS) == 0) {
+        Club existing = clubMapper.findById(id);
+        if (existing == null) {
             throw new IllegalArgumentException("Club not found");
         }
+        // Only an active (or already archived, so this stays idempotent) club can be archived.
+        // Archiving something in another state -- a pending club, say -- would overwrite the
+        // only record of that state, and restore() would then happily publish it, which is
+        // exactly what restore()'s own guard exists to prevent.
+        if (!ACTIVE_STATUS.equalsIgnoreCase(existing.getStatus())
+            && !ARCHIVED_STATUS.equalsIgnoreCase(existing.getStatus())) {
+            throw new IllegalStateException("Only an active club can be archived");
+        }
+        clubMapper.updateStatus(id, ARCHIVED_STATUS);
         return clubMapper.findById(id);
     }
 

--- a/backend/src/main/java/com/example/demo/club/service/InstagramAvatarCacheService.java
+++ b/backend/src/main/java/com/example/demo/club/service/InstagramAvatarCacheService.java
@@ -495,9 +495,11 @@ public class InstagramAvatarCacheService {
             // Never leave the future incomplete: joiners park on it with no timeout, so an
             // Error escaping this method (an OutOfMemoryError during a decode, say) would
             // otherwise strand every request thread already waiting on this handle for the
-            // life of the process. Completing it here is a no-op on the paths above.
-            future.completeExceptionally(
-                new IOException("Avatar refresh for " + safeHandle + " ended without a result"));
+            // life of the process.
+            if (!future.isDone()) {
+                future.completeExceptionally(
+                    new IOException("Avatar refresh for " + safeHandle + " ended without a result"));
+            }
             inFlightRefreshes.remove(safeHandle, future);
         }
     }

--- a/backend/src/main/java/com/example/demo/club/service/InstagramAvatarCacheService.java
+++ b/backend/src/main/java/com/example/demo/club/service/InstagramAvatarCacheService.java
@@ -492,6 +492,12 @@ public class InstagramAvatarCacheService {
             future.completeExceptionally(ex);
             throw ex;
         } finally {
+            // Never leave the future incomplete: joiners park on it with no timeout, so an
+            // Error escaping this method (an OutOfMemoryError during a decode, say) would
+            // otherwise strand every request thread already waiting on this handle for the
+            // life of the process. Completing it here is a no-op on the paths above.
+            future.completeExceptionally(
+                new IOException("Avatar refresh for " + safeHandle + " ended without a result"));
             inFlightRefreshes.remove(safeHandle, future);
         }
     }

--- a/backend/src/main/java/com/example/demo/club/service/UploadCleanupService.java
+++ b/backend/src/main/java/com/example/demo/club/service/UploadCleanupService.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -39,6 +40,16 @@ public class UploadCleanupService {
     // also sweep up completely unrelated subsystems that happen to live under the same root,
     // notably avatar-cache/instagram/ (InstagramAvatarCacheService).
     private static final String CLUB_POSTS_SUBDIRECTORY = "club-posts";
+
+    // ...and, at the top level, only files this application could itself have written: a
+    // UUID name with an image extension, matching ImageStorageService's own delete guard.
+    // Files.list() returns every regular file directly under the upload root, so without this
+    // the job would also reclaim anything an operator or another subsystem happens to keep
+    // there (an .env copy, a README, a database dump) purely because no club row points at it.
+    private static final Pattern GENERATED_FLAT_FILE_NAME = Pattern.compile(
+        "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+            + "\\.(?:jpg|jpeg|png|webp|gif)$",
+        Pattern.CASE_INSENSITIVE);
 
     // Files must be at least this old to be reclaimed. A file can land on disk moments before
     // its row commits; listing files before querying the database (below) already narrows that
@@ -99,7 +110,10 @@ public class UploadCleanupService {
 
     private List<Path> listLegacyFlatFiles() {
         try (Stream<Path> topLevel = Files.list(uploadDir)) {
-            return topLevel.filter(Files::isRegularFile).collect(Collectors.toList());
+            return topLevel
+                .filter(Files::isRegularFile)
+                .filter(file -> GENERATED_FLAT_FILE_NAME.matcher(file.getFileName().toString()).matches())
+                .collect(Collectors.toList());
         } catch (IOException e) {
             log.error("Failed to list upload directory for cleanup", e);
             return List.of();

--- a/backend/src/main/java/com/example/demo/summary/service/SummaryService.java
+++ b/backend/src/main/java/com/example/demo/summary/service/SummaryService.java
@@ -36,6 +36,7 @@ public class SummaryService {
     private final String slug;
     private final Duration cacheTtl;
     private final AtomicReference<CachedSummary> cached = new AtomicReference<>();
+    private final Object refreshLock = new Object();
 
     public SummaryService(ClubMapper clubMapper,
                           @Value("${app.summary.school-name:HS Clubs}") String schoolName,
@@ -54,9 +55,20 @@ public class SummaryService {
         if (snapshot != null && !snapshot.isExpired(cacheTtl)) {
             return snapshot.summary();
         }
-        SummaryResponse summary = computeSummary();
-        cached.set(new CachedSummary(summary, System.nanoTime()));
-        return summary;
+        // Single-flight: without this, every request in flight when the TTL expires (or on a
+        // cold start) runs its own query, which is exactly the burst the cache exists to
+        // absorb -- and this endpoint is unauthenticated, so the burst size is whatever the
+        // servlet pool allows. The second checked read inside the lock is what makes the
+        // losers reuse the winner's result instead of repeating it.
+        synchronized (refreshLock) {
+            CachedSummary current = cached.get();
+            if (current != null && !current.isExpired(cacheTtl)) {
+                return current.summary();
+            }
+            SummaryResponse summary = computeSummary();
+            cached.set(new CachedSummary(summary, System.nanoTime()));
+            return summary;
+        }
     }
 
     private SummaryResponse computeSummary() {

--- a/backend/src/main/resources/mapper/ClubMapper.xml
+++ b/backend/src/main/resources/mapper/ClubMapper.xml
@@ -231,6 +231,12 @@
              upload path, never through this general club-editing form: writing it from this
              statement would let a manager set their own club's imageUrl to another club's
              real, guessable stored image path via a PUT request body. -->
+        <!-- status, visibility, approved_at and approved_by_oauth_user_id are not written here
+             either, for the same reason and one more: a club president reaches this statement
+             through PUT /api/clubs/{id}. The service already refuses to take those fields from
+             the request body, but it still carried the values it read a moment earlier, so an
+             edit that raced a platform owner's archive would write the club back to active.
+             Status changes only through updateStatus (the archive endpoints). -->
         UPDATE clubs
         SET name = #{name},
             slug = #{slug},
@@ -243,10 +249,6 @@
             contact_email = #{contactEmail},
             advisor = #{advisor},
             achievements = #{achievements, typeHandler=com.example.demo.club.mapper.AchievementsTypeHandler},
-            status = #{status},
-            visibility = #{visibility},
-            approved_at = #{approvedAt},
-            approved_by_oauth_user_id = #{approvedByOauthUserId},
             updated_at = CURRENT_TIMESTAMP
         WHERE id = #{id}
     </update>

--- a/backend/src/test/java/com/example/demo/club/controller/ClubControllerTest.java
+++ b/backend/src/test/java/com/example/demo/club/controller/ClubControllerTest.java
@@ -3,6 +3,7 @@ package com.example.demo.club.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -134,6 +135,19 @@ class ClubControllerTest {
 
         mockMvc.perform(post("/api/clubs/1/members/apply").principal(oauthToken(STUDENT_EMAIL)))
             .andExpect(status().isConflict());
+    }
+
+    // The apply endpoint resolves the club without a status filter, so it has to run the same
+    // visibility policy the detail endpoint does: otherwise a guessed id lands a request in a
+    // president's queue for a club the directory says does not exist.
+    @Test
+    void applyingToANonActiveClubIsANotFoundForANonMember() throws Exception {
+        when(clubService.resolveBySlugOrId(eq("7"), any())).thenReturn(nonActiveClub());
+
+        mockMvc.perform(post("/api/clubs/7/members/apply").principal(oauthToken(STUDENT_EMAIL)))
+            .andExpect(status().isNotFound());
+
+        verify(clubService, never()).applyForMembership(any(), any());
     }
 
     // ---- Detail visibility ----

--- a/backend/src/test/java/com/example/demo/club/mapper/ClubMapperTest.java
+++ b/backend/src/test/java/com/example/demo/club/mapper/ClubMapperTest.java
@@ -207,6 +207,29 @@ class ClubMapperTest {
         assertThat(clubMapper.findAllPaginated(0, 10)).hasSize(1);
     }
 
+    // A club president reaches update() through PUT /api/clubs/{id}. The service refuses to
+    // take these fields from the request body, but it used to write back the values it had
+    // read a moment earlier, so an edit racing a platform owner's archive re-published the
+    // club. The statement simply does not touch them any more.
+    @Test
+    void updateNeverWritesStatusVisibilityOrTheApprovalColumns() {
+        insertSearchableClub();
+        clubMapper.updateStatus(4L, "archived");
+
+        Club edit = clubMapper.findById(4L);
+        edit.setName("Chess Team");
+        edit.setStatus("active");
+        edit.setVisibility("private");
+        edit.setApprovedByOauthUserId(99L);
+        clubMapper.update(edit);
+
+        Club stored = clubMapper.findById(4L);
+        assertThat(stored.getName()).isEqualTo("Chess Team");
+        assertThat(stored.getStatus()).isEqualTo("archived");
+        assertThat(stored.getVisibility()).isEqualTo("public");
+        assertThat(stored.getApprovedByOauthUserId()).isNull();
+    }
+
     // ---- Bounded public queries (#104) ----
 
     @Test

--- a/backend/src/test/java/com/example/demo/club/service/ClubServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/ClubServiceTest.java
@@ -256,7 +256,7 @@ class ClubServiceTest {
     // so archiving has to go through the column-scoped statement instead.
     @Test
     void archiveWritesOnlyTheStatusColumnAndNeverTheGeneralUpdate() {
-        when(clubMapper.updateStatus(7L, "archived")).thenReturn(1);
+        when(clubMapper.findById(7L)).thenReturn(storedClub());
 
         clubService.archive(7L);
 
@@ -288,6 +288,32 @@ class ClubServiceTest {
             .hasMessageContaining("archived");
 
         verify(clubMapper, never()).updateStatus(any(), any());
+    }
+
+    // Otherwise restore()'s guard is trivially bypassed: archive a pending club, and the only
+    // record of that state is gone, so restoring it publishes something never approved.
+    @Test
+    void archiveRefusesAClubThatIsNeitherActiveNorAlreadyArchived() {
+        Club pending = storedClub();
+        pending.setStatus("pending");
+        when(clubMapper.findById(7L)).thenReturn(pending);
+
+        assertThatThrownBy(() -> clubService.archive(7L))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("active");
+
+        verify(clubMapper, never()).updateStatus(any(), any());
+    }
+
+    @Test
+    void archivingAnAlreadyArchivedClubStaysIdempotent() {
+        Club archived = storedClub();
+        archived.setStatus("archived");
+        when(clubMapper.findById(7L)).thenReturn(archived);
+
+        clubService.archive(7L);
+
+        verify(clubMapper).updateStatus(7L, "archived");
     }
 
     @Test

--- a/backend/src/test/java/com/example/demo/club/service/UploadCleanupServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/UploadCleanupServiceTest.java
@@ -18,17 +18,23 @@ import org.junit.jupiter.api.io.TempDir;
 
 class UploadCleanupServiceTest {
 
+    // Cleanup only owns top-level files this application could itself have written, i.e. the
+    // UUID names ImageStorageService produces -- see the non-generated-name test below.
+    private static final String STILL_USED_FLAT_FILE = "11111111-1111-4111-8111-111111111111.png";
+    private static final String ORPHAN_FLAT_FILE = "22222222-2222-4222-8222-222222222222.png";
+    private static final String LEGACY_ORPHAN_FLAT_FILE = "33333333-3333-4333-8333-333333333333.png";
+
     @TempDir
     Path uploadDir;
 
     @Test
     void doesNotDeleteAnImageStillUsedByAnArchivedClub() throws Exception {
-        Path stillUsed = ageFile(uploadDir.resolve("still-used.png"));
-        Path orphan = ageFile(uploadDir.resolve("orphan.png"));
+        Path stillUsed = ageFile(uploadDir.resolve(STILL_USED_FLAT_FILE));
+        Path orphan = ageFile(uploadDir.resolve(ORPHAN_FLAT_FILE));
 
         Club archivedClub = new Club();
         archivedClub.setStatus("archived");
-        archivedClub.setImageUrl("/uploads/still-used.png");
+        archivedClub.setImageUrl("/uploads/" + STILL_USED_FLAT_FILE);
 
         ClubMapper clubMapper = mock(ClubMapper.class);
         when(clubMapper.findAllRegardlessOfStatus()).thenReturn(List.of(archivedClub));
@@ -99,7 +105,7 @@ class UploadCleanupServiceTest {
 
     @Test
     void stillReclaimsALegacyFlatOrphanDirectlyUnderTheUploadRoot() throws Exception {
-        Path legacyOrphan = ageFile(uploadDir.resolve("legacy-orphan.png"));
+        Path legacyOrphan = ageFile(uploadDir.resolve(LEGACY_ORPHAN_FLAT_FILE));
 
         ClubMapper clubMapper = mock(ClubMapper.class);
         when(clubMapper.findAllRegardlessOfStatus()).thenReturn(List.of());
@@ -111,6 +117,30 @@ class UploadCleanupServiceTest {
         service.cleanOrphanedUploads();
 
         assertThat(Files.exists(legacyOrphan)).isFalse();
+    }
+
+    // Files.list returns every regular file directly under the upload root, so without a name
+    // check this job would reclaim anything an operator or another subsystem keeps there --
+    // a README, an .env copy, a database dump -- purely because no club row points at it.
+    // ImageStorageService's own delete guard is scoped the same way.
+    @Test
+    void neverDeletesATopLevelFileThisApplicationCouldNotHaveWritten() throws Exception {
+        Path operatorFile = ageFile(uploadDir.resolve("README.txt"));
+        Path databaseDump = ageFile(uploadDir.resolve("backup-2026-02-01.sql"));
+        Path notAUuidImage = ageFile(uploadDir.resolve("logo.png"));
+
+        ClubMapper clubMapper = mock(ClubMapper.class);
+        when(clubMapper.findAllRegardlessOfStatus()).thenReturn(List.of());
+        ClubPostMapper clubPostMapper = mock(ClubPostMapper.class);
+        when(clubPostMapper.findAllImageUrls()).thenReturn(List.of());
+
+        UploadCleanupService service = new UploadCleanupService(clubMapper, clubPostMapper, uploadDir.toString());
+
+        service.cleanOrphanedUploads();
+
+        assertThat(Files.exists(operatorFile)).isTrue();
+        assertThat(Files.exists(databaseDump)).isTrue();
+        assertThat(Files.exists(notAUuidImage)).isTrue();
     }
 
     // Guards the race in the issue: a file can land on disk moments before its row commits, so

--- a/docs/API.md
+++ b/docs/API.md
@@ -170,6 +170,10 @@ that was never approved and lose that state for good. Anything else is a 409.
 
 Status: 200 | 403 | 404 | 409 (the club is not archived)
 
+Symmetrically, only an `active` club can be archived (archiving an already-archived one is a
+no-op, so the endpoint stays idempotent). Otherwise the guard above could be side-stepped by
+archiving a `pending` club first, which would overwrite the only record of that state.
+
 ---
 
 ## Club Media (Posts and Comments)
@@ -427,6 +431,10 @@ Both 409 cases are real checks, not just documentation: an existing member (incl
 club's own president) is rejected before a request row is created, and a duplicate request
 that slips past the check-then-insert -- a double-clicked button, or two tabs -- surfaces as
 the same 409 through the unique constraint rather than a 500.
+
+Applying is gated by the same `ClubVisibilityPolicy` as the detail endpoint, so a club that is
+archived or still pending answers 404 here too rather than quietly queueing a request its
+president would see for a club nobody can open.
 
 ### DELETE /api/clubs/{id}/members/apply
 Cancel own membership application. Requires: authenticated.


### PR DESCRIPTION
Six issues the final review sweep confirmed on `main`.

1. **PUT still wrote the status columns.** The service refuses to take `status`/`visibility`/`approved_*` from the request body, but it wrote back the values it had read a moment earlier, so a president's edit racing a platform owner's archive silently republished the club. The update statement no longer touches those columns at all; status changes only through the archive endpoints.
2. **`archive()` accepted any state**, which made `restore()`'s "archived only" guard bypassable: archiving a `pending` club overwrote the only record of that state, and restoring it then published something never approved. Only an active club (or an already-archived one, so the endpoint stays idempotent) can be archived.
3. **Apply ignored visibility.** The endpoint resolved the club without a status filter, so a guessed id could queue a membership request for an archived or pending club whose detail endpoint answers 404 for that same caller. It now runs the same `ClubVisibilityPolicy`.
4. **Upload cleanup was too broad.** It deleted *every* unreferenced regular file directly under the upload root -- a README, an `.env` copy, a database dump -- not just the UUID-named files this application writes. Now scoped to the same shape `ImageStorageService` already refuses to delete outside of. (Behaviour change: the existing tests used arbitrary top-level names and were updated to real generated names, plus a new test for operator files.)
5. **The summary cache did not collapse a burst**: every request in flight when the TTL expired ran its own query, which is exactly what the cache exists to absorb on an unauthenticated endpoint. Single-flight now, with a second checked read inside the lock.
6. **A stranded avatar future.** If the thread owning an in-flight refresh died with an `Error`, the shared future was removed but never completed, and joiners wait on it with no timeout -- so every request already parked on that handle hung for the life of the process. The future is now always completed.

## Verification

- New/updated tests: mapper-level proof that `update` cannot change status/visibility/approval; service tests for the archive state machine (refuses pending, idempotent re-archive); controller test that applying to a non-active club is a 404 and never reaches the service; cleanup test that operator files under the upload root survive.
- Full `mvnw test`: 459 tests, only the 8 pre-existing Windows-only failures (#109).