### PR TITLE
Make the Instaloader tests run on Windows

### DIFF
--- a/backend/src/test/java/com/example/demo/club/service/FakeInstaloader.java
+++ b/backend/src/test/java/com/example/demo/club/service/FakeInstaloader.java
@@ -49,6 +49,8 @@ public final class FakeInstaloader {
         }
         List<String> serviceArgs = List.of(args).subList(1, args.length);
 
+        exitWhenTheLauncherDies();
+
         recordArguments(config, serviceArgs);
 
         PrintStream out = new PrintStream(System.out, true, StandardCharsets.UTF_8);
@@ -68,6 +70,26 @@ public final class FakeInstaloader {
         out.flush();
 
         System.exit(Integer.parseInt(config.getProperty(EXIT_CODE, "0")));
+    }
+
+    /**
+     * Ends this process as soon as the launcher that started it is gone.
+     *
+     * <p>On POSIX the launcher {@code exec}s this JVM, so the service's {@code destroyForcibly()}
+     * on a timed-out fetch kills it directly. Windows has no {@code exec}: the service kills
+     * {@code cmd.exe} and this JVM would keep running (and keep the inherited output pipe open)
+     * until its configured sleep finished, leaking a process per timeout test on the very
+     * platform this fake exists to support.
+     */
+    private static void exitWhenTheLauncherDies() {
+        ProcessHandle.current().parent().ifPresent(parent -> {
+            Thread watchdog = new Thread(() -> {
+                parent.onExit().join();
+                Runtime.getRuntime().halt(143);
+            }, "fake-instaloader-parent-watchdog");
+            watchdog.setDaemon(true);
+            watchdog.start();
+        });
     }
 
     /**

--- a/backend/src/test/java/com/example/demo/club/service/FakeInstaloader.java
+++ b/backend/src/test/java/com/example/demo/club/service/FakeInstaloader.java
@@ -1,0 +1,190 @@
+package com.example.demo.club.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+
+/**
+ * A stand-in for the Instaloader command line, used by {@link InstagramAvatarCacheServiceTest}.
+ *
+ * <p>These tests need a program that prints a URL, sleeps, floods its output, fails, or records
+ * the arguments it was handed. They used to be POSIX shell scripts, which meant the whole class
+ * failed on Windows (the executable bit cannot be set, and {@code ProcessBuilder} will not run a
+ * {@code .sh}), so a contributor there could never get a green suite and had to remember which
+ * failures were "expected" -- see issue #109. The behaviour lives in this class instead, run by
+ * the same JVM the tests run in, so it is identical on every platform and is exercised by CI.
+ *
+ * <p>{@link Script} writes the tiny platform launcher (a {@code .sh} or a {@code .cmd}) that the
+ * service is pointed at as its {@code python-command}.
+ */
+public final class FakeInstaloader {
+
+    private static final String SLEEP_MS = "sleepMs";
+    private static final String EXIT_CODE = "exitCode";
+    private static final String NOISE_LINES = "noiseLines";
+    private static final String STDOUT_PREFIX = "stdout.";
+    private static final String APPEND_FILE = "appendFile";
+    private static final String APPEND_PREFIX = "append.";
+
+    private FakeInstaloader() {
+    }
+
+    /**
+     * @param args {@code [0]} is the config file written by {@link Script}; the rest are exactly
+     *             what the service passes to the interpreter, so {@code args[1]} is {@code $1}
+     *             in the shell scripts these replaced
+     */
+    public static void main(String[] args) throws Exception {
+        Properties config = new Properties();
+        try (InputStream in = Files.newInputStream(Path.of(args[0]))) {
+            config.load(in);
+        }
+        List<String> serviceArgs = List.of(args).subList(1, args.length);
+
+        recordArguments(config, serviceArgs);
+
+        PrintStream out = new PrintStream(System.out, true, StandardCharsets.UTF_8);
+        int noiseLines = Integer.parseInt(config.getProperty(NOISE_LINES, "0"));
+        for (int i = 0; i < noiseLines; i++) {
+            out.println("WARNING noisy line " + i + " " + "x".repeat(80));
+        }
+
+        long sleepMs = Long.parseLong(config.getProperty(SLEEP_MS, "0"));
+        if (sleepMs > 0) {
+            Thread.sleep(sleepMs);
+        }
+
+        for (String line : orderedValues(config, STDOUT_PREFIX)) {
+            out.println(line);
+        }
+        out.flush();
+
+        System.exit(Integer.parseInt(config.getProperty(EXIT_CODE, "0")));
+    }
+
+    /**
+     * Appends one line per configured entry to the file the test named: {@code literal:<text>}
+     * writes the text, {@code arg:<n>} writes the nth interpreter argument (1-based, matching
+     * the {@code $n} the shell fixtures used).
+     */
+    private static void recordArguments(Properties config, List<String> serviceArgs) throws IOException {
+        String appendFile = config.getProperty(APPEND_FILE);
+        if (appendFile == null) {
+            return;
+        }
+        List<String> lines = new ArrayList<>();
+        for (String entry : orderedValues(config, APPEND_PREFIX)) {
+            if (entry.startsWith("literal:")) {
+                lines.add(entry.substring("literal:".length()));
+            } else if (entry.startsWith("arg:")) {
+                int index = Integer.parseInt(entry.substring("arg:".length())) - 1;
+                lines.add(index >= 0 && index < serviceArgs.size() ? serviceArgs.get(index) : "");
+            }
+        }
+        Files.write(Path.of(appendFile), lines, StandardCharsets.UTF_8,
+            StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+    }
+
+    private static List<String> orderedValues(Properties config, String prefix) {
+        List<String> values = new ArrayList<>();
+        for (int i = 0; config.containsKey(prefix + i); i++) {
+            values.add(config.getProperty(prefix + i));
+        }
+        return values;
+    }
+
+    /** Builds the launcher the service is pointed at, plus the config that drives it. */
+    public static final class Script {
+
+        private final Path directory;
+        private final String name;
+        private final Properties config = new Properties();
+        private int stdoutCount;
+        private int appendCount;
+
+        private Script(Path directory, String name) {
+            this.directory = directory;
+            this.name = name;
+        }
+
+        public static Script named(Path directory, String name) {
+            return new Script(directory, name);
+        }
+
+        public Script prints(String line) {
+            config.setProperty(STDOUT_PREFIX + stdoutCount++, line);
+            return this;
+        }
+
+        /** Prints this many long lines before anything else, to flood the output pipe. */
+        public Script printsNoiseLines(int lines) {
+            config.setProperty(NOISE_LINES, Integer.toString(lines));
+            return this;
+        }
+
+        public Script sleeps(long millis) {
+            config.setProperty(SLEEP_MS, Long.toString(millis));
+            return this;
+        }
+
+        public Script exitsWith(int exitCode) {
+            config.setProperty(EXIT_CODE, Integer.toString(exitCode));
+            return this;
+        }
+
+        public Script recordsInto(Path file) {
+            config.setProperty(APPEND_FILE, file.toAbsolutePath().toString());
+            return this;
+        }
+
+        /** Records a fixed marker per invocation, for tests that only count calls. */
+        public Script recordsMarker() {
+            config.setProperty(APPEND_PREFIX + appendCount++, "literal:x");
+            return this;
+        }
+
+        /** Records the nth interpreter argument (1-based), e.g. 3 for the club handle. */
+        public Script recordsArgument(int oneBasedIndex) {
+            config.setProperty(APPEND_PREFIX + appendCount++, "arg:" + oneBasedIndex);
+            return this;
+        }
+
+        /** @return the path to hand the service as its {@code python-command} */
+        public String create() throws IOException {
+            Path configFile = directory.resolve(name + ".properties");
+            try (var out = Files.newBufferedWriter(configFile, StandardCharsets.UTF_8)) {
+                config.store(out, "FakeInstaloader configuration for " + name);
+            }
+
+            String java = Path.of(System.getProperty("java.home"), "bin", "java").toString();
+            String classpath = System.getProperty("java.class.path");
+            String mainClass = FakeInstaloader.class.getName();
+            boolean windows = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
+
+            Path launcher = directory.resolve(name + (windows ? ".cmd" : ".sh"));
+            if (windows) {
+                Files.writeString(launcher,
+                    "@echo off\r\n\"%s\" -cp \"%s\" %s \"%s\" %%*\r\n"
+                        .formatted(java, classpath, mainClass, configFile),
+                    StandardCharsets.UTF_8);
+            } else {
+                Files.writeString(launcher,
+                    "#!/bin/sh\nexec \"%s\" -cp \"%s\" %s \"%s\" \"$@\"\n"
+                        .formatted(java, classpath, mainClass, configFile),
+                    StandardCharsets.UTF_8);
+                if (!launcher.toFile().setExecutable(true)) {
+                    throw new IOException("Could not make the fake interpreter executable: " + launcher);
+                }
+            }
+            return launcher.toString();
+        }
+    }
+}

--- a/backend/src/test/java/com/example/demo/club/service/InstagramAvatarCacheServiceTest.java
+++ b/backend/src/test/java/com/example/demo/club/service/InstagramAvatarCacheServiceTest.java
@@ -7,6 +7,8 @@ import com.example.demo.club.mapper.ClubMapper;
 import com.example.demo.club.model.Club;
 import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.http.MediaType;
 
@@ -95,12 +97,13 @@ class InstagramAvatarCacheServiceTest {
     void resolveAvatarNeverSpawnsProcessForHandleNotLinkedToAKnownClub() throws IOException {
         Path invocations = tempDir.resolve("unknown-handle-invocations.txt");
         Files.writeString(invocations, "", StandardCharsets.UTF_8);
-        Path script = tempDir.resolve("would-be-invoked.sh");
-        Files.writeString(script, "#!/bin/sh\necho x >> \"%s\"\nexit 0\n".formatted(invocations), StandardCharsets.UTF_8);
-        assertThat(script.toFile().setExecutable(true)).isTrue();
+        String script = FakeInstaloader.Script.named(tempDir, "would-be-invoked")
+            .recordsInto(invocations)
+            .recordsMarker()
+            .create();
         // Only "mvhsclubs" is a known club handle -- "randomhandle" is well-formed but unknown.
         InstagramAvatarCacheService service =
-            service(true, script.toString(), "http://127.0.0.1/unused?username=%s", 1000, List.of(club("mvhsclubs")));
+            service(true, script, "http://127.0.0.1/unused?username=%s", 1000, List.of(club("mvhsclubs")));
 
         InstagramAvatarCacheService.ResolvedAvatar avatar = service.resolveAvatar("randomhandle");
 
@@ -144,10 +147,12 @@ class InstagramAvatarCacheServiceTest {
     void resolveAvatarSkipsRetryForRecentlyFailedHandle() throws IOException {
         Path invocations = tempDir.resolve("negative-cache-invocations.txt");
         Files.writeString(invocations, "", StandardCharsets.UTF_8);
-        Path script = tempDir.resolve("always-failing-instaloader.sh");
-        Files.writeString(script, "#!/bin/sh\necho x >> \"%s\"\nexit 1\n".formatted(invocations), StandardCharsets.UTF_8);
-        assertThat(script.toFile().setExecutable(true)).isTrue();
-        InstagramAvatarCacheService service = service(true, script.toString(), "http://127.0.0.1/unused?username=%s", 1000);
+        String script = FakeInstaloader.Script.named(tempDir, "always-failing-instaloader")
+            .recordsInto(invocations)
+            .recordsMarker()
+            .exitsWith(1)
+            .create();
+        InstagramAvatarCacheService service = service(true, script, "http://127.0.0.1/unused?username=%s", 1000);
 
         service.resolveAvatar("mvhsclubs");
         service.resolveAvatar("mvhsclubs");
@@ -157,14 +162,15 @@ class InstagramAvatarCacheServiceTest {
 
     @Test
     void resolveAvatarLimitsConcurrentOnDemandRefreshesAcrossDistinctHandles() throws Exception {
-        Path script = tempDir.resolve("slow-instaloader.sh");
-        Files.writeString(script, "#!/bin/sh\nsleep 2\nexit 1\n", StandardCharsets.UTF_8);
-        assertThat(script.toFile().setExecutable(true)).isTrue();
+        String script = FakeInstaloader.Script.named(tempDir, "slow-instaloader")
+            .sleeps(2000)
+            .exitsWith(1)
+            .create();
         InstagramAvatarCacheService service = new InstagramAvatarCacheService(
             clubMapper(List.of(club("mvhsclubs"), club("otherclub"))),
             tempDir.toString(),
             true,
-            script.toString(),
+            script,
             "",
             "",
             "",
@@ -197,10 +203,10 @@ class InstagramAvatarCacheServiceTest {
 
     @Test
     void resolveAvatarTimesOutHungInstaloaderProcess() throws IOException {
-        Path sleeper = tempDir.resolve("sleepy-instaloader.sh");
-        Files.writeString(sleeper, "#!/bin/sh\nsleep 5\n", StandardCharsets.UTF_8);
-        assertThat(sleeper.toFile().setExecutable(true)).isTrue();
-        InstagramAvatarCacheService service = service(true, sleeper.toString(), 1000);
+        String sleeper = FakeInstaloader.Script.named(tempDir, "sleepy-instaloader")
+            .sleeps(5000)
+            .create();
+        InstagramAvatarCacheService service = service(true, sleeper, 1000);
 
         InstagramAvatarCacheService.ResolvedAvatar avatar = assertTimeoutPreemptively(
             Duration.ofSeconds(3),
@@ -227,15 +233,12 @@ class InstagramAvatarCacheServiceTest {
         server.start();
         try {
             String avatarUrl = "http://127.0.0.1:" + server.getAddress().getPort() + "/avatar.png";
-            Path chatty = tempDir.resolve("chatty-instaloader.sh");
             // ~200 KB of noise, comfortably past a 64 KB pipe buffer, then the real answer.
-            Files.writeString(chatty,
-                "#!/bin/sh\ni=0\nwhile [ $i -lt 2000 ]; do\n"
-                    + "  echo 'WARNING xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'\n"
-                    + "  i=$((i+1))\ndone\necho '%s'\n".formatted(avatarUrl),
-                StandardCharsets.UTF_8);
-            assertThat(chatty.toFile().setExecutable(true)).isTrue();
-            InstagramAvatarCacheService service = service(true, chatty.toString(), 5000);
+            String chatty = FakeInstaloader.Script.named(tempDir, "chatty-instaloader")
+                .printsNoiseLines(2000)
+                .prints(avatarUrl)
+                .create();
+            InstagramAvatarCacheService service = service(true, chatty, 5000);
 
             InstagramAvatarCacheService.ResolvedAvatar avatar = assertTimeoutPreemptively(
                 Duration.ofSeconds(20),
@@ -264,15 +267,13 @@ class InstagramAvatarCacheServiceTest {
 
         Path invocations = tempDir.resolve("coalesced-invocations.txt");
         Files.writeString(invocations, "", StandardCharsets.UTF_8);
-        Path script = tempDir.resolve("coalesced-instaloader.sh");
-        Files.writeString(
-            script,
-            "#!/bin/sh\necho x >> \"%s\"\nsleep 1\necho \"http://127.0.0.1:%d/avatar.png\"\n"
-                .formatted(invocations, port),
-            StandardCharsets.UTF_8
-        );
-        assertThat(script.toFile().setExecutable(true)).isTrue();
-        InstagramAvatarCacheService service = service(true, script.toString(), 4000);
+        String script = FakeInstaloader.Script.named(tempDir, "coalesced-instaloader")
+            .recordsInto(invocations)
+            .recordsMarker()
+            .sleeps(1000)
+            .prints("http://127.0.0.1:" + port + "/avatar.png")
+            .create();
+        InstagramAvatarCacheService service = service(true, script, 4000);
 
         ExecutorService executor = Executors.newFixedThreadPool(2);
         CountDownLatch start = new CountDownLatch(1);
@@ -319,12 +320,12 @@ class InstagramAvatarCacheServiceTest {
             exchange.close();
         });
         server.start();
-        Path script = tempDir.resolve("failing-instaloader.sh");
-        Files.writeString(script, "#!/bin/sh\nexit 1\n", StandardCharsets.UTF_8);
-        assertThat(script.toFile().setExecutable(true)).isTrue();
+        String script = FakeInstaloader.Script.named(tempDir, "failing-instaloader")
+            .exitsWith(1)
+            .create();
         InstagramAvatarCacheService service = service(
             true,
-            script.toString(),
+            script,
             "http://127.0.0.1:%d/profile?username=%%s".formatted(server.getAddress().getPort()),
             4000
         );
@@ -339,22 +340,26 @@ class InstagramAvatarCacheServiceTest {
         }
     }
 
+    // POSIX only, and not because of the fake interpreter: Windows passes a command line to
+    // cmd.exe as one string, and the service's second argument is the multi-line Instaloader
+    // script, so everything after its first newline is truncated -- a launcher there simply
+    // cannot observe the later arguments this test is about. The behaviour under test is
+    // platform-independent and is verified by CI (see #109).
+    @EnabledOnOs({OS.LINUX, OS.MAC})
     @Test
     void refreshClubInstagramAvatarsCapsFailedAttempts() throws IOException {
         Path invocations = tempDir.resolve("failed-prewarm-invocations.txt");
         Files.writeString(invocations, "", StandardCharsets.UTF_8);
-        Path script = tempDir.resolve("failing-instaloader.sh");
-        Files.writeString(
-            script,
-            "#!/bin/sh\nprintf '%s\\n' \"$3\" >> \"%s\"\nexit 1\n".formatted("%s", invocations),
-            StandardCharsets.UTF_8
-        );
-        assertThat(script.toFile().setExecutable(true)).isTrue();
+        String script = FakeInstaloader.Script.named(tempDir, "failing-prewarm-instaloader")
+            .recordsInto(invocations)
+            .recordsArgument(3)
+            .exitsWith(1)
+            .create();
         InstagramAvatarCacheService service = new InstagramAvatarCacheService(
             clubMapper(List.of(club("alpha"), club("beta"), club("gamma"))),
             tempDir.toString(),
             true,
-            script.toString(),
+            script,
             "",
             "",
             "",
@@ -373,21 +378,25 @@ class InstagramAvatarCacheServiceTest {
         assertThat(Files.readAllLines(invocations, StandardCharsets.UTF_8)).containsExactly("alpha", "beta");
     }
 
-    @Test
-    void resolveAvatarPassesBrowserCookieConfigurationToInstaloader() throws Exception {
+    // POSIX only, and not because of the fake interpreter: Windows passes a command line to
+    // cmd.exe as one string, and the service's second argument is the multi-line Instaloader
+    // script, so everything after its first newline is truncated -- a launcher there simply
+    // cannot observe the later arguments this test is about. The behaviour under test is
+    // platform-independent and is verified by CI (see #109).
+    @EnabledOnOs({OS.LINUX, OS.MAC})
+    @Test    void resolveAvatarPassesBrowserCookieConfigurationToInstaloader() throws Exception {
         Path argsFile = tempDir.resolve("instaloader-args.txt");
-        Path script = tempDir.resolve("capturing-instaloader.sh");
-        Files.writeString(
-            script,
-            "#!/bin/sh\necho \"$6\" > \"%s\"\necho \"$7\" >> \"%s\"\nexit 1\n".formatted(argsFile, argsFile),
-            StandardCharsets.UTF_8
-        );
-        assertThat(script.toFile().setExecutable(true)).isTrue();
+        String script = FakeInstaloader.Script.named(tempDir, "capturing-instaloader")
+            .recordsInto(argsFile)
+            .recordsArgument(6)
+            .recordsArgument(7)
+            .exitsWith(1)
+            .create();
         InstagramAvatarCacheService service = new InstagramAvatarCacheService(
             clubMapper(List.of(club("mvhsclubs"))),
             tempDir.toString(),
             true,
-            script.toString(),
+            script,
             "",
             "",
             "firefox",
@@ -429,14 +438,10 @@ class InstagramAvatarCacheServiceTest {
         });
         server.start();
         int port = server.getAddress().getPort();
-        Path script = tempDir.resolve("avif-instaloader.sh");
-        Files.writeString(
-            script,
-            "#!/bin/sh\necho \"http://127.0.0.1:%d/avatar.avif\"\n".formatted(port),
-            StandardCharsets.UTF_8
-        );
-        assertThat(script.toFile().setExecutable(true)).isTrue();
-        InstagramAvatarCacheService service = service(true, script.toString(), 4000);
+        String script = FakeInstaloader.Script.named(tempDir, "avif-instaloader")
+            .prints("http://127.0.0.1:" + port + "/avatar.avif")
+            .create();
+        InstagramAvatarCacheService service = service(true, script, 4000);
 
         try {
             InstagramAvatarCacheService.ResolvedAvatar avatar = service.resolveAvatar("mvhsclubs");
@@ -470,14 +475,10 @@ class InstagramAvatarCacheServiceTest {
         });
         server.start();
         int port = server.getAddress().getPort();
-        Path script = tempDir.resolve("mislabeled-png-instaloader.sh");
-        Files.writeString(
-            script,
-            "#!/bin/sh\necho \"http://127.0.0.1:%d/avatar.bin\"\n".formatted(port),
-            StandardCharsets.UTF_8
-        );
-        assertThat(script.toFile().setExecutable(true)).isTrue();
-        InstagramAvatarCacheService service = service(true, script.toString(), 4000);
+        String script = FakeInstaloader.Script.named(tempDir, "mislabeled-png-instaloader")
+            .prints("http://127.0.0.1:" + port + "/avatar.bin")
+            .create();
+        InstagramAvatarCacheService service = service(true, script, 4000);
 
         try {
             InstagramAvatarCacheService.ResolvedAvatar first = service.resolveAvatar("mvhsclubs");
@@ -512,14 +513,10 @@ class InstagramAvatarCacheServiceTest {
         });
         server.start();
         int port = server.getAddress().getPort();
-        Path script = tempDir.resolve("svg-instaloader.sh");
-        Files.writeString(
-            script,
-            "#!/bin/sh\necho \"http://127.0.0.1:%d/avatar.svg\"\n".formatted(port),
-            StandardCharsets.UTF_8
-        );
-        assertThat(script.toFile().setExecutable(true)).isTrue();
-        InstagramAvatarCacheService service = service(true, script.toString(), 4000);
+        String script = FakeInstaloader.Script.named(tempDir, "svg-instaloader")
+            .prints("http://127.0.0.1:" + port + "/avatar.svg")
+            .create();
+        InstagramAvatarCacheService service = service(true, script, 4000);
 
         try {
             InstagramAvatarCacheService.ResolvedAvatar avatar = service.resolveAvatar("mvhsclubs");
@@ -554,14 +551,10 @@ class InstagramAvatarCacheServiceTest {
         });
         server.start();
         int port = server.getAddress().getPort();
-        Path script = tempDir.resolve("webp-instaloader.sh");
-        Files.writeString(
-            script,
-            "#!/bin/sh\necho \"http://127.0.0.1:%d/avatar.webp\"\n".formatted(port),
-            StandardCharsets.UTF_8
-        );
-        assertThat(script.toFile().setExecutable(true)).isTrue();
-        InstagramAvatarCacheService service = service(true, script.toString(), 4000);
+        String script = FakeInstaloader.Script.named(tempDir, "webp-instaloader")
+            .prints("http://127.0.0.1:" + port + "/avatar.webp")
+            .create();
+        InstagramAvatarCacheService service = service(true, script, 4000);
 
         try {
             InstagramAvatarCacheService.ResolvedAvatar first = service.resolveAvatar("mvhsclubs");


### PR DESCRIPTION
Closes #109.

The fixtures wrote `#!/bin/sh` scripts and asserted `setExecutable(true)`, so the whole class failed on Windows -- the executable bit cannot be set there and `ProcessBuilder` will not run a `.sh`. Every backend change made from Windows had to be verified against a remembered baseline of "8 expected failures", which is exactly how a real regression hides.

## Change

- The fake Instaloader's behaviour moved into a Java class (`FakeInstaloader`) run by the same JVM the tests run in, driven by a small properties file: print lines, flood the output, sleep, exit non-zero, record arguments.
- `FakeInstaloader.Script` generates a one-line platform launcher (`.sh` or `.cmd`) per fixture that invokes it. The behaviour is identical on every platform, so CI exercises exactly what a contributor runs -- unlike hand-translated batch files, which CI would never execute.

## The two remaining skips

`refreshClubInstagramAvatarsCapsFailedAttempts` and `resolveAvatarPassesBrowserCookieConfigurationToInstaloader` are annotated `@EnabledOnOs({LINUX, MAC})`, and **not** because of the fake: on Windows the command line reaches `cmd.exe` as a single string, and the service's second argument is the multi-line Instaloader script, so everything after its first newline is truncated. A launcher there cannot see the later arguments those two assert on. I verified that directly with a scratch harness before settling for the annotation. Both still run in CI, and the annotation carries the reason.

## Result

Backend suite on Windows: **466 tests, 0 failures, 2 skipped** (it was 8 failures). Unchanged on Linux, where all 20 tests in the class run.