### PR TITLE
Record that the guiding-page pull path is built

### DIFF
--- a/docs/AGGREGATOR_BRIDGE.md
+++ b/docs/AGGREGATOR_BRIDGE.md
@@ -3,14 +3,17 @@
 How a school site (this repo) and the future guiding page (the 2nd repo) exchange data, and how
 the guiding page decides a school site is genuine.
 
-> Status: design, not built. Only the pull half exists today (`GET /api/summary`). Nothing here
-> should be implemented before the sample school workflow is stable
-> (see `docs/DEVELOPMENT_SEQUENCE.md`, Guiding Rule).
+> Status: the pull half is built on both sides. This repo publishes `GET /api/summary`; the
+> guiding-page repo loads and verifies its registry, polls every verified school conditionally,
+> stores each result independently, and serves the page. The optional ping half remains design
+> only and, per the private/single-operator decision below, should not be built without a new
+> reason to expose an inbound endpoint from that machine.
 >
 > The consuming side now exists as its own repository,
 > [`hsclubs-guiding-page`](https://github.com/bangxiao0927/hsclubs-guiding-page), which carries
-> the consumer's copy of this contract, the registry format, and its own roadmap. Nothing in
-> *this* repo has been built for it, and per the Decisions below nothing needs to be.
+> the consumer's copy of this contract, the registry format, the poller, the page, and the
+> origin-verification tooling. Nothing else in *this* repo has been built for it, and per the
+> Decisions below nothing needs to be.
 
 ## Decisions taken
 

--- a/docs/DEVELOPMENT_SEQUENCE.md
+++ b/docs/DEVELOPMENT_SEQUENCE.md
@@ -165,10 +165,11 @@ Start the 2nd repo only after Phase 6 exits cleanly.
 
 The 2nd repo should consume public summary data. It should not copy the club workflow, admin workflow, or auth model unless there is a strong reason.
 
-Status: started. Phase 6 exited, and the 2nd repo is scaffolded at
-[`hsclubs-guiding-page`](https://github.com/bangxiao0927/hsclubs-guiding-page) with the contract,
-the school registry format and its own roadmap. It consumes `GET /api/summary` and nothing else,
-and this repo gains nothing for it.
+Status: complete as a decision and implemented as a minimal consumer. Phase 6 exited, and
+[`hsclubs-guiding-page`](https://github.com/bangxiao0927/hsclubs-guiding-page) now has the
+contract, the school registry, bounded/conditional polling, the private page, and origin
+verification with scheduled re-checks. It consumes `GET /api/summary` and nothing else, and this
+repo gains nothing for it.
 
 How the two sides connect -- pull vs push, verifying a school site, and the only settings this
 repo would gain -- is designed in `docs/AGGREGATOR_BRIDGE.md`. Its open questions are the


### PR DESCRIPTION
Docs only. The cross-repo status still said "design, not built" and Phase 7 only "started", which stopped being true when [hsclubs-guiding-page](https://github.com/bangxiao0927/hsclubs-guiding-page) completed all four roadmap phases.

Records what exists now: this repo publishes `/api/summary`; the consumer loads and verifies its registry, polls each verified school conditionally and independently, keeps stale data with reasons, serves the private page, and re-checks origin control on a schedule. It consumes nothing else and this repo gained nothing for it.

The boundary remains explicit: the optional ping half is still design-only and should not be built for a private, single-operator machine without a new reason to expose an inbound endpoint.