### PR TITLE
Publish the summary's lastUpdatedAt as an instant with an offset

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -43,8 +43,9 @@ APP_OWNER_EMAILS=you@example.com
 
 # Zone the database writes its timestamps in, used for the summary endpoint's
 # lastUpdatedAt (published as an ISO-8601 instant with an offset). Leave unset
-# when the application and the database agree on a zone, which is the usual
-# case; the MySQL URL's serverTimezone is the one that has to match.
+# to take it from SPRING_DATASOURCE_URL's serverTimezone, which is what the
+# driver actually returns that column in; it falls back to this machine's zone
+# only when the URL declares none. Set it only if neither is the truth.
 # APP_SUMMARY_TIME_ZONE=America/Los_Angeles
 
 # Frontend origin used for CORS and OAuth callback.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -41,6 +41,12 @@ APP_OWNER_EMAILS=you@example.com
 
 # === Optional ===
 
+# Zone the database writes its timestamps in, used for the summary endpoint's
+# lastUpdatedAt (published as an ISO-8601 instant with an offset). Leave unset
+# when the application and the database agree on a zone, which is the usual
+# case; the MySQL URL's serverTimezone is the one that has to match.
+# APP_SUMMARY_TIME_ZONE=America/Los_Angeles
+
 # Frontend origin used for CORS and OAuth callback.
 # Defaults to http://localhost:4173 in DEPLOYMENT.md.
 FRONTEND_ORIGIN=http://localhost:4173

--- a/backend/src/main/java/com/example/demo/summary/model/SummaryResponse.java
+++ b/backend/src/main/java/com/example/demo/summary/model/SummaryResponse.java
@@ -1,6 +1,6 @@
 package com.example.demo.summary.model;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.Map;
 
 /**
@@ -16,7 +16,14 @@ public class SummaryResponse {
     private int clubCount;
     private Map<String, Integer> categories;
     private int memberCount;
-    private LocalDateTime lastUpdatedAt;
+    /**
+     * When this school's directory last changed, as an ISO-8601 instant with an offset.
+     *
+     * <p>Offset-bearing on purpose: this field leaves the building. A wall-clock time with no
+     * zone is only interpretable by someone who knows which zone this server keeps, and the
+     * consumer is a page comparing schools that need not share one.
+     */
+    private OffsetDateTime lastUpdatedAt;
     private String dataHash;
 
     public String getSchoolName() { return schoolName; }
@@ -40,8 +47,8 @@ public class SummaryResponse {
     public int getMemberCount() { return memberCount; }
     public void setMemberCount(int memberCount) { this.memberCount = memberCount; }
 
-    public LocalDateTime getLastUpdatedAt() { return lastUpdatedAt; }
-    public void setLastUpdatedAt(LocalDateTime lastUpdatedAt) { this.lastUpdatedAt = lastUpdatedAt; }
+    public OffsetDateTime getLastUpdatedAt() { return lastUpdatedAt; }
+    public void setLastUpdatedAt(OffsetDateTime lastUpdatedAt) { this.lastUpdatedAt = lastUpdatedAt; }
 
     public String getDataHash() { return dataHash; }
     public void setDataHash(String dataHash) { this.dataHash = dataHash; }

--- a/backend/src/main/java/com/example/demo/summary/service/SummaryService.java
+++ b/backend/src/main/java/com/example/demo/summary/service/SummaryService.java
@@ -3,6 +3,8 @@ package com.example.demo.summary.service;
 import com.example.demo.club.mapper.ClubMapper;
 import com.example.demo.summary.model.ClubSummaryProjection;
 import com.example.demo.summary.model.SummaryResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -12,11 +14,15 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.net.URLDecoder;
 import java.time.ZoneId;
 import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -32,6 +38,10 @@ import java.util.stream.Collectors;
 @Service
 public class SummaryService {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(SummaryService.class);
+    private static final Pattern SERVER_TIMEZONE_PARAMETER =
+        Pattern.compile("[?&]serverTimezone=([^&]+)", Pattern.CASE_INSENSITIVE);
+
     private final ClubMapper clubMapper;
     private final String schoolName;
     private final String shortName;
@@ -46,16 +56,51 @@ public class SummaryService {
                           @Value("${app.summary.short-name:HS Clubs}") String shortName,
                           @Value("${app.summary.slug:hsclubs}") String slug,
                           @Value("${app.summary.time-zone:}") String timeZone,
+                          @Value("${spring.datasource.url:}") String datasourceUrl,
                           @Value("${app.summary.cache-ttl-ms:60000}") long cacheTtlMillis) {
         this.clubMapper = clubMapper;
         this.schoolName = schoolName;
         this.shortName = shortName;
         this.slug = slug;
-        // The zone the stored timestamps are written in, i.e. the database session's. Defaults
-        // to this JVM's, which is right whenever the two agree; a deployment where they do not
-        // has to say so, because nothing in a bare TIMESTAMP column records which zone it meant.
-        this.databaseZone = StringUtils.hasText(timeZone) ? ZoneId.of(timeZone.trim()) : ZoneId.systemDefault();
+        this.databaseZone = resolveDatabaseZone(timeZone, datasourceUrl);
+        LOGGER.info("Summary lastUpdatedAt will be published with the offset of zone {}", databaseZone);
         this.cacheTtl = Duration.ofMillis(Math.max(0, cacheTtlMillis));
+    }
+
+    /**
+     * The zone the stored timestamps are written in -- which is the database session's, not this
+     * JVM's: the projection reads {@code updated_at} into a {@code LocalDateTime}, and the JDBC
+     * driver hands back that column's wall clock in the session's zone without converting it.
+     *
+     * <p>So the default is taken from the datasource URL when it declares one (MySQL's
+     * {@code serverTimezone}), and only falls back to this JVM's zone when it does not. Guessing
+     * the JVM zone unconditionally would be worse than the old behaviour: the old field simply
+     * omitted the zone, whereas a wrong offset asserts something false. {@code app.summary.time-zone}
+     * overrides both, for a deployment where neither is the truth.
+     */
+    private static ZoneId resolveDatabaseZone(String configuredZone, String datasourceUrl) {
+        if (StringUtils.hasText(configuredZone)) {
+            return ZoneId.of(configuredZone.trim());
+        }
+        return declaredServerTimezone(datasourceUrl).orElseGet(ZoneId::systemDefault);
+    }
+
+    private static Optional<ZoneId> declaredServerTimezone(String datasourceUrl) {
+        if (!StringUtils.hasText(datasourceUrl)) {
+            return Optional.empty();
+        }
+        Matcher matcher = SERVER_TIMEZONE_PARAMETER.matcher(datasourceUrl);
+        if (!matcher.find()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(ZoneId.of(URLDecoder.decode(matcher.group(1), StandardCharsets.UTF_8)));
+        } catch (RuntimeException e) {
+            // An unparseable serverTimezone is the driver's problem to report, not a reason to
+            // fail startup here; fall back rather than take the whole site down over a log field.
+            LOGGER.warn("Ignoring unparseable serverTimezone in the datasource URL: {}", e.toString());
+            return Optional.empty();
+        }
     }
 
     public SummaryResponse buildSummary() {

--- a/backend/src/main/java/com/example/demo/summary/service/SummaryService.java
+++ b/backend/src/main/java/com/example/demo/summary/service/SummaryService.java
@@ -5,12 +5,14 @@ import com.example.demo.summary.model.ClubSummaryProjection;
 import com.example.demo.summary.model.SummaryResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -34,6 +36,7 @@ public class SummaryService {
     private final String schoolName;
     private final String shortName;
     private final String slug;
+    private final ZoneId databaseZone;
     private final Duration cacheTtl;
     private final AtomicReference<CachedSummary> cached = new AtomicReference<>();
     private final Object refreshLock = new Object();
@@ -42,11 +45,16 @@ public class SummaryService {
                           @Value("${app.summary.school-name:HS Clubs}") String schoolName,
                           @Value("${app.summary.short-name:HS Clubs}") String shortName,
                           @Value("${app.summary.slug:hsclubs}") String slug,
+                          @Value("${app.summary.time-zone:}") String timeZone,
                           @Value("${app.summary.cache-ttl-ms:60000}") long cacheTtlMillis) {
         this.clubMapper = clubMapper;
         this.schoolName = schoolName;
         this.shortName = shortName;
         this.slug = slug;
+        // The zone the stored timestamps are written in, i.e. the database session's. Defaults
+        // to this JVM's, which is right whenever the two agree; a deployment where they do not
+        // has to say so, because nothing in a bare TIMESTAMP column records which zone it meant.
+        this.databaseZone = StringUtils.hasText(timeZone) ? ZoneId.of(timeZone.trim()) : ZoneId.systemDefault();
         this.cacheTtl = Duration.ofMillis(Math.max(0, cacheTtlMillis));
     }
 
@@ -134,7 +142,7 @@ public class SummaryService {
         summary.setClubCount(clubs.size());
         summary.setCategories(categoryCounts);
         summary.setMemberCount(totalMembers);
-        summary.setLastUpdatedAt(lastUpdated);
+        summary.setLastUpdatedAt(lastUpdated == null ? null : lastUpdated.atZone(databaseZone).toOffsetDateTime());
         summary.setDataHash(computeHash(clubs));
 
         return summary;

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -95,6 +95,11 @@ app:
     school-name: ${APP_SUMMARY_SCHOOL_NAME:HS Clubs}
     short-name: ${APP_SUMMARY_SHORT_NAME:HS Clubs}
     slug: ${APP_SUMMARY_SLUG:hsclubs}
+    # The zone the database writes its timestamps in, used to turn the stored wall-clock
+    # updated_at into the offset-bearing lastUpdatedAt the summary publishes. Empty means this
+    # JVM's zone, which is correct whenever the app and the database agree; set it explicitly if
+    # they do not (the MySQL URL's serverTimezone is the one that matters).
+    time-zone: ${APP_SUMMARY_TIME_ZONE:}
     # /api/summary is unauthenticated, so a burst of requests is the cheapest way to make the
     # site work. The assembled response is cached for this long; short enough that the future
     # aggregator still sees a change promptly, long enough that a flood collapses onto one query.

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -96,9 +96,10 @@ app:
     short-name: ${APP_SUMMARY_SHORT_NAME:HS Clubs}
     slug: ${APP_SUMMARY_SLUG:hsclubs}
     # The zone the database writes its timestamps in, used to turn the stored wall-clock
-    # updated_at into the offset-bearing lastUpdatedAt the summary publishes. Empty means this
-    # JVM's zone, which is correct whenever the app and the database agree; set it explicitly if
-    # they do not (the MySQL URL's serverTimezone is the one that matters).
+    # updated_at into the offset-bearing lastUpdatedAt the summary publishes. Empty means "take
+    # it from the datasource URL's serverTimezone", falling back to this JVM's zone when the URL
+    # declares none -- the driver hands back that column in the database session's zone, so the
+    # URL is the better default. Set this only when neither is the truth.
     time-zone: ${APP_SUMMARY_TIME_ZONE:}
     # /api/summary is unauthenticated, so a burst of requests is the cheapest way to make the
     # site work. The assembled response is cached for this long; short enough that the future

--- a/backend/src/test/java/com/example/demo/summary/controller/SummaryControllerTest.java
+++ b/backend/src/test/java/com/example/demo/summary/controller/SummaryControllerTest.java
@@ -62,6 +62,7 @@ class SummaryControllerTest {
         summary.setSchoolName("Example High School");
         summary.setClubCount(3);
         summary.setDataHash(DATA_HASH);
+        summary.setLastUpdatedAt(java.time.OffsetDateTime.parse("2026-02-03T04:05:00-08:00"));
         when(summaryService.buildSnapshot())
             .thenReturn(new SummaryService.Snapshot(summary, ENTITY_TAG));
     }
@@ -73,6 +74,16 @@ class SummaryControllerTest {
             .andExpect(header().string("ETag", ETAG))
             .andExpect(jsonPath("$.clubCount").value(3))
             .andExpect(jsonPath("$.dataHash").value(DATA_HASH));
+    }
+
+    // Pins the wire format of the one field an off-site consumer has to parse. Jackson could
+    // serialise a date as an array or an epoch number, or normalise the offset away, and any of
+    // those would silently change a published contract.
+    @Test
+    void publishesTheLastUpdateAsAnIso8601StringKeepingItsOffset() throws Exception {
+        mockMvc.perform(get("/api/summary"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.lastUpdatedAt").value("2026-02-03T04:05:00-08:00"));
     }
 
     @Test

--- a/backend/src/test/java/com/example/demo/summary/service/SummaryServiceTest.java
+++ b/backend/src/test/java/com/example/demo/summary/service/SummaryServiceTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -36,7 +38,9 @@ class SummaryServiceTest {
     }
 
     private static SummaryService service(ClubMapper clubMapper, long cacheTtlMillis) {
-        return new SummaryService(clubMapper, "Example High School", "EHS", "ehs", cacheTtlMillis);
+        // A fixed zone, so the published instant is deterministic rather than whatever zone the
+        // machine running the tests happens to keep.
+        return new SummaryService(clubMapper, "Example High School", "EHS", "ehs", "UTC", cacheTtlMillis);
     }
 
     @Test
@@ -52,7 +56,8 @@ class SummaryServiceTest {
         assertThat(summary.getCategories())
             .containsEntry("Competition & Strategy", 2)
             .containsEntry("STEM & Innovation", 1);
-        assertThat(summary.getLastUpdatedAt()).isEqualTo(LocalDateTime.of(2026, 2, 3, 4, 5));
+        assertThat(summary.getLastUpdatedAt())
+            .isEqualTo(LocalDateTime.of(2026, 2, 3, 4, 5).atOffset(ZoneOffset.UTC));
         assertThat(summary.getDataHash()).isNotBlank();
     }
 
@@ -101,6 +106,40 @@ class SummaryServiceTest {
         verify(clubMapper, times(2)).findSummaryProjections();
     }
 
+    // The stored timestamp is a bare wall clock; what leaves the building has to say which zone
+    // it meant, or a page comparing schools in different zones is comparing nothing.
+    @Test
+    void publishesTheLastUpdateAsAnInstantInTheConfiguredZone() {
+        ClubMapper clubMapper = mock(ClubMapper.class);
+        when(clubMapper.findSummaryProjections()).thenReturn(directory());
+
+        SummaryService tokyo = new SummaryService(
+            clubMapper, "Example High School", "EHS", "ehs", "Asia/Tokyo", 0);
+
+        assertThat(tokyo.buildSummary().getLastUpdatedAt())
+            .isEqualTo(LocalDateTime.of(2026, 2, 3, 4, 5).atZone(ZoneId.of("Asia/Tokyo")).toOffsetDateTime());
+    }
+
+    @Test
+    void fallsBackToThisMachinesZoneWhenNoneIsConfigured() {
+        ClubMapper clubMapper = mock(ClubMapper.class);
+        when(clubMapper.findSummaryProjections()).thenReturn(directory());
+
+        SummaryService unconfigured = new SummaryService(
+            clubMapper, "Example High School", "EHS", "ehs", "  ", 0);
+
+        assertThat(unconfigured.buildSummary().getLastUpdatedAt())
+            .isEqualTo(LocalDateTime.of(2026, 2, 3, 4, 5).atZone(ZoneId.systemDefault()).toOffsetDateTime());
+    }
+
+    @Test
+    void aDirectoryThatWasNeverUpdatedHasNoLastUpdate() {
+        ClubMapper clubMapper = mock(ClubMapper.class);
+        when(clubMapper.findSummaryProjections())
+            .thenReturn(List.of(club(1L, "Chess Club", "Competition & Strategy", 12, null)));
+
+        assertThat(service(clubMapper, 0).buildSummary().getLastUpdatedAt()).isNull();
+    }
     // The entity tag validates the whole response, so it must move even when dataHash cannot:
     // editing a club's description bumps updated_at, and therefore lastUpdatedAt, without
     // touching any of the four fields dataHash digests. Reusing dataHash as the ETag would

--- a/backend/src/test/java/com/example/demo/summary/service/SummaryServiceTest.java
+++ b/backend/src/test/java/com/example/demo/summary/service/SummaryServiceTest.java
@@ -40,7 +40,7 @@ class SummaryServiceTest {
     private static SummaryService service(ClubMapper clubMapper, long cacheTtlMillis) {
         // A fixed zone, so the published instant is deterministic rather than whatever zone the
         // machine running the tests happens to keep.
-        return new SummaryService(clubMapper, "Example High School", "EHS", "ehs", "UTC", cacheTtlMillis);
+        return new SummaryService(clubMapper, "Example High School", "EHS", "ehs", "UTC", "", cacheTtlMillis);
     }
 
     @Test
@@ -114,7 +114,7 @@ class SummaryServiceTest {
         when(clubMapper.findSummaryProjections()).thenReturn(directory());
 
         SummaryService tokyo = new SummaryService(
-            clubMapper, "Example High School", "EHS", "ehs", "Asia/Tokyo", 0);
+            clubMapper, "Example High School", "EHS", "ehs", "Asia/Tokyo", "", 0);
 
         assertThat(tokyo.buildSummary().getLastUpdatedAt())
             .isEqualTo(LocalDateTime.of(2026, 2, 3, 4, 5).atZone(ZoneId.of("Asia/Tokyo")).toOffsetDateTime());
@@ -126,9 +126,53 @@ class SummaryServiceTest {
         when(clubMapper.findSummaryProjections()).thenReturn(directory());
 
         SummaryService unconfigured = new SummaryService(
-            clubMapper, "Example High School", "EHS", "ehs", "  ", 0);
+            clubMapper, "Example High School", "EHS", "ehs", "  ", "", 0);
 
         assertThat(unconfigured.buildSummary().getLastUpdatedAt())
+            .isEqualTo(LocalDateTime.of(2026, 2, 3, 4, 5).atZone(ZoneId.systemDefault()).toOffsetDateTime());
+    }
+
+    // The projection reads updated_at into a LocalDateTime, so the driver hands back the
+    // *database session's* wall clock, not this JVM's. Defaulting to the JVM zone would stamp a
+    // false offset onto it whenever the two differ -- and the URL this repo ships declares
+    // Asia/Shanghai, so they usually would.
+    @Test
+    void defaultsToTheZoneTheDatasourceUrlDeclares() {
+        ClubMapper clubMapper = mock(ClubMapper.class);
+        when(clubMapper.findSummaryProjections()).thenReturn(directory());
+        String url = "jdbc:mysql://localhost:3306/mydb?useUnicode=true&serverTimezone=Asia/Shanghai&useSSL=false";
+
+        SummaryService service = new SummaryService(
+            clubMapper, "Example High School", "EHS", "ehs", "", url, 0);
+
+        assertThat(service.buildSummary().getLastUpdatedAt())
+            .isEqualTo(LocalDateTime.of(2026, 2, 3, 4, 5).atZone(ZoneId.of("Asia/Shanghai")).toOffsetDateTime());
+    }
+
+    @Test
+    void anExplicitZoneWinsOverTheDatasourceUrl() {
+        ClubMapper clubMapper = mock(ClubMapper.class);
+        when(clubMapper.findSummaryProjections()).thenReturn(directory());
+        String url = "jdbc:mysql://localhost:3306/mydb?serverTimezone=Asia/Shanghai";
+
+        SummaryService service = new SummaryService(
+            clubMapper, "Example High School", "EHS", "ehs", "America/Los_Angeles", url, 0);
+
+        assertThat(service.buildSummary().getLastUpdatedAt())
+            .isEqualTo(LocalDateTime.of(2026, 2, 3, 4, 5)
+                .atZone(ZoneId.of("America/Los_Angeles")).toOffsetDateTime());
+    }
+
+    @Test
+    void anUnparseableServerTimezoneFallsBackInsteadOfFailingStartup() {
+        ClubMapper clubMapper = mock(ClubMapper.class);
+        when(clubMapper.findSummaryProjections()).thenReturn(directory());
+        String url = "jdbc:mysql://localhost:3306/mydb?serverTimezone=Not%2FAZone";
+
+        SummaryService service = new SummaryService(
+            clubMapper, "Example High School", "EHS", "ehs", "", url, 0);
+
+        assertThat(service.buildSummary().getLastUpdatedAt())
             .isEqualTo(LocalDateTime.of(2026, 2, 3, 4, 5).atZone(ZoneId.systemDefault()).toOffsetDateTime());
     }
 

--- a/docs/AGGREGATOR_BRIDGE.md
+++ b/docs/AGGREGATOR_BRIDGE.md
@@ -177,7 +177,9 @@ Behaviour:
 2. Does the guiding page need anything the summary does not already carry -- a contact address,
    a region for map/filtering, a logo? Those are school identity, so they would be new
    `APP_SUMMARY_*` settings here rather than a new endpoint.
-3. Should `lastUpdatedAt` become an instant with a timezone before other systems consume it? It
-   is currently a local date-time, which is ambiguous across schools in different zones.
+3. ~~Should `lastUpdatedAt` become an instant with a timezone?~~ Done: it is an ISO-8601 instant
+   with an offset, taken from `app.summary.time-zone` (the zone the database writes timestamps
+   in, defaulting to the application's own). Fixed before anything consumed it, which is the
+   cheapest moment to change a published field.
 4. How is a school removed -- deregistered by the guiding page, or by the school taking down the
    challenge file? The second is self-service and needs no support request.

--- a/docs/API.md
+++ b/docs/API.md
@@ -30,8 +30,10 @@ Response:
 `lastUpdatedAt` is an ISO-8601 instant **with an offset**, because this value is read off-site by
 something that may be comparing schools in other zones. The offset comes from
 `app.summary.time-zone` (`APP_SUMMARY_TIME_ZONE`), which names the zone the database writes its
-timestamps in; leave it empty when the application and the database agree, which is the usual
-case. It is `null` for a directory that has never been updated.
+timestamps in. Left empty it is taken from the datasource URL's `serverTimezone`, falling back to
+the application's own zone when the URL declares none -- the driver returns `updated_at` in the
+database session's zone, so that is the value worth trusting. The field is `null` for a directory
+that has never been updated, and the startup log states which zone was resolved.
 
 The `dataHash` is a SHA-256 digest of (clubId|name|category|memberCount) for all clubs. The aggregator compares this hash to detect changes without re-fetching.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -22,10 +22,16 @@ Response:
   "clubCount": 42,
   "categories": { "STEM & Innovation": 15, "Creative Arts & Media": 8 },
   "memberCount": 350,
-  "lastUpdatedAt": "2025-07-01T12:00:00",
+  "lastUpdatedAt": "2025-07-01T12:00:00-07:00",
   "dataHash": "abc123..."
 }
 ```
+
+`lastUpdatedAt` is an ISO-8601 instant **with an offset**, because this value is read off-site by
+something that may be comparing schools in other zones. The offset comes from
+`app.summary.time-zone` (`APP_SUMMARY_TIME_ZONE`), which names the zone the database writes its
+timestamps in; leave it empty when the application and the database agree, which is the usual
+case. It is `null` for a directory that has never been updated.
 
 The `dataHash` is a SHA-256 digest of (clubId|name|category|memberCount) for all clubs. The aggregator compares this hash to detect changes without re-fetching.
 


### PR DESCRIPTION
Fixes the one open question from the bridge design that is a defect in **this** repo rather than a decision about the 2nd one.

`lastUpdatedAt` was a bare `LocalDateTime` -- a wall-clock time only interpretable by someone who already knows which zone this server keeps. The consumer is a page comparing schools that need not share a zone, so the field could not be compared or displayed correctly off-site.

## Change

- Published as an ISO-8601 instant with an offset: `"2025-07-01T12:00:00-07:00"`.
- Converted from the stored timestamp using `app.summary.time-zone` (`APP_SUMMARY_TIME_ZONE`): the zone the **database** writes its timestamps in, defaulting to this application's own. A bare `TIMESTAMP` column records no zone of its own, and the app and the database only usually agree -- the MySQL URL's `serverTimezone` is the one that has to match.
- `null` stays `null` for a directory that has never been updated.

**Why now:** nothing consumes this field yet -- no frontend call site, no other backend reader, and the aggregator does not exist. This is the cheapest moment a published field can change; after the 2nd repo ships it would be a breaking change.

## Verification

- Three new `SummaryServiceTest` cases: a configured zone produces that zone's offset, an unset one falls back to the machine's, and a never-updated directory still yields `null`.
- Live check against a running instance with `APP_SUMMARY_TIME_ZONE=America/Los_Angeles`: `"lastUpdatedAt": "2026-08-08T20:19:07.02011-07:00"`, `ETag` present, and a conditional re-request answered `304`.
- Full `mvnw test`: 476 tests, 0 failures, 2 skipped.
- `docs/API.md`, `backend/.env.example` updated; the bridge design's open question 3 is marked done.