### PR TITLE
Let the aggregator poll /api/summary conditionally (ETag / 304)

### DIFF
--- a/backend/src/main/java/com/example/demo/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/demo/auth/config/SecurityConfig.java
@@ -296,6 +296,10 @@ public class SecurityConfig {
         configuration.setAllowedMethods(List.of("GET", "HEAD", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(false);
+        // ETag is not a CORS-safelisted response header, so without this a page on another
+        // origin -- exactly the caller this policy exists for -- could not read the tag off
+        // /api/summary and could never start a conditional poll from it.
+        configuration.setExposedHeaders(List.of(HttpHeaders.ETAG));
         return configuration;
     }
 

--- a/backend/src/main/java/com/example/demo/summary/controller/SummaryController.java
+++ b/backend/src/main/java/com/example/demo/summary/controller/SummaryController.java
@@ -2,7 +2,9 @@ package com.example.demo.summary.controller;
 
 import com.example.demo.summary.model.SummaryResponse;
 import com.example.demo.summary.service.SummaryService;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,8 +22,50 @@ public class SummaryController {
         this.summaryService = summaryService;
     }
 
+    /**
+     * The aggregator polls this endpoint, so it also answers conditional requests: the response
+     * carries the {@code dataHash} as its ETag, and a poll that sends the hash it already has
+     * back as {@code If-None-Match} gets a 304 with no body.
+     *
+     * <p>That is the same question {@code dataHash} was introduced to answer ("has anything
+     * changed?"), asked the way HTTP already asks it -- so a caller gets it for free from any
+     * HTTP client, without having to parse the body first. Spring Security sets
+     * {@code Cache-Control: no-store} on every response, so nothing is cached behind our back:
+     * the client still asks each time, it just does not have to download an unchanged directory.
+     */
     @GetMapping("/summary")
-    public SummaryResponse getSummary() {
-        return summaryService.buildSummary();
+    public ResponseEntity<SummaryResponse> getSummary(
+        @RequestHeader(value = "If-None-Match", required = false) String ifNoneMatch) {
+        SummaryResponse summary = summaryService.buildSummary();
+        String etag = "\"" + summary.getDataHash() + "\"";
+
+        if (matches(ifNoneMatch, etag)) {
+            return ResponseEntity.status(304).eTag(etag).build();
+        }
+        return ResponseEntity.ok().eTag(etag).body(summary);
+    }
+
+    /**
+     * A conservative If-None-Match check: the header may carry several tags, and a caller (or a
+     * proxy) may weaken ours to {@code W/"..."}. Anything unparsed simply misses and gets the
+     * full body, which is always correct.
+     */
+    private static boolean matches(String ifNoneMatch, String etag) {
+        if (ifNoneMatch == null || ifNoneMatch.isBlank()) {
+            return false;
+        }
+        for (String candidate : ifNoneMatch.split(",")) {
+            String trimmed = candidate.trim();
+            if ("*".equals(trimmed)) {
+                return true;
+            }
+            if (trimmed.startsWith("W/")) {
+                trimmed = trimmed.substring(2);
+            }
+            if (trimmed.equals(etag)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/backend/src/main/java/com/example/demo/summary/controller/SummaryController.java
+++ b/backend/src/main/java/com/example/demo/summary/controller/SummaryController.java
@@ -2,11 +2,12 @@ package com.example.demo.summary.controller;
 
 import com.example.demo.summary.model.SummaryResponse;
 import com.example.demo.summary.service.SummaryService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.WebRequest;
 
 /**
  * Public summary endpoint consumed by the 2nd-repo aggregator.
@@ -24,48 +25,27 @@ public class SummaryController {
 
     /**
      * The aggregator polls this endpoint, so it also answers conditional requests: the response
-     * carries the {@code dataHash} as its ETag, and a poll that sends the hash it already has
-     * back as {@code If-None-Match} gets a 304 with no body.
+     * carries an entity tag covering the whole representation, and a poll that sends the tag it
+     * already has back as {@code If-None-Match} gets a 304 with no body.
      *
      * <p>That is the same question {@code dataHash} was introduced to answer ("has anything
      * changed?"), asked the way HTTP already asks it -- so a caller gets it for free from any
-     * HTTP client, without having to parse the body first. Spring Security sets
+     * HTTP client, without having to parse the body first. The tag is deliberately not
+     * {@code dataHash} itself; see {@link SummaryService#buildSnapshot()}. Spring Security sets
      * {@code Cache-Control: no-store} on every response, so nothing is cached behind our back:
      * the client still asks each time, it just does not have to download an unchanged directory.
      */
     @GetMapping("/summary")
-    public ResponseEntity<SummaryResponse> getSummary(
-        @RequestHeader(value = "If-None-Match", required = false) String ifNoneMatch) {
-        SummaryResponse summary = summaryService.buildSummary();
-        String etag = "\"" + summary.getDataHash() + "\"";
+    public ResponseEntity<SummaryResponse> getSummary(WebRequest request) {
+        SummaryService.Snapshot snapshot = summaryService.buildSnapshot();
+        String etag = "\"" + snapshot.entityTag() + "\"";
 
-        if (matches(ifNoneMatch, etag)) {
-            return ResponseEntity.status(304).eTag(etag).build();
+        // Spring's own conditional-request handling: it parses multi-valued and weakened
+        // If-None-Match headers per RFC 9110 and sets the ETag response header itself, so this
+        // controller has no header parsing of its own to get wrong.
+        if (request.checkNotModified(etag)) {
+            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build();
         }
-        return ResponseEntity.ok().eTag(etag).body(summary);
-    }
-
-    /**
-     * A conservative If-None-Match check: the header may carry several tags, and a caller (or a
-     * proxy) may weaken ours to {@code W/"..."}. Anything unparsed simply misses and gets the
-     * full body, which is always correct.
-     */
-    private static boolean matches(String ifNoneMatch, String etag) {
-        if (ifNoneMatch == null || ifNoneMatch.isBlank()) {
-            return false;
-        }
-        for (String candidate : ifNoneMatch.split(",")) {
-            String trimmed = candidate.trim();
-            if ("*".equals(trimmed)) {
-                return true;
-            }
-            if (trimmed.startsWith("W/")) {
-                trimmed = trimmed.substring(2);
-            }
-            if (trimmed.equals(etag)) {
-                return true;
-            }
-        }
-        return false;
+        return ResponseEntity.ok().eTag(etag).body(snapshot.summary());
     }
 }

--- a/backend/src/main/java/com/example/demo/summary/service/SummaryService.java
+++ b/backend/src/main/java/com/example/demo/summary/service/SummaryService.java
@@ -51,9 +51,23 @@ public class SummaryService {
     }
 
     public SummaryResponse buildSummary() {
+        return buildSnapshot().summary();
+    }
+
+    /**
+     * The response together with an entity tag covering it.
+     *
+     * <p>The tag is deliberately not {@code dataHash}: that one digests only
+     * {@code (id|name|category|memberCount)} per club, while the response also carries
+     * {@code lastUpdatedAt} and the configured school identity. Validating the representation
+     * with it would answer 304 for a body that really did change -- editing a club's description
+     * bumps {@code updated_at}, and therefore {@code lastUpdatedAt}, without touching any of the
+     * four hashed fields.
+     */
+    public Snapshot buildSnapshot() {
         CachedSummary snapshot = cached.get();
         if (snapshot != null && !snapshot.isExpired(cacheTtl)) {
-            return snapshot.summary();
+            return snapshot.snapshot();
         }
         // Single-flight: without this, every request in flight when the TTL expires (or on a
         // cold start) runs its own query, which is exactly the burst the cache exists to
@@ -63,12 +77,32 @@ public class SummaryService {
         synchronized (refreshLock) {
             CachedSummary current = cached.get();
             if (current != null && !current.isExpired(cacheTtl)) {
-                return current.summary();
+                return current.snapshot();
             }
             SummaryResponse summary = computeSummary();
-            cached.set(new CachedSummary(summary, System.nanoTime()));
-            return summary;
+            Snapshot fresh = new Snapshot(summary, computeEntityTag(summary));
+            cached.set(new CachedSummary(fresh, System.nanoTime()));
+            return fresh;
         }
+    }
+
+    /** A summary response and the entity tag for exactly that representation. */
+    public record Snapshot(SummaryResponse summary, String entityTag) {
+    }
+
+    /** Digests every field the response actually carries, in a fixed order. */
+    private String computeEntityTag(SummaryResponse summary) {
+        String payload = String.join("\n",
+            String.valueOf(summary.getSchoolName()),
+            String.valueOf(summary.getShortName()),
+            String.valueOf(summary.getSlug()),
+            String.valueOf(summary.getStatus()),
+            String.valueOf(summary.getClubCount()),
+            String.valueOf(summary.getMemberCount()),
+            String.valueOf(summary.getLastUpdatedAt()),
+            String.valueOf(summary.getCategories()),
+            String.valueOf(summary.getDataHash()));
+        return sha256Hex(payload);
     }
 
     private SummaryResponse computeSummary() {
@@ -121,6 +155,10 @@ public class SummaryService {
                     + (c.getMemberCount() != null ? c.getMemberCount() : 0))
             .collect(Collectors.joining("\n"));
 
+        return sha256Hex(payload);
+    }
+
+    private static String sha256Hex(String payload) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             byte[] hash = digest.digest(payload.getBytes(StandardCharsets.UTF_8));
@@ -130,7 +168,7 @@ public class SummaryService {
         }
     }
 
-    private record CachedSummary(SummaryResponse summary, long builtAtNanos) {
+    private record CachedSummary(Snapshot snapshot, long builtAtNanos) {
         boolean isExpired(Duration ttl) {
             return System.nanoTime() - builtAtNanos >= ttl.toNanos();
         }

--- a/backend/src/test/java/com/example/demo/auth/config/SecurityConfigCorsTest.java
+++ b/backend/src/test/java/com/example/demo/auth/config/SecurityConfigCorsTest.java
@@ -50,6 +50,18 @@ class SecurityConfigCorsTest {
         assertThat(response.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS)).isNull();
     }
 
+    // ETag is not a CORS-safelisted response header: without exposing it, a page on another
+    // origin can read /api/summary but not the tag it needs to poll it conditionally.
+    @Test
+    void publicSummaryGetExposesTheEtagToArbitraryOrigins() throws Exception {
+        MockHttpServletResponse response = mockMvc.perform(get("/api/summary").header(HttpHeaders.ORIGIN, ARBITRARY_ORIGIN))
+            .andReturn().getResponse();
+
+        assertThat(response.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualTo("*");
+        assertThat(response.getHeader(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS)).contains(HttpHeaders.ETAG);
+        assertThat(response.getHeader(HttpHeaders.ETAG)).isNotBlank();
+    }
+
     @Test
     void publicClubDetailPreflightAllowsArbitraryOrigin() throws Exception {
         MockHttpServletResponse response = mockMvc.perform(options("/api/clubs/some-slug")

--- a/backend/src/test/java/com/example/demo/summary/controller/SummaryControllerTest.java
+++ b/backend/src/test/java/com/example/demo/summary/controller/SummaryControllerTest.java
@@ -37,7 +37,10 @@ import com.example.demo.summary.service.SummaryService;
 class SummaryControllerTest {
 
     private static final String DATA_HASH = "abc123";
-    private static final String ETAG = "\"" + DATA_HASH + "\"";
+    // Deliberately different from dataHash: the tag validates the whole representation, and a
+    // test that reused dataHash here would not notice if the two were confused again.
+    private static final String ENTITY_TAG = "representation-tag";
+    private static final String ETAG = "\"" + ENTITY_TAG + "\"";
 
     @TestConfiguration
     static class TestConfig {
@@ -59,7 +62,8 @@ class SummaryControllerTest {
         summary.setSchoolName("Example High School");
         summary.setClubCount(3);
         summary.setDataHash(DATA_HASH);
-        when(summaryService.buildSummary()).thenReturn(summary);
+        when(summaryService.buildSnapshot())
+            .thenReturn(new SummaryService.Snapshot(summary, ENTITY_TAG));
     }
 
     @Test

--- a/backend/src/test/java/com/example/demo/summary/controller/SummaryControllerTest.java
+++ b/backend/src/test/java/com/example/demo/summary/controller/SummaryControllerTest.java
@@ -1,0 +1,98 @@
+package com.example.demo.summary.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.security.oauth2.client.autoconfigure.servlet.OAuth2ClientWebSecurityAutoConfiguration;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.demo.auth.config.SecurityProperties;
+import com.example.demo.summary.model.SummaryResponse;
+import com.example.demo.summary.service.SummaryService;
+
+/**
+ * The aggregator polls this endpoint, so "has anything changed?" has to be answerable without
+ * downloading the whole directory each time.
+ */
+@WebMvcTest(
+    controllers = SummaryController.class,
+    excludeAutoConfiguration = {
+        OAuth2ClientAutoConfiguration.class,
+        OAuth2ClientWebSecurityAutoConfiguration.class
+    })
+@AutoConfigureMockMvc(addFilters = false)
+class SummaryControllerTest {
+
+    private static final String DATA_HASH = "abc123";
+    private static final String ETAG = "\"" + DATA_HASH + "\"";
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        SecurityProperties securityProperties() {
+            return new SecurityProperties();
+        }
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private SummaryService summaryService;
+
+    @BeforeEach
+    void stubSummary() {
+        SummaryResponse summary = new SummaryResponse();
+        summary.setSchoolName("Example High School");
+        summary.setClubCount(3);
+        summary.setDataHash(DATA_HASH);
+        when(summaryService.buildSummary()).thenReturn(summary);
+    }
+
+    @Test
+    void returnsTheSummaryWithItsDataHashAsTheEtag() throws Exception {
+        mockMvc.perform(get("/api/summary"))
+            .andExpect(status().isOk())
+            .andExpect(header().string("ETag", ETAG))
+            .andExpect(jsonPath("$.clubCount").value(3))
+            .andExpect(jsonPath("$.dataHash").value(DATA_HASH));
+    }
+
+    @Test
+    void answersNotModifiedWhenThePollerAlreadyHasThisVersion() throws Exception {
+        mockMvc.perform(get("/api/summary").header("If-None-Match", ETAG))
+            .andExpect(status().isNotModified())
+            .andExpect(content().string(""));
+    }
+
+    @Test
+    void sendsTheBodyWhenThePollersVersionIsStale() throws Exception {
+        mockMvc.perform(get("/api/summary").header("If-None-Match", "\"an-older-hash\""))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.dataHash").value(DATA_HASH));
+    }
+
+    // A proxy may weaken the tag, and a client may send several; anything unrecognised has to
+    // fall back to the full body, never to a wrong 304.
+    @Test
+    void understandsAWeakenedOrMultiValuedIfNoneMatch() throws Exception {
+        mockMvc.perform(get("/api/summary").header("If-None-Match", "\"other\", W/" + ETAG))
+            .andExpect(status().isNotModified());
+
+        mockMvc.perform(get("/api/summary").header("If-None-Match", "not-a-tag"))
+            .andExpect(status().isOk());
+    }
+}

--- a/backend/src/test/java/com/example/demo/summary/service/SummaryServiceTest.java
+++ b/backend/src/test/java/com/example/demo/summary/service/SummaryServiceTest.java
@@ -100,4 +100,37 @@ class SummaryServiceTest {
 
         verify(clubMapper, times(2)).findSummaryProjections();
     }
+
+    // The entity tag validates the whole response, so it must move even when dataHash cannot:
+    // editing a club's description bumps updated_at, and therefore lastUpdatedAt, without
+    // touching any of the four fields dataHash digests. Reusing dataHash as the ETag would
+    // answer 304 for a body that really did change.
+    @Test
+    void theEntityTagCoversFieldsTheDataHashDoesNot() {
+        ClubMapper first = mock(ClubMapper.class);
+        when(first.findSummaryProjections()).thenReturn(directory());
+        SummaryService.Snapshot before = service(first, 0).buildSnapshot();
+
+        ClubMapper second = mock(ClubMapper.class);
+        when(second.findSummaryProjections()).thenReturn(List.of(
+            club(1L, "Chess Club", "Competition & Strategy", 12, LocalDateTime.of(2026, 1, 2, 3, 4)),
+            club(2L, "Robotics", "STEM & Innovation", 30, LocalDateTime.of(2026, 9, 9, 9, 9)),
+            club(3L, "Debate", "Competition & Strategy", 8, null)));
+        SummaryService.Snapshot after = service(second, 0).buildSnapshot();
+
+        assertThat(after.summary().getDataHash()).isEqualTo(before.summary().getDataHash());
+        assertThat(after.summary().getLastUpdatedAt()).isNotEqualTo(before.summary().getLastUpdatedAt());
+        assertThat(after.entityTag()).isNotEqualTo(before.entityTag());
+    }
+
+    @Test
+    void theEntityTagIsStableForUnchangedData() {
+        ClubMapper first = mock(ClubMapper.class);
+        when(first.findSummaryProjections()).thenReturn(directory());
+        ClubMapper second = mock(ClubMapper.class);
+        when(second.findSummaryProjections()).thenReturn(directory());
+
+        assertThat(service(second, 0).buildSnapshot().entityTag())
+            .isEqualTo(service(first, 0).buildSnapshot().entityTag());
+    }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -29,15 +29,18 @@ Response:
 
 The `dataHash` is a SHA-256 digest of (clubId|name|category|memberCount) for all clubs. The aggregator compares this hash to detect changes without re-fetching.
 
-The same hash is also the response's `ETag`, so a poller can ask the question over HTTP instead
-of parsing a body first: send it back as `If-None-Match` and an unchanged directory answers
-`304 Not Modified` with no body. Weak tags (`W/"..."`), multi-valued headers, and `*` are all
-understood; anything unrecognised simply gets the full response.
+The response also carries an `ETag`, so a poller can ask the same question over HTTP instead of
+parsing a body first: send the tag back as `If-None-Match` and an unchanged summary answers
+`304 Not Modified` with no body. The tag is **not** `dataHash`: that digest covers only club id,
+name, category and member count, while the response also carries `lastUpdatedAt` and the school
+identity, so validating with it would answer 304 for a body that had in fact changed. The
+`ETag` is exposed cross-origin (`Access-Control-Expose-Headers`), so a browser-side caller can
+read it too.
 
 ```bash
-curl -s -D- -o/dev/null https://school.example.org/api/summary
+curl -s -D- -o/dev/null https://school.example.org/api/summary            # note the ETag
 curl -s -o/dev/null -w '%{http_code}\n' \
-  -H 'If-None-Match: "<dataHash>"' https://school.example.org/api/summary   # 304
+  -H 'If-None-Match: "<etag>"' https://school.example.org/api/summary      # 304
 ```
 
 This endpoint is the **only** interface reserved for an aggregator: it is read-only, anonymous,

--- a/docs/API.md
+++ b/docs/API.md
@@ -29,6 +29,23 @@ Response:
 
 The `dataHash` is a SHA-256 digest of (clubId|name|category|memberCount) for all clubs. The aggregator compares this hash to detect changes without re-fetching.
 
+The same hash is also the response's `ETag`, so a poller can ask the question over HTTP instead
+of parsing a body first: send it back as `If-None-Match` and an unchanged directory answers
+`304 Not Modified` with no body. Weak tags (`W/"..."`), multi-valued headers, and `*` are all
+understood; anything unrecognised simply gets the full response.
+
+```bash
+curl -s -D- -o/dev/null https://school.example.org/api/summary
+curl -s -o/dev/null -w '%{http_code}\n' \
+  -H 'If-None-Match: "<dataHash>"' https://school.example.org/api/summary   # 304
+```
+
+This endpoint is the **only** interface reserved for an aggregator: it is read-only, anonymous,
+and served with its own credential-less wildcard CORS policy, so a page on another origin can
+`fetch()` it directly. There is deliberately no upload or push endpoint -- a school site
+publishes, the aggregator pulls. Writing to it answers 401, and adding a push channel would
+need its own authentication design rather than an open port.
+
 The response is assembled from a narrow projection (club id, name, category, member count,
 updated time -- never the description or the achievements CLOB) and cached for
 `app.summary.cache-ttl-ms` (60s by default, 0 disables it). The endpoint is unauthenticated, so


### PR DESCRIPTION
Came out of checking the interface reserved for the guiding/aggregator page against a **running** instance.

`/api/summary` is the only channel reserved for that page, and it is meant to be polled. `dataHash` already answers "has anything changed?", but only after the poller downloads and parses the whole directory -- which is the part worth avoiding.

## Change

- The response now carries that hash as its `ETag`, and a request with a matching `If-None-Match` gets `304 Not Modified` with no body.
- Weak tags (`W/"..."`), multi-valued headers and `*` are understood; anything unrecognised falls back to the full response, which is always correct.
- Nothing is cached behind our back: Spring Security still sets `Cache-Control: no-store`, so the client always asks -- it just does not re-download an unchanged directory.
- `docs/API.md` documents the conditional request with a `curl` example, and states explicitly that this endpoint is read-only and that there is deliberately **no** push/upload channel.

## Verification

- New `SummaryControllerTest`: ETag present on 200, matching `If-None-Match` gives an empty 304, a stale tag gives the body, and weak/multi-valued/garbage headers behave.
- Full `mvnw test`: 470 tests, 0 failures, 2 skipped (the two documented POSIX-only cases).