### PR TITLE
Load the club roster once, not twice, for a club president

### DIFF
--- a/frontend/src/views/ClubAdminView.spec.ts
+++ b/frontend/src/views/ClubAdminView.spec.ts
@@ -118,6 +118,18 @@ describe('ClubAdminView member count', () => {
   // /clubs/:id/admin is only guarded by requiresAuth and fetchClubById is a public endpoint, so
   // the editor used to render for any signed-in visitor and only fail once they pressed Save.
   // The backend was always enforced; this is about not inviting the edit in the first place.
+  // Loading a club both calls loadMembers directly and flips canManageClub from false to true
+  // for a club president, which fires the watcher: two concurrent roster requests whose
+  // responses race to write members.value.
+  it('loads the roster once for a club president, not twice', async () => {
+    const club = buildClub({ canManage: true })
+    fetchClubMembersMock.mockResolvedValue([])
+
+    await mountView(club)
+
+    expect(fetchClubMembersMock).toHaveBeenCalledTimes(1)
+  })
+
   it('renders a read-only notice instead of the editor for someone who does not manage the club', async () => {
     const club = buildClub({ canManage: false })
 

--- a/frontend/src/views/ClubAdminView.vue
+++ b/frontend/src/views/ClubAdminView.vue
@@ -192,6 +192,12 @@ const loadMembers = async (id: string) => {
     members.value = []
     return
   }
+  // Loading the club both calls this directly and flips canManageClub from false to true for a
+  // club president, which fires the watcher below -- two concurrent roster requests whose
+  // responses race to write members.value. One request in flight is enough.
+  if (membersLoading.value) {
+    return
+  }
   membersLoading.value = true
   membersError.value = ''
   try {


### PR DESCRIPTION
Last finding from the review sweep.

`loadClub` calls `loadMembers` directly **and** flips `canManageClub` from false to true, which fires the watcher that loads members again. For a club president -- whose `canManageClub` is false until their club arrives -- every initial load and every route change into a club they manage issued two concurrent `GET /api/clubs/{id}/members` requests, whose responses raced to write `members.value` and `membersLoading`. Platform owners never saw it: `canManageClub` is already true for them, so the watcher never fires.

Guarded on the in-flight flag rather than removing either trigger, because both are needed: the direct call covers owners, the watcher covers a president whose rights arrive with the club.

Verification: new spec case asserts exactly one roster request for a president; frontend suite 280 tests, type-check clean.