### PR TITLE
Audit fixes: club editor closes after its own save, and 401s from media calls are ignored

### DIFF
--- a/frontend/src/services/clubPostService.spec.ts
+++ b/frontend/src/services/clubPostService.spec.ts
@@ -8,6 +8,7 @@ import {
   publishClubPost,
   unpinClubPost,
 } from './clubPostService'
+import { setUnauthorizedHandler } from './httpClient'
 
 const jsonResponse = (body: unknown) => ({
   ok: true,
@@ -34,6 +35,59 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals()
+  setUnauthorizedHandler(null)
+})
+
+// A session can die while a student is on the club media page. Without reporting it, the auth
+// store goes on saying they are signed in, the router guards keep admitting them, and every
+// action on the page fails with a raw server error instead of a sign-in prompt.
+describe('unauthorized responses', () => {
+  it('reports a 401 from a media request', async () => {
+    const onUnauthorized = vi.fn()
+    setUnauthorizedHandler(onUnauthorized)
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+      text: async () => 'Unauthorized',
+    })
+
+    await expect(deleteClubPost('1', 9)).rejects.toThrow()
+
+    expect(onUnauthorized).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports a 401 from the multipart publish call', async () => {
+    const onUnauthorized = vi.fn()
+    setUnauthorizedHandler(onUnauthorized)
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+      text: async () => 'Unauthorized',
+    })
+
+    await expect(
+      publishClubPost('1', 'Meeting recap', new File(['image'], 'photo.jpg', { type: 'image/jpeg' })),
+    ).rejects.toThrow()
+
+    expect(onUnauthorized).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not report an ordinary error response', async () => {
+    const onUnauthorized = vi.fn()
+    setUnauthorizedHandler(onUnauthorized)
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 403,
+      headers: { get: () => null },
+      text: async () => 'Members only',
+    })
+
+    await expect(deleteClubPost('1', 9)).rejects.toThrow()
+
+    expect(onUnauthorized).not.toHaveBeenCalled()
+  })
 })
 
 describe('publishClubPost', () => {

--- a/frontend/src/services/clubPostService.ts
+++ b/frontend/src/services/clubPostService.ts
@@ -1,5 +1,5 @@
 import type { ClubPost, ClubPostComment, ClubPostFeedPage } from '../types/clubPost'
-import { buildApiUrl } from './httpClient'
+import { buildApiUrl, notifyIfUnauthorized } from './httpClient'
 import { resolveErrorMessage } from './httpErrorMessage'
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
@@ -9,6 +9,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     credentials: init?.credentials ?? 'include',
   })
   if (!response.ok) {
+    notifyIfUnauthorized(response)
     const message = await resolveErrorMessage(response, `Request failed with status ${response.status}`)
     throw new Error(message)
   }
@@ -52,6 +53,7 @@ export const publishClubPost = async (
     body: formData,
   })
   if (!response.ok) {
+    notifyIfUnauthorized(response)
     const message = await resolveErrorMessage(response, `Request failed with status ${response.status}`)
     throw new Error(message)
   }

--- a/frontend/src/views/ClubAdminView.spec.ts
+++ b/frontend/src/views/ClubAdminView.spec.ts
@@ -145,6 +145,23 @@ describe('ClubAdminView member count', () => {
     expect(wrapper.find('form.admin-form').exists()).toBe(true)
   })
 
+  // The update endpoint answers with the stored row, which carries no viewer-scoped fields.
+  // Assigning it wholesale erased canManage, so a *successful* save flipped a club president
+  // straight into the "you do not manage this club" notice.
+  it('keeps the editor open after a successful save by a club president', async () => {
+    const club = buildClub({ canManage: true })
+    const { canManage: _ignored, ...storedRowFromUpdate } = buildClub({ name: 'Chess Team' })
+    updateClubMock.mockResolvedValue(storedRowFromUpdate as Club)
+
+    const wrapper = await mountView(club)
+    await wrapper.find('form.admin-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Changes saved')
+    expect(wrapper.find('form.admin-form').exists()).toBe(true)
+    expect(wrapper.text()).not.toContain('You do not manage')
+  })
+
   it('refreshes the club snapshot and invalidates list caches after assigning a president', async () => {
     const club = buildClub({ memberCount: 42, canManage: true })
     const refreshedClub = buildClub({ memberCount: 43, canManage: true })

--- a/frontend/src/views/ClubAdminView.vue
+++ b/frontend/src/views/ClubAdminView.vue
@@ -14,7 +14,7 @@ import type { Club, ClubMember } from '../types/club'
 import type { UserSearchResult } from '../services/userService'
 import { useAuthStore } from '../stores/auth'
 import { clubCategoryOptions } from '../utils/clubCategories'
-import { buildApiUrl } from '../services/httpClient'
+import { buildApiUrl, notifyIfUnauthorized } from '../services/httpClient'
 import { resolveErrorMessage } from '../services/httpErrorMessage'
 import { clubImage } from '../utils/clubImages'
 import { userAvatar } from '../utils/avatarImages'
@@ -236,6 +236,15 @@ const handleMemberRoleChange = async (member: ClubMember, event: Event) => {
   }
 }
 
+// The fields the API only fills in on a *read* for the current viewer. Any response that is a
+// plain stored row (the update endpoint) has to be merged with these rather than replacing them.
+const viewerContextOf = (current: Club) => ({
+  canManage: current.canManage,
+  viewerIsMember: current.viewerIsMember,
+  viewerRole: current.viewerRole,
+  viewerHasPendingRequest: current.viewerHasPendingRequest,
+})
+
 const refreshClubSnapshot = async () => {
   if (!club.value) {
     return
@@ -273,6 +282,7 @@ const handleImageUpload = async (event: Event) => {
       credentials: 'include',
       body: formData})
     if (!response.ok) {
+      notifyIfUnauthorized(response)
       const msg = await resolveErrorMessage(response, 'Upload failed')
       throw new Error(msg)
     }
@@ -317,7 +327,11 @@ const handleSave = async () => {
       imageUrl: form.imageUrl || null}
 
     const updated = await updateClub(club.value.id, payload)
-    club.value = updated
+    // The update endpoint answers with the stored row, which carries no viewer-scoped fields:
+    // canManage/viewerIsMember/viewerRole are only populated on the read path. Assigning it
+    // wholesale erased canManage, so a successful save flipped a club president straight into
+    // the "you do not manage this club" notice.
+    club.value = { ...updated, ...viewerContextOf(club.value) }
     hydrateForm(updated)
     successMessage.value = 'Changes saved'
   } catch (err) {


### PR DESCRIPTION
Two frontend findings from the final audit sweep.

## 1. A successful save flipped a president into the read-only notice

`PUT /api/clubs/{id}` answers with the stored row, which carries **no viewer-scoped fields** -- `canManage`, `viewerIsMember` and `viewerRole` are only populated on the read path. `ClubAdminView` assigned that response straight to `club.value`, erasing `canManage`, and the gate added in #107 then hid the editor from the very person who had just used it. (Before that gate the same bug only hid the roster section, which is why it went unnoticed.)

The response is now merged over the viewer context instead of replacing it.

## 2. 401s from the media calls never reached the auth store

`clubPostService`'s request helper, its multipart publish call, and `ClubAdminView`'s raw image-upload `fetch` never called `notifyIfUnauthorized`, so a session that died while a student was on the club media page or uploading an image left the store believing they were still signed in: the router guards kept admitting them and every action failed with a raw server error instead of a sign-in prompt.

## Verification

- `ClubAdminView.spec.ts`: a president's save keeps the editor open and never shows the notice, with the update response deliberately built **without** `canManage` to reproduce the real payload.
- `clubPostService.spec.ts`: a 401 from a media request and from the multipart publish both report to the handler; a 403 does not.
- Frontend: 279 tests pass, `type-check` and `build` clean.