### PR TITLE
Record that the guiding page repo now exists

### DIFF
--- a/docs/AGGREGATOR_BRIDGE.md
+++ b/docs/AGGREGATOR_BRIDGE.md
@@ -6,6 +6,11 @@ the guiding page decides a school site is genuine.
 > Status: design, not built. Only the pull half exists today (`GET /api/summary`). Nothing here
 > should be implemented before the sample school workflow is stable
 > (see `docs/DEVELOPMENT_SEQUENCE.md`, Guiding Rule).
+>
+> The consuming side now exists as its own repository,
+> [`hsclubs-guiding-page`](https://github.com/bangxiao0927/hsclubs-guiding-page), which carries
+> the consumer's copy of this contract, the registry format, and its own roadmap. Nothing in
+> *this* repo has been built for it, and per the Decisions below nothing needs to be.
 
 ## Decisions taken
 

--- a/docs/DEVELOPMENT_SEQUENCE.md
+++ b/docs/DEVELOPMENT_SEQUENCE.md
@@ -165,6 +165,11 @@ Start the 2nd repo only after Phase 6 exits cleanly.
 
 The 2nd repo should consume public summary data. It should not copy the club workflow, admin workflow, or auth model unless there is a strong reason.
 
+Status: started. Phase 6 exited, and the 2nd repo is scaffolded at
+[`hsclubs-guiding-page`](https://github.com/bangxiao0927/hsclubs-guiding-page) with the contract,
+the school registry format and its own roadmap. It consumes `GET /api/summary` and nothing else,
+and this repo gains nothing for it.
+
 How the two sides connect -- pull vs push, verifying a school site, and the only settings this
 repo would gain -- is designed in `docs/AGGREGATOR_BRIDGE.md`. Its open questions are the
 decisions Phase 7 has to make; none of it is built yet, and none of it should be built before

--- a/docs/REPO_STRATEGY.md
+++ b/docs/REPO_STRATEGY.md
@@ -98,9 +98,17 @@ The 2nd repo needs reliable data from real school sites. The 3rd repo needs a mo
 
 ## Current Boundary
 
-Do not create the 2nd or 3rd repo yet. Track their requirements here and in the roadmap, but keep active implementation inside this repo until the sample school workflow is dependable.
+The 2nd repo now exists and is being scaffolded:
+[`hsclubs-guiding-page`](https://github.com/bangxiao0927/hsclubs-guiding-page). Phase 6 of
+`docs/DEVELOPMENT_SEQUENCE.md` exited first -- the summary endpoint it consumes is shipped,
+documented and tested -- which is the gate that was holding it.
 
-## How the 2nd Repo Will Connect
+The boundary that still stands: **no multi-school notion enters this repo.** A school site knows
+about itself and publishes one summary. It does not know the guiding page exists, does not depend
+on it being up, and gains no registry, no cross-school query, and no inbound endpoint for it. The
+3rd repo (mobile) is still not started; the sample school workflow comes first.
+
+## How the 2nd Repo Connects
 
 The data exchange between a school site and the guiding page -- what is pulled, what may be
 pushed, how a school site is verified, and what this repo would need to add -- is designed in
@@ -108,3 +116,8 @@ pushed, how a school site is verified, and what this repo would need to add -- i
 school may optionally *notify* it that something changed. A school never pushes the data itself,
 so the school site stays the single source of truth and the guiding page never renders content
 that someone else's server handed it.
+
+The consumer's own copy of that contract lives in the 2nd repo, in its `docs/BRIDGE_CONTRACT.md`,
+so neither side has to read the other's codebase to stay compatible. Because the guiding page is
+private and single-operator, the notification half is deliberately not being built: pull is
+sufficient, and it works from a machine with no inbound port that is free to be offline.


### PR DESCRIPTION
Docs only. Phase 6 exited (the summary endpoint is shipped, documented and tested), which was the gate holding the 2nd repo, so it is now scaffolded at [hsclubs-guiding-page](https://github.com/bangxiao0927/hsclubs-guiding-page) -- contract, registry format, roadmap, no application code yet.

- `REPO_STRATEGY.md`: "do not create the 2nd or 3rd repo yet" is replaced with what actually holds now -- **no multi-school notion enters this repo**. A school site knows about itself and publishes one summary; it does not know the guiding page exists, does not depend on it being up, and gains no registry, cross-school query, or inbound endpoint. The 3rd repo is still not started.
- `DEVELOPMENT_SEQUENCE.md`: Phase 7 marked started, with what the 2nd repo consumes (`GET /api/summary`, and nothing else).
- `AGGREGATOR_BRIDGE.md`: points at the consumer's own copy of the contract, so neither side has to read the other's codebase to stay compatible.

Nothing was built in this repo for it, and per the decisions recorded earlier nothing needs to be.