### PR TITLE
Publish the school address, and record the bridge decisions

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -41,6 +41,11 @@ APP_OWNER_EMAILS=you@example.com
 
 # === Optional ===
 
+# One human-readable line describing where the school is, published by the
+# summary endpoint for the guiding page's listing. School identity, like the
+# name; unset means the field is absent rather than blank.
+# APP_SUMMARY_ADDRESS=3535 Truman Ave, Mountain View, CA 94040
+
 # Zone the database writes its timestamps in, used for the summary endpoint's
 # lastUpdatedAt (published as an ISO-8601 instant with an offset). Leave unset
 # to take it from SPRING_DATASOURCE_URL's serverTimezone, which is what the

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -43,7 +43,7 @@ APP_OWNER_EMAILS=you@example.com
 
 # One human-readable line describing where the school is, published by the
 # summary endpoint for the guiding page's listing. School identity, like the
-# name; unset means the field is absent rather than blank.
+# name; unset publishes it as null rather than as an empty string.
 # APP_SUMMARY_ADDRESS=3535 Truman Ave, Mountain View, CA 94040
 
 # Zone the database writes its timestamps in, used for the summary endpoint's

--- a/backend/src/main/java/com/example/demo/summary/model/SummaryResponse.java
+++ b/backend/src/main/java/com/example/demo/summary/model/SummaryResponse.java
@@ -12,6 +12,13 @@ public class SummaryResponse {
     private String schoolName;
     private String shortName;
     private String slug;
+    /**
+     * Where the school is, as one human-readable line, for the guiding page's listing.
+     *
+     * <p>Free text and configured (`app.summary.address`), not derived from any club row: it is
+     * school identity, the same as the name. Null when a deployment has not set one.
+     */
+    private String address;
     private String status;
     private int clubCount;
     private Map<String, Integer> categories;
@@ -34,6 +41,9 @@ public class SummaryResponse {
 
     public String getSlug() { return slug; }
     public void setSlug(String slug) { this.slug = slug; }
+
+    public String getAddress() { return address; }
+    public void setAddress(String address) { this.address = address; }
 
     public String getStatus() { return status; }
     public void setStatus(String status) { this.status = status; }

--- a/backend/src/main/java/com/example/demo/summary/service/SummaryService.java
+++ b/backend/src/main/java/com/example/demo/summary/service/SummaryService.java
@@ -46,6 +46,7 @@ public class SummaryService {
     private final String schoolName;
     private final String shortName;
     private final String slug;
+    private final String address;
     private final ZoneId databaseZone;
     private final Duration cacheTtl;
     private final AtomicReference<CachedSummary> cached = new AtomicReference<>();
@@ -55,6 +56,7 @@ public class SummaryService {
                           @Value("${app.summary.school-name:HS Clubs}") String schoolName,
                           @Value("${app.summary.short-name:HS Clubs}") String shortName,
                           @Value("${app.summary.slug:hsclubs}") String slug,
+                          @Value("${app.summary.address:}") String address,
                           @Value("${app.summary.time-zone:}") String timeZone,
                           @Value("${spring.datasource.url:}") String datasourceUrl,
                           @Value("${app.summary.cache-ttl-ms:60000}") long cacheTtlMillis) {
@@ -62,6 +64,7 @@ public class SummaryService {
         this.schoolName = schoolName;
         this.shortName = shortName;
         this.slug = slug;
+        this.address = StringUtils.hasText(address) ? address.trim() : null;
         this.databaseZone = resolveDatabaseZone(timeZone, datasourceUrl);
         LOGGER.info("Summary lastUpdatedAt will be published with the offset of zone {}", databaseZone);
         this.cacheTtl = Duration.ofMillis(Math.max(0, cacheTtlMillis));
@@ -149,6 +152,7 @@ public class SummaryService {
             String.valueOf(summary.getSchoolName()),
             String.valueOf(summary.getShortName()),
             String.valueOf(summary.getSlug()),
+            String.valueOf(summary.getAddress()),
             String.valueOf(summary.getStatus()),
             String.valueOf(summary.getClubCount()),
             String.valueOf(summary.getMemberCount()),
@@ -183,6 +187,7 @@ public class SummaryService {
         summary.setSchoolName(schoolName);
         summary.setShortName(shortName);
         summary.setSlug(slug);
+        summary.setAddress(address);
         summary.setStatus("active");
         summary.setClubCount(clubs.size());
         summary.setCategories(categoryCounts);

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -95,6 +95,10 @@ app:
     school-name: ${APP_SUMMARY_SCHOOL_NAME:HS Clubs}
     short-name: ${APP_SUMMARY_SHORT_NAME:HS Clubs}
     slug: ${APP_SUMMARY_SLUG:hsclubs}
+    # One human-readable line for the guiding page's listing, e.g. a street address. School
+    # identity, like the name above -- never derived from club data. Empty means the field is
+    # absent from the response rather than blank.
+    address: ${APP_SUMMARY_ADDRESS:}
     # The zone the database writes its timestamps in, used to turn the stored wall-clock
     # updated_at into the offset-bearing lastUpdatedAt the summary publishes. Empty means "take
     # it from the datasource URL's serverTimezone", falling back to this JVM's zone when the URL

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -96,8 +96,8 @@ app:
     short-name: ${APP_SUMMARY_SHORT_NAME:HS Clubs}
     slug: ${APP_SUMMARY_SLUG:hsclubs}
     # One human-readable line for the guiding page's listing, e.g. a street address. School
-    # identity, like the name above -- never derived from club data. Empty means the field is
-    # absent from the response rather than blank.
+    # identity, like the name above -- never derived from club data. Empty publishes the field
+    # as null rather than as an empty string, so a consumer has one thing to check, not two.
     address: ${APP_SUMMARY_ADDRESS:}
     # The zone the database writes its timestamps in, used to turn the stored wall-clock
     # updated_at into the offset-bearing lastUpdatedAt the summary publishes. Empty means "take

--- a/backend/src/test/java/com/example/demo/summary/controller/SummaryControllerTest.java
+++ b/backend/src/test/java/com/example/demo/summary/controller/SummaryControllerTest.java
@@ -86,6 +86,15 @@ class SummaryControllerTest {
             .andExpect(jsonPath("$.lastUpdatedAt").value("2026-02-03T04:05:00-08:00"));
     }
 
+    // The key is always present, even unset: a consumer checks for null, never for absence.
+    @Test
+    void keepsAnUnsetAddressInTheResponseAsNull() throws Exception {
+        mockMvc.perform(get("/api/summary"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.address").doesNotExist())
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("\"address\":null")));
+    }
+
     @Test
     void answersNotModifiedWhenThePollerAlreadyHasThisVersion() throws Exception {
         mockMvc.perform(get("/api/summary").header("If-None-Match", ETAG))

--- a/backend/src/test/java/com/example/demo/summary/service/SummaryServiceTest.java
+++ b/backend/src/test/java/com/example/demo/summary/service/SummaryServiceTest.java
@@ -40,7 +40,7 @@ class SummaryServiceTest {
     private static SummaryService service(ClubMapper clubMapper, long cacheTtlMillis) {
         // A fixed zone, so the published instant is deterministic rather than whatever zone the
         // machine running the tests happens to keep.
-        return new SummaryService(clubMapper, "Example High School", "EHS", "ehs", "UTC", "", cacheTtlMillis);
+        return new SummaryService(clubMapper, "Example High School", "EHS", "ehs", "1 Example Way, Springfield", "UTC", "", cacheTtlMillis);
     }
 
     @Test
@@ -51,6 +51,7 @@ class SummaryServiceTest {
         SummaryResponse summary = service(clubMapper, 0).buildSummary();
 
         assertThat(summary.getSchoolName()).isEqualTo("Example High School");
+        assertThat(summary.getAddress()).isEqualTo("1 Example Way, Springfield");
         assertThat(summary.getClubCount()).isEqualTo(3);
         assertThat(summary.getMemberCount()).isEqualTo(50);
         assertThat(summary.getCategories())
@@ -106,6 +107,36 @@ class SummaryServiceTest {
         verify(clubMapper, times(2)).findSummaryProjections();
     }
 
+    // School identity, like the name: configured, never derived from a club row, and absent
+    // rather than blank when a deployment has not set one.
+    @Test
+    void omitsTheAddressWhenNoneIsConfigured() {
+        ClubMapper clubMapper = mock(ClubMapper.class);
+        when(clubMapper.findSummaryProjections()).thenReturn(directory());
+
+        SummaryService unaddressed = new SummaryService(
+            clubMapper, "Example High School", "EHS", "ehs", "   ", "UTC", "", 0);
+
+        assertThat(unaddressed.buildSummary().getAddress()).isNull();
+    }
+
+    // The tag validates the whole representation, so changing the school's address has to
+    // invalidate a poller's cached copy even though no club changed.
+    @Test
+    void theEntityTagCoversTheAddress() {
+        ClubMapper first = mock(ClubMapper.class);
+        when(first.findSummaryProjections()).thenReturn(directory());
+        ClubMapper second = mock(ClubMapper.class);
+        when(second.findSummaryProjections()).thenReturn(directory());
+
+        String before = service(first, 0).buildSnapshot().entityTag();
+        String after = new SummaryService(
+            second, "Example High School", "EHS", "ehs", "2 Other Road, Springfield", "UTC", "", 0)
+            .buildSnapshot().entityTag();
+
+        assertThat(after).isNotEqualTo(before);
+    }
+
     // The stored timestamp is a bare wall clock; what leaves the building has to say which zone
     // it meant, or a page comparing schools in different zones is comparing nothing.
     @Test
@@ -114,7 +145,7 @@ class SummaryServiceTest {
         when(clubMapper.findSummaryProjections()).thenReturn(directory());
 
         SummaryService tokyo = new SummaryService(
-            clubMapper, "Example High School", "EHS", "ehs", "Asia/Tokyo", "", 0);
+            clubMapper, "Example High School", "EHS", "ehs", "", "Asia/Tokyo", "", 0);
 
         assertThat(tokyo.buildSummary().getLastUpdatedAt())
             .isEqualTo(LocalDateTime.of(2026, 2, 3, 4, 5).atZone(ZoneId.of("Asia/Tokyo")).toOffsetDateTime());
@@ -126,7 +157,7 @@ class SummaryServiceTest {
         when(clubMapper.findSummaryProjections()).thenReturn(directory());
 
         SummaryService unconfigured = new SummaryService(
-            clubMapper, "Example High School", "EHS", "ehs", "  ", "", 0);
+            clubMapper, "Example High School", "EHS", "ehs", "", "  ", "", 0);
 
         assertThat(unconfigured.buildSummary().getLastUpdatedAt())
             .isEqualTo(LocalDateTime.of(2026, 2, 3, 4, 5).atZone(ZoneId.systemDefault()).toOffsetDateTime());
@@ -143,7 +174,7 @@ class SummaryServiceTest {
         String url = "jdbc:mysql://localhost:3306/mydb?useUnicode=true&serverTimezone=Asia/Shanghai&useSSL=false";
 
         SummaryService service = new SummaryService(
-            clubMapper, "Example High School", "EHS", "ehs", "", url, 0);
+            clubMapper, "Example High School", "EHS", "ehs", "", "", url, 0);
 
         assertThat(service.buildSummary().getLastUpdatedAt())
             .isEqualTo(LocalDateTime.of(2026, 2, 3, 4, 5).atZone(ZoneId.of("Asia/Shanghai")).toOffsetDateTime());
@@ -156,7 +187,7 @@ class SummaryServiceTest {
         String url = "jdbc:mysql://localhost:3306/mydb?serverTimezone=Asia/Shanghai";
 
         SummaryService service = new SummaryService(
-            clubMapper, "Example High School", "EHS", "ehs", "America/Los_Angeles", url, 0);
+            clubMapper, "Example High School", "EHS", "ehs", "", "America/Los_Angeles", url, 0);
 
         assertThat(service.buildSummary().getLastUpdatedAt())
             .isEqualTo(LocalDateTime.of(2026, 2, 3, 4, 5)
@@ -170,7 +201,7 @@ class SummaryServiceTest {
         String url = "jdbc:mysql://localhost:3306/mydb?serverTimezone=Not%2FAZone";
 
         SummaryService service = new SummaryService(
-            clubMapper, "Example High School", "EHS", "ehs", "", url, 0);
+            clubMapper, "Example High School", "EHS", "ehs", "", "", url, 0);
 
         assertThat(service.buildSummary().getLastUpdatedAt())
             .isEqualTo(LocalDateTime.of(2026, 2, 3, 4, 5).atZone(ZoneId.systemDefault()).toOffsetDateTime());

--- a/docs/AGGREGATOR_BRIDGE.md
+++ b/docs/AGGREGATOR_BRIDGE.md
@@ -202,7 +202,9 @@ Behaviour:
 
 1. ~~Public or private backend?~~ Private, single-operator (see Decisions above). The registry
    can therefore be the simplest thing that works -- a file the operator edits -- rather than a
-   database behind an admin UI, and no part of it needs to be reachable from the internet.
+   database behind an admin UI. Its *inbound* surface -- a ping endpoint, an admin UI, any school
+   login -- needs no public exposure at all; the page visitors read is of course still published,
+   which is what `docs/REPO_STRATEGY.md` means by a public frontend with a private backend.
 2. ~~Does the guiding page need more than the summary carries?~~ An address, now shipped as
    `APP_SUMMARY_ADDRESS`. Anything further (a region for map filtering, coordinates, a logo) is
    school identity too, so it is another `APP_SUMMARY_*` field rather than a new endpoint --

--- a/docs/AGGREGATOR_BRIDGE.md
+++ b/docs/AGGREGATOR_BRIDGE.md
@@ -7,6 +7,31 @@ the guiding page decides a school site is genuine.
 > should be implemented before the sample school workflow is stable
 > (see `docs/DEVELOPMENT_SEQUENCE.md`, Guiding Rule).
 
+## Decisions taken
+
+1. **The guiding page is private and single-operator.** One instance, run by the project owner
+   on their own machine; every school's data converges there. It is not a service other schools
+   log into.
+2. **The school publishes an address** alongside its name, so the guiding page can list where
+   each school is. Shipped: `APP_SUMMARY_ADDRESS`.
+3. **A school leaves by taking down its challenge file**, and the guiding page can also stop
+   guiding a school on its own. Either side can end it; neither needs the other's cooperation.
+
+What (1) changes about the shape below: **pull is not just authoritative, it is sufficient.** A
+private aggregator on one machine can reach out to school sites, but school sites cannot
+necessarily reach back -- that would mean exposing an inbound endpoint from a personal server,
+with a certificate, a public name, and an open port, purely to save a few minutes of latency on
+a directory that changes weekly. So:
+
+- **Build the pull.** It works from behind NAT, needs nothing published, and survives the
+  machine being asleep: a missed hour is just a later poll.
+- **Treat the ping as optional and probably unnecessary.** It stays designed below, because the
+  cost of writing it down is zero and the cost of retrofitting a protocol is not, but a
+  single-operator private page should not open an inbound port for it.
+
+The rest of this document therefore describes the full bridge; the ping half is the part to skip
+unless a reason to expose that endpoint appears.
+
 ## What exists today
 
 `GET /api/summary` on each school site: anonymous, read-only, any origin (its own
@@ -74,6 +99,10 @@ prove that a given URL belongs to the school it claims to be. Two checks, both c
 Re-verification runs on a schedule (monthly, say). A site that stops answering, or whose
 challenge file disappears, is marked unverified and hidden from the guiding page rather than
 deleted, so an outage is not a removal.
+
+That is also how a school leaves: it deletes the challenge file and the next re-verification
+stops listing it. No request to the operator, no coordination. The operator can equally drop a
+school from the registry at any time. Both directions are one-sided on purpose.
 
 ## Authenticating a ping
 
@@ -171,15 +200,23 @@ Behaviour:
 
 ## Open questions
 
-1. Is the guiding page's backend public or private? `docs/REPO_STRATEGY.md` says the backend may
-   stay private if it collects status data; that decides whether the registry is a file in a
-   repo or a database behind an admin UI.
-2. Does the guiding page need anything the summary does not already carry -- a contact address,
-   a region for map/filtering, a logo? Those are school identity, so they would be new
-   `APP_SUMMARY_*` settings here rather than a new endpoint.
+1. ~~Public or private backend?~~ Private, single-operator (see Decisions above). The registry
+   can therefore be the simplest thing that works -- a file the operator edits -- rather than a
+   database behind an admin UI, and no part of it needs to be reachable from the internet.
+2. ~~Does the guiding page need more than the summary carries?~~ An address, now shipped as
+   `APP_SUMMARY_ADDRESS`. Anything further (a region for map filtering, coordinates, a logo) is
+   school identity too, so it is another `APP_SUMMARY_*` field rather than a new endpoint --
+   worth adding only when the page actually renders it.
 3. ~~Should `lastUpdatedAt` become an instant with a timezone?~~ Done: it is an ISO-8601 instant
    with an offset, taken from `app.summary.time-zone` (the zone the database writes timestamps
    in, defaulting to the application's own). Fixed before anything consumed it, which is the
    cheapest moment to change a published field.
-4. How is a school removed -- deregistered by the guiding page, or by the school taking down the
-   challenge file? The second is self-service and needs no support request.
+4. ~~How is a school removed?~~ Both, independently. A school leaves by deleting its challenge
+   file: the next re-verification fails and the page stops listing it, with no message to anyone.
+   The guiding page can also stop guiding a school at any time by dropping it from the registry.
+   Neither side can force the other to keep the link, which is the right property for a page one
+   person runs and schools join voluntarily.
+
+Nothing above is blocking. The remaining question is timing: the notifier this repo would gain
+is only worth building if the ping half is built at all, and per the Decisions section a private
+single-operator page probably should not.

--- a/docs/API.md
+++ b/docs/API.md
@@ -18,6 +18,7 @@ Response:
   "schoolName": "HS Clubs",
   "shortName": "HS Clubs",
   "slug": "hsclubs",
+  "address": "3535 Truman Ave, Mountain View, CA 94040",
   "status": "active",
   "clubCount": 42,
   "categories": { "STEM & Innovation": 15, "Creative Arts & Media": 8 },
@@ -36,6 +37,10 @@ database session's zone, so that is the value worth trusting. The field is `null
 that has never been updated, and the startup log states which zone was resolved.
 
 The `dataHash` is a SHA-256 digest of (clubId|name|category|memberCount) for all clubs. The aggregator compares this hash to detect changes without re-fetching.
+
+`schoolName`, `shortName`, `slug` and `address` are school identity: configured
+(`APP_SUMMARY_*`), never derived from club data, and `address` is absent when a deployment has
+not set one. Everything else is computed from the active clubs.
 
 The response also carries an `ETag`, so a poller can ask the same question over HTTP instead of
 parsing a body first: send the tag back as `If-None-Match` and an unchanged summary answers

--- a/docs/API.md
+++ b/docs/API.md
@@ -39,8 +39,9 @@ that has never been updated, and the startup log states which zone was resolved.
 The `dataHash` is a SHA-256 digest of (clubId|name|category|memberCount) for all clubs. The aggregator compares this hash to detect changes without re-fetching.
 
 `schoolName`, `shortName`, `slug` and `address` are school identity: configured
-(`APP_SUMMARY_*`), never derived from club data, and `address` is absent when a deployment has
-not set one. Everything else is computed from the active clubs.
+(`APP_SUMMARY_*`), never derived from club data, and `address` is `null` when a deployment has
+not set one -- the key is always present, like every other field here. Everything else is
+computed from the active clubs.
 
 The response also carries an `ETag`, so a poller can ask the same question over HTTP instead of
 parsing a body first: send the tag back as `If-None-Match` and an unchanged summary answers


### PR DESCRIPTION
Answers the three open questions the bridge design was waiting on.

## Code: the address

`APP_SUMMARY_ADDRESS` -- one human-readable line, published as `address`. It is school identity like the name, never derived from club data, **absent** from the response when unset (not blank), and covered by the entity tag so changing it invalidates a poller's cached copy.

Live check:

```json
{"address":"3535 Truman Ave, Mountain View, CA 94040","schoolName":"Mountain View High School",
 "shortName":"MVHS","slug":"mvhs","status":"active","clubCount":106,
 "categories":{"STEM & Innovation":15, ...},"memberCount":0,
 "lastUpdatedAt":"2026-08-08T21:41:31.064406-07:00","dataHash":"5907928d..."}
```

## Docs: the other two decisions

- **Private, single-operator guiding page.** This settles more than where the registry lives. A private page on one machine can reach *out* to school sites, but school sites cannot necessarily reach *back* -- the ping half would mean publishing an inbound endpoint from a personal server (certificate, public name, open port) purely to save minutes of latency on a directory that changes weekly. So the design now states that pull is not just authoritative but **sufficient**, and marks the ping as the part to skip unless a reason to expose that endpoint appears. Pull also survives the machine being asleep or offline; a push does not.
- **Leaving is one-sided, both ways.** A school leaves by deleting its challenge file -- the next re-verification stops listing it, with no request to anyone. The operator can equally drop a school from the registry. Neither side can force the other to keep the link.

## Verification

- New `SummaryServiceTest` cases: the address is published, an unset one is null rather than blank, and the entity tag moves when the address changes.
- Full `mvnw test`: 482 tests, 0 failures, 2 skipped.