### PR TITLE
harden automated deployment runtime

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -26,12 +26,19 @@
 | -------------------- | --------------------------- | -------------------------- |
 | Java                 | 17+                         | Backend runtime            |
 | MySQL                | 8.0+                        | Database                   |
-| Node.js              | 20+                         | Frontend build             |
+| Node.js              | See `frontend/package.json`'s `engines.node` (currently `^20.19.0 \|\| >=22.12.0`) | Frontend build |
 | npm                  | 10+                         | Frontend dependencies      |
 | Python               | 3.10+ with `venv` and `pip` | Instaloader avatar cache   |
 | Caddy or nginx       | Caddy 2.7+ / nginx 1.24+    | Reverse proxy (production) |
 | Google Cloud Project | —                           | OAuth2 credentials         |
 | Domain               | —                           | HTTPS + OAuth redirect     |
+
+`deploy-main.sh` checks the active Node.js against that `engines.node` range
+before building the frontend. If the server's default Node.js does not
+satisfy it (for example an older LTS installed via the OS package manager),
+the script activates a compatible version through
+[nvm](https://github.com/nvm-sh/nvm) instead of failing outright -- see
+"Node.js runtime selection" below.
 
 ---
 
@@ -313,27 +320,41 @@ cd backend
 
 ### Run as a service (systemd)
 
-Create `/etc/systemd/system/hsclubs.service`:
+Create `/etc/systemd/system/hsclubs.service`. The sample below is byte-for-byte
+what `scripts/deploy-main.sh`'s `backend_service_unit_content` function
+generates for the documented defaults: `APP_DIR=/opt/hsclubs`,
+`BACKEND_RUN_USER=your-deploy-user`, `SYSTEMD_SCOPE=system`, and a `java`
+resolved from `PATH` at `/usr/bin/java`. `restart_or_require_admin_setup`
+compares this file byte-for-byte against the installed unit before every
+restart, so any customization -- a different `APP_DIR`, `BACKEND_RUN_USER`,
+`BACKEND_ENV_FILE`, or `java` location -- changes the exact unit the script
+expects. Run `scripts/deploy-main.sh` once with your real environment
+variables set and read the generated unit from the "Generated the desired
+unit at" message it prints instead of hand-editing this sample, if your
+deployment differs from the defaults above.
 
 ```ini
 [Unit]
 Description=HSclubs Backend
-After=network.target mysql.service
+Wants=network-online.target
+After=network-online.target mysql.service
 
 [Service]
 Type=simple
 User=your-deploy-user
 WorkingDirectory=/opt/hsclubs/backend
+EnvironmentFile=/opt/hsclubs/backend/.env
 ExecStart=/usr/bin/java -jar /opt/hsclubs/backend/target/demo-0.0.1-SNAPSHOT.jar
 Restart=on-failure
 RestartSec=5
 
-# Pass environment variables
-EnvironmentFile=/opt/hsclubs/backend/.env
-
 [Install]
 WantedBy=multi-user.target
 ```
+
+The `ExecStart` jar filename comes from your Maven build (`target/*.jar`) and
+is resolved at deploy time, so it will differ from the example above only if
+`backend/pom.xml`'s `artifactId` or `version` changes.
 
 ```bash
 sudo systemctl daemon-reload
@@ -348,7 +369,9 @@ service, checks the backend, and then publishes the frontend. Its production def
 the system service and, for a fresh installation, the non-root account that invokes the
 deploy script. If the service already exists, deployment preserves its configured `User=`
 unless `BACKEND_RUN_USER` is explicitly set. Run the script directly from the deployment
-account; it uses `sudo` internally for privileged installation steps. Set
+account. For a system-scope service that is already installed, enabled, and unchanged, the
+only privileged step it runs is the exact command granted by
+`ops/hsclubs-deploy.sudoers` -- see "Restricted sudo for system-scope deploys" below. Set
 `BACKEND_RUN_USER` only when the backend should use a different, existing account or when
 intentionally migrating an existing service:
 
@@ -382,6 +405,75 @@ system manager.
 
 The deploy script respects `APP_INSTAGRAM_AVATAR_CACHE_ENABLED=false` and skips
 Instaloader initialization when the cache is disabled.
+
+### Restricted sudo for system-scope deploys
+
+A system-scope unit is root-owned. Installing, enabling, and reloading it is a one-time
+admin task, done by hand once; routine deploys afterward must not repeat those privileged
+steps. `scripts/deploy-main.sh` enforces that split:
+
+- It generates the unit it would install into a temp file and compares it against
+  `/etc/systemd/system/$BACKEND_SERVICE`.
+- If the installed unit is identical and already enabled, it runs exactly one privileged
+  command: `sudo /usr/bin/systemctl restart hsclubs.service` (the `systemctl` path is
+  resolved and canonicalized at run time so it matches the sudoers rule below).
+- If the unit is missing, different, or not enabled, it fails immediately with the exact
+  `install`/`daemon-reload`/`enable`/`start` commands an admin needs to run once, instead of
+  attempting a broad privileged install itself.
+- When `BACKEND_RUN_USER` is the account running the deploy (for example `webowner` running
+  as `webowner`), the runtime-access checks that back it call the backend directly instead
+  of through `sudo -u`, since no privilege boundary needs crossing.
+
+One-time admin setup, after creating the unit shown under "Run as a service" above:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable hsclubs.service
+sudo systemctl start hsclubs.service
+
+# Validate the sudoers rule before installing it.
+sudo visudo -cf ops/hsclubs-deploy.sudoers
+sudo install -m 0440 ops/hsclubs-deploy.sudoers /etc/sudoers.d/hsclubs-deploy
+```
+
+`ops/hsclubs-deploy.sudoers` grants exactly one command to the deployment account, with no
+wildcard and no shell or helper script:
+
+```
+webowner ALL=(root) NOPASSWD: /usr/bin/systemctl restart hsclubs.service
+```
+
+After that one-time setup, every routine deploy needs only that single restart command as
+root; it never re-installs, re-enables, or daemon-reloads the unit.
+
+### Node.js runtime selection
+
+Before installing frontend dependencies or building, `deploy-main.sh` checks
+the Node.js on `PATH` against `frontend/package.json`'s `engines.node` range.
+
+- If it already satisfies the range, the script uses it as-is.
+- If it does not, the script sources `nvm.sh` from `$NVM_DIR/nvm.sh` (default
+  `$HOME/.nvm/nvm.sh`) and activates the highest already-installed nvm
+  version that satisfies the range.
+- Set `DEPLOY_NODE_VERSION` to force a specific nvm-managed version instead
+  (for example `DEPLOY_NODE_VERSION=22.12.0`). The script still verifies that
+  version satisfies `engines.node` before using it.
+
+The script never installs a Node.js version over the network: if no
+already-installed version (system or nvm) satisfies the requirement, or nvm
+itself is not installed at the expected path, it fails with a message naming
+the required range and, when nvm is available, the versions it found
+installed. Install a compatible version with `nvm install <version>` and
+re-run the deploy, or set `DEPLOY_NODE_VERSION` to a version you have already
+installed.
+
+```bash
+# Force a specific already-installed nvm version.
+DEPLOY_NODE_VERSION=22.12.0 ./scripts/deploy-main.sh
+
+# Use a non-default nvm installation location.
+NVM_DIR=/opt/nvm ./scripts/deploy-main.sh
+```
 
 ### Health check
 

--- a/frontend/src/utils/staleChunk.spec.ts
+++ b/frontend/src/utils/staleChunk.spec.ts
@@ -64,7 +64,10 @@ describe('recoverFromStaleChunk', () => {
 
   it('does not reload when the marker cannot be stored, since the loop could not be broken', () => {
     const reload = vi.fn()
-    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+    // Node 25 exposes its own global Storage, which is not jsdom's window Storage.
+    // Spy on the prototype used by the browser object the implementation actually calls.
+    const storagePrototype = Object.getPrototypeOf(window.sessionStorage) as Storage
+    const setItem = vi.spyOn(storagePrototype, 'setItem').mockImplementation(() => {
       throw new Error('storage disabled')
     })
 

--- a/frontend/src/utils/staleChunk.spec.ts
+++ b/frontend/src/utils/staleChunk.spec.ts
@@ -7,7 +7,7 @@ import {
 } from './staleChunk'
 
 beforeEach(() => {
-  sessionStorage.clear()
+  window.sessionStorage.clear()
 })
 
 describe('isStaleChunkError', () => {

--- a/frontend/src/utils/staleChunk.ts
+++ b/frontend/src/utils/staleChunk.ts
@@ -41,6 +41,11 @@ const defaultReload = (target: string) => {
  * kept, so no reload is attempted at all -- an unrecoverable page beats an
  * infinite reload loop.
  *
+ * Uses `window.sessionStorage` explicitly: in a browser it is the same
+ * object as the unqualified global, but Node 25 added its own built-in
+ * `sessionStorage` that shadows jsdom's under Vitest, so the unqualified
+ * name there resolves to Node's storage instead of the one tests spy on.
+ *
  * @returns whether a reload was triggered.
  */
 export const recoverFromStaleChunk = (
@@ -48,10 +53,10 @@ export const recoverFromStaleChunk = (
   reload: (target: string) => void = defaultReload,
 ): boolean => {
   try {
-    if (sessionStorage.getItem(RELOAD_MARKER_KEY) === target) {
+    if (window.sessionStorage.getItem(RELOAD_MARKER_KEY) === target) {
       return false
     }
-    sessionStorage.setItem(RELOAD_MARKER_KEY, target)
+    window.sessionStorage.setItem(RELOAD_MARKER_KEY, target)
   } catch {
     return false
   }
@@ -65,7 +70,7 @@ export const recoverFromStaleChunk = (
  */
 export const clearStaleChunkRecovery = () => {
   try {
-    sessionStorage.removeItem(RELOAD_MARKER_KEY)
+    window.sessionStorage.removeItem(RELOAD_MARKER_KEY)
   } catch {
     // Nothing to clean up if storage never worked.
   }

--- a/ops/hsclubs-deploy.sudoers
+++ b/ops/hsclubs-deploy.sudoers
@@ -1,0 +1,19 @@
+# ops/hsclubs-deploy.sudoers
+#
+# Grants the webowner deployment account permission to run exactly one root
+# command: restarting the already-installed hsclubs.service unit. No
+# wildcards, no shell, no helper script -- the deploy account can restart the
+# service and nothing else as root.
+#
+# scripts/deploy-main.sh's normal system-scope path never installs, enables,
+# or daemon-reloads the unit; that is a one-time admin task (see
+# docs/DEPLOYMENT.md). This rule is the only privilege the routine deploy
+# needs afterward.
+#
+# Validate before installing:
+#   sudo visudo -cf ops/hsclubs-deploy.sudoers
+#
+# Install with the mode sudoers requires:
+#   sudo install -m 0440 ops/hsclubs-deploy.sudoers /etc/sudoers.d/hsclubs-deploy
+
+webowner ALL=(root) NOPASSWD: /usr/bin/systemctl restart hsclubs.service

--- a/scripts/deploy-main.sh
+++ b/scripts/deploy-main.sh
@@ -20,6 +20,18 @@ SYSTEMD_SCOPE="${SYSTEMD_SCOPE:-system}"
 RUN_BACKEND_TESTS="${RUN_BACKEND_TESTS:-0}"
 SKIP_GIT_PULL="${SKIP_GIT_PULL:-0}"
 SETUP_INSTALOADER="${SETUP_INSTALOADER:-1}"
+# Optional exact nvm version to activate when the ambient Node.js does not
+# satisfy frontend/package.json's engines.node (e.g. the server default is
+# older than the frontend's minimum). Left unset, deployment auto-selects an
+# already-installed nvm version that satisfies the requirement.
+DEPLOY_NODE_VERSION="${DEPLOY_NODE_VERSION:-}"
+NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+# Canonical path to systemctl, resolved lazily by resolve_systemctl_bin so
+# the privileged restart command matches ops/hsclubs-deploy.sudoers exactly.
+SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-}"
+# Where system-scope unit files live. Overridable so tests can point at a
+# fixture directory instead of the real, root-owned /etc/systemd/system.
+SYSTEM_UNIT_DIR="${SYSTEM_UNIT_DIR:-/etc/systemd/system}"
 
 log() {
   printf '\n[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
@@ -55,6 +67,235 @@ require_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
 }
 
+is_release_version() {
+  [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+
+version_compare() {
+  local -a left_parts right_parts
+  local index left_component right_component
+
+  is_release_version "$1" || die "Internal error: version_compare received a" \
+    "non-release version string: $1"
+  is_release_version "$2" || die "Internal error: version_compare received a" \
+    "non-release version string: $2"
+
+  IFS='.' read -r -a left_parts <<< "$1"
+  IFS='.' read -r -a right_parts <<< "$2"
+
+  for index in 0 1 2; do
+    left_component="${left_parts[index]:-0}"
+    right_component="${right_parts[index]:-0}"
+    if (( 10#$left_component > 10#$right_component )); then
+      printf '1\n'
+      return
+    fi
+    if (( 10#$left_component < 10#$right_component )); then
+      printf '\055\061\n'
+      return
+    fi
+  done
+  printf '0\n'
+}
+
+version_ge() {
+  [[ "$(version_compare "$1" "$2")" != "-1" ]]
+}
+
+version_gt() {
+  [[ "$(version_compare "$1" "$2")" == "1" ]]
+}
+
+node_version_matches_clause() {
+  local version="$1"
+  local clause="$2"
+
+  case "$clause" in
+    ^*)
+      local base="${clause#^}"
+      is_release_version "$base" || die "Unsupported frontend engines.node clause:" \
+        "'$clause' (expected ^X.Y.Z)."
+      [[ "${version%%.*}" == "${base%%.*}" ]] && version_ge "$version" "$base"
+      ;;
+    '>='*)
+      local base="${clause#>=}"
+      is_release_version "$base" || die "Unsupported frontend engines.node clause:" \
+        "'$clause' (expected >=X.Y.Z)."
+      version_ge "$version" "$base"
+      ;;
+    *)
+      is_release_version "$clause" || die "Unsupported frontend engines.node clause:" \
+        "'$clause' (expected an exact X.Y.Z version, ^X.Y.Z, or >=X.Y.Z)."
+      [[ "$version" == "$clause" ]]
+      ;;
+  esac
+}
+
+# Range syntax supported: `||`-separated clauses of `^X.Y.Z`, `>=X.Y.Z`, or an
+# exact version, which is what frontend/package.json's engines.node uses.
+node_version_satisfies_engine_range() {
+  local version="$1"
+  local range="$2"
+  local clause
+
+  is_release_version "$version" || return 1
+
+  while IFS= read -r clause; do
+    clause="${clause#"${clause%%[![:space:]]*}"}"
+    clause="${clause%"${clause##*[![:space:]]}"}"
+    [[ -z "$clause" ]] && continue
+    node_version_matches_clause "$version" "$clause" && return 0
+  done <<< "${range//||/$'\n'}"
+  return 1
+}
+
+frontend_node_engine_range() {
+  local package_json="$APP_DIR/frontend/package.json"
+
+  [[ -r "$package_json" ]] || die "Frontend package.json is missing or unreadable: $package_json"
+  awk -F'"' '
+    /"engines"[[:space:]]*:/ { in_engines = 1 }
+    in_engines {
+      for (i = 1; i <= NF; i++) {
+        if ($i == "node") {
+          print $(i + 2)
+          exit
+        }
+      }
+    }
+    in_engines && /}/ { in_engines = 0 }
+  ' "$package_json"
+}
+
+load_nvm() {
+  local nvm_script="$NVM_DIR/nvm.sh"
+
+  [[ -r "$nvm_script" ]] || die "Current Node.js does not satisfy the frontend's" \
+    "engine requirement and nvm was not found at $nvm_script. Install a" \
+    "compatible Node.js version, install nvm, or set NVM_DIR to where nvm is installed."
+
+  # nvm.sh is not written for `set -Eeuo pipefail`: it references some
+  # unset variables, and sourcing it normally auto-activates the `default`
+  # alias, which returns non-zero (aborting this script under -e) whenever
+  # that alias points at a version that has since been uninstalled -- before
+  # the caller ever gets to scan installed versions. `--no-use` skips that
+  # auto-activation, and errexit/nounset/pipefail/ERR are relaxed only for
+  # the source itself; loading is verified afterward by checking for the
+  # `nvm` function, so a real failure to load still produces an actionable
+  # error.
+  local restore_errexit=0 restore_nounset=0 restore_pipefail=0
+  [[ $- == *e* ]] && restore_errexit=1
+  [[ $- == *u* ]] && restore_nounset=1
+  [[ ":$SHELLOPTS:" == *:pipefail:* ]] && restore_pipefail=1
+
+  set +e
+  set +u
+  set +o pipefail
+  trap - ERR
+  # shellcheck source=/dev/null
+  . "$nvm_script" --no-use
+
+  (( restore_errexit )) && set -e
+  (( restore_nounset )) && set -u
+  (( restore_pipefail )) && set -o pipefail
+  trap 'on_error $LINENO' ERR
+
+  command -v nvm >/dev/null 2>&1 || die "Sourced $nvm_script but the nvm function did not load."
+}
+
+# Activates an installed nvm Node.js version matching DEPLOY_NODE_VERSION.
+# Never installs a version; nvm reports a clear error when it is missing.
+select_requested_nvm_node() {
+  local requested_version="$1"
+  local engine_range="$2"
+  local resolved_version
+
+  load_nvm
+  nvm use "$requested_version" >/dev/null || \
+    die "DEPLOY_NODE_VERSION=$requested_version is not installed via nvm." \
+      "Install it with 'nvm install $requested_version' or unset" \
+      "DEPLOY_NODE_VERSION to auto-select an installed compatible version."
+
+  resolved_version="$(node --version)"
+  resolved_version="${resolved_version#v}"
+  node_version_satisfies_engine_range "$resolved_version" "$engine_range" || \
+    die "DEPLOY_NODE_VERSION=$requested_version resolves to Node.js" \
+      "$resolved_version, which does not satisfy frontend engines.node:" \
+      "$engine_range."
+  log "Using nvm-selected Node.js $resolved_version (DEPLOY_NODE_VERSION=$requested_version)"
+}
+
+# Picks the highest already-installed nvm Node.js version that satisfies
+# engine_range by reading nvm's on-disk version directories directly, since
+# their layout is stable across nvm releases and avoids parsing `nvm ls`
+# output. Never installs a version.
+select_compatible_nvm_node() {
+  local engine_range="$1"
+  local versions_dir
+  local candidate_dir candidate_version
+  local best_version=""
+
+  load_nvm
+  versions_dir="$NVM_DIR/versions/node"
+  [[ -d "$versions_dir" ]] || die "No nvm-managed Node.js versions found in" \
+    "$versions_dir. Install a version that satisfies frontend engines.node" \
+    "($engine_range) with nvm, or set DEPLOY_NODE_VERSION."
+
+  for candidate_dir in "$versions_dir"/v*; do
+    [[ -x "$candidate_dir/bin/node" ]] || continue
+    candidate_version="$(basename "$candidate_dir")"
+    candidate_version="${candidate_version#v}"
+    if node_version_satisfies_engine_range "$candidate_version" "$engine_range"; then
+      if [[ -z "$best_version" ]] || version_gt "$candidate_version" "$best_version"; then
+        best_version="$candidate_version"
+      fi
+    fi
+  done
+
+  if [[ -z "$best_version" ]]; then
+    local installed
+    installed="$(ls -1 "$versions_dir" 2>/dev/null | tr '\n' ' ')"
+    die "No installed nvm Node.js version satisfies frontend engines.node" \
+      "($engine_range). Installed versions: ${installed:-none}. Install a" \
+      "compatible version with nvm (for example 'nvm install 22.12.0') or set" \
+      "DEPLOY_NODE_VERSION to an installed compatible version."
+  fi
+
+  nvm use "$best_version" >/dev/null || die "Failed to activate nvm Node.js $best_version."
+  log "Using nvm-selected Node.js $best_version (satisfies frontend engines.node: $engine_range)"
+}
+
+# Ensures the Node.js on PATH for the rest of the script satisfies
+# frontend/package.json's engines.node, switching via nvm when needed. Must
+# run before any `require_cmd npm` / npm invocation, since nvm changes PATH
+# only for the current shell.
+ensure_frontend_node_runtime() {
+  local engine_range
+  local current_version
+
+  engine_range="$(frontend_node_engine_range)"
+  [[ -n "$engine_range" ]] || die "Could not read engines.node from frontend/package.json."
+
+  if [[ -n "$DEPLOY_NODE_VERSION" ]]; then
+    select_requested_nvm_node "$DEPLOY_NODE_VERSION" "$engine_range"
+    return
+  fi
+
+  if command -v node >/dev/null 2>&1; then
+    current_version="$(node --version)"
+    current_version="${current_version#v}"
+    if node_version_satisfies_engine_range "$current_version" "$engine_range"; then
+      log "Using system Node.js $current_version (satisfies frontend engines.node: $engine_range)"
+      return
+    fi
+    log "System Node.js $current_version does not satisfy frontend engines.node: $engine_range"
+  else
+    log "No Node.js found on PATH; frontend requires engines.node: $engine_range"
+  fi
+
+  select_compatible_nvm_node "$engine_range"
+}
+
 run() {
   log "$*"
   "$@"
@@ -83,7 +324,7 @@ backend_service_user() {
 }
 
 run_as_backend_user() {
-  if [[ "$SYSTEMD_SCOPE" == "system" ]]; then
+  if [[ "$SYSTEMD_SCOPE" == "system" && "$BACKEND_RUN_USER" != "$(id -un)" ]]; then
     sudo -H -u "$BACKEND_RUN_USER" -- "$@"
   else
     "$@"
@@ -98,16 +339,34 @@ service_cmd() {
   fi
 }
 
-install_service_file() {
-  local source_file="$1"
+# Resolves the exact, canonical path to the `systemctl` binary so the
+# restart command run under sudo matches the literal path granted in
+# ops/hsclubs-deploy.sudoers -- sudo does not consult PATH the way an
+# interactive shell does, and a symlinked or non-standard location would
+# otherwise silently fail to match that rule.
+resolve_systemctl_bin() {
+  local resolved
 
-  if [[ "$SYSTEMD_SCOPE" == "user" ]]; then
-    local user_unit_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
-    run mkdir -p "$user_unit_dir"
-    run install -m 0644 "$source_file" "$user_unit_dir/$BACKEND_SERVICE"
-  else
-    run sudo install -m 0644 "$source_file" "/etc/systemd/system/$BACKEND_SERVICE"
+  if [[ -n "$SYSTEMCTL_BIN" ]]; then
+    return
   fi
+
+  resolved="$(command -v systemctl)" || die "Missing required command: systemctl"
+  if command -v readlink >/dev/null 2>&1; then
+    resolved="$(readlink -f "$resolved" 2>/dev/null || printf '%s\n' "$resolved")"
+  fi
+  SYSTEMCTL_BIN="$resolved"
+}
+
+# User-scope units are owned by the deployment account, so the script can
+# install and enable them itself without elevation. System-scope units are
+# root-owned and installed once by an admin; see restart_or_require_admin_setup.
+install_user_service_file() {
+  local source_file="$1"
+  local user_unit_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+
+  run mkdir -p "$user_unit_dir"
+  run install -m 0644 "$source_file" "$user_unit_dir/$BACKEND_SERVICE"
 }
 
 validate_configuration() {
@@ -390,14 +649,11 @@ publish_frontend() {
   run sudo rsync -a --delete "$source_dir" "$target_dir"
 }
 
-install_and_start_backend_service() {
+backend_service_unit_content() {
   local jar_path="$1"
   local java_path
-  local service_file
 
   java_path="$(command -v java)"
-  service_file="$(mktemp)"
-
   {
     printf '%s\n' \
       '[Unit]' \
@@ -423,17 +679,78 @@ install_and_start_backend_service() {
     else
       printf 'WantedBy=default.target\n'
     fi
-  } > "$service_file"
+  }
+}
 
-  if ! install_service_file "$service_file"; then
+install_and_start_backend_service() {
+  local jar_path="$1"
+  local service_file
+
+  service_file="$(mktemp)"
+  backend_service_unit_content "$jar_path" > "$service_file"
+  chmod 0600 "$service_file"
+
+  if [[ "$SYSTEMD_SCOPE" != "user" ]]; then
+    restart_or_require_admin_setup "$service_file"
     rm -f "$service_file"
-    die "Could not install the systemd service file."
+    return
+  fi
+
+  if ! install_user_service_file "$service_file"; then
+    rm -f "$service_file"
+    die "Could not install the systemd user service file."
   fi
   rm -f "$service_file"
 
   run service_cmd daemon-reload
   run service_cmd enable "$BACKEND_SERVICE"
   run service_cmd restart "$BACKEND_SERVICE"
+}
+
+# System-scope units are root-owned and already installed by an admin;
+# routine deploys must not reinstall, daemon-reload, or re-enable them. This
+# compares the desired unit against the installed one and, if they match and
+# the unit is enabled, runs only the exact restart command granted by
+# ops/hsclubs-deploy.sudoers. Otherwise it fails with the one-time setup an
+# admin must run by hand, rather than attempting a broad privileged install.
+restart_or_require_admin_setup() {
+  local desired_file="$1"
+  local installed_unit="$SYSTEM_UNIT_DIR/$BACKEND_SERVICE"
+
+  if [[ -f "$installed_unit" ]] \
+    && diff -q "$desired_file" "$installed_unit" >/dev/null 2>&1 \
+    && systemctl is-enabled --quiet "$BACKEND_SERVICE" 2>/dev/null; then
+    run sudo "$SYSTEMCTL_BIN" restart "$BACKEND_SERVICE"
+    return
+  fi
+
+  fail_with_admin_setup_instructions "$desired_file" "$installed_unit"
+}
+
+fail_with_admin_setup_instructions() {
+  local desired_file="$1"
+  local installed_unit="$2"
+
+  {
+    printf '\nERROR: %s is missing, different from the unit this deploy\n' "$installed_unit"
+    printf 'would install, or not enabled. Routine deploys never install, enable,\n'
+    printf 'or daemon-reload a system-scope unit; that is a one-time admin task.\n\n'
+    printf 'Generated the desired unit at: %s\n' "$desired_file"
+    printf '(mode 0600, owned by this account; the path is unpredictable and not\n'
+    printf 'reused across runs, so do not copy it to a fixed location.)\n\n'
+    printf 'Run once, as an administrator, to install it:\n\n'
+    printf '  sudo install -m 0644 "%s" "%s"\n' "$desired_file" "$installed_unit"
+    printf '  sudo systemctl daemon-reload\n'
+    printf '  sudo systemctl enable "%s"\n' "$BACKEND_SERVICE"
+    printf '  sudo systemctl start "%s"\n\n' "$BACKEND_SERVICE"
+    printf 'Then grant the deploy account the restart-only sudoers rule (see\n'
+    printf 'ops/hsclubs-deploy.sudoers):\n\n'
+    printf '  sudo visudo -cf ops/hsclubs-deploy.sudoers\n'
+    printf '  sudo install -m 0440 ops/hsclubs-deploy.sudoers /etc/sudoers.d/hsclubs-deploy\n\n'
+    printf 'Re-run this deploy once the unit is installed, enabled, and matches.\n'
+    printf 'Once installed, remove the generated file: rm -f "%s"\n' "$desired_file"
+  } >&2
+  exit 1
 }
 
 wait_for_backend() {
@@ -449,7 +766,12 @@ wait_for_backend() {
     fi
   done
 
-  service_cmd status "$BACKEND_SERVICE" --no-pager || true
+  if [[ "$SYSTEMD_SCOPE" == "user" ]]; then
+    service_cmd status "$BACKEND_SERVICE" --no-pager || true
+  else
+    # Reading unit status does not require root, unlike restart/enable.
+    systemctl status "$BACKEND_SERVICE" --no-pager || true
+  fi
   die "Backend health check failed after 60 seconds: $BACKEND_HEALTH_URL"
 }
 
@@ -457,15 +779,17 @@ main() {
   validate_deployment_user
 
   require_cmd git
-  require_cmd npm
   require_cmd rsync
   require_cmd java
   require_cmd curl
   require_cmd systemctl
   require_cmd install
   require_cmd mktemp
+  require_cmd diff
+  require_cmd chmod
   if [[ "$SYSTEMD_SCOPE" == "system" ]]; then
     require_cmd sudo
+    resolve_systemctl_bin
   fi
 
   resolve_backend_run_user
@@ -477,6 +801,8 @@ main() {
 
   log "Building frontend"
   cd "$APP_DIR/frontend"
+  ensure_frontend_node_runtime
+  require_cmd npm
   run npm ci --include=dev
   run npm run build
 
@@ -503,4 +829,8 @@ main() {
   log "Deployment complete"
 }
 
-main "$@"
+# Guarded so tests can source this file to reach the individual functions
+# above without running the full deployment.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/scripts/test-deploy-main.sh
+++ b/scripts/test-deploy-main.sh
@@ -1,0 +1,671 @@
+#!/usr/bin/env bash
+# Focused tests for the Node.js range/parser/runtime-selection functions in
+# deploy-main.sh. No test framework: each check is a small function that
+# reports pass/fail, run against fixtures under a throwaway temp directory.
+# Nothing here touches the host's real nvm installation, system Node.js, or
+# the network -- every PATH, NVM_DIR, and APP_DIR used below is a fixture
+# created by this script.
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_MAIN="$SCRIPT_DIR/deploy-main.sh"
+DEPLOYMENT_DOC="$SCRIPT_DIR/../docs/DEPLOYMENT.md"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+FIXTURE_ROOT="$(mktemp -d)"
+cleanup() {
+  rm -rf "$FIXTURE_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  printf 'FAIL: %s\n' "$*" >&2
+}
+
+pass() {
+  printf 'ok - %s\n' "$*"
+}
+
+run_test() {
+  local name="$1"
+  shift
+  TESTS_RUN=$((TESTS_RUN + 1))
+  if "$@"; then
+    pass "$name"
+  else
+    fail "$name"
+  fi
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local message="${3:-}"
+  if [[ "$expected" == "$actual" ]]; then
+    return 0
+  fi
+  printf '  expected: %s\n  actual:   %s\n  %s\n' "$expected" "$actual" "$message" >&2
+  return 1
+}
+
+# Runs a snippet of code in a fresh, isolated shell: it sources deploy-main.sh
+# (which never runs main() when sourced) with the given environment, then
+# evaluates the snippet. Captures combined stdout+stderr and the exit code so
+# tests can assert on either without depending on real system state.
+run_isolated() {
+  local env_assignments="$1"
+  local snippet="$2"
+  env -i \
+    PATH="$FIXTURE_ROOT/bin:/usr/bin:/bin" \
+    HOME="$FIXTURE_ROOT/home" \
+    bash --noprofile --norc -c "
+      $env_assignments
+      # shellcheck source=/dev/null
+      source '$DEPLOY_MAIN'
+      $snippet
+    " 2>&1
+}
+
+### Fixtures ###############################################################
+
+REPO_DIR="$FIXTURE_ROOT/repo"
+mkdir -p "$REPO_DIR/frontend" "$REPO_DIR/.git" "$FIXTURE_ROOT/home" "$FIXTURE_ROOT/bin"
+cat > "$REPO_DIR/frontend/package.json" <<'JSON'
+{
+  "name": "fixture-frontend",
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  }
+}
+JSON
+
+NVM_ROOT="$FIXTURE_ROOT/nvm"
+VERSIONS_DIR="$NVM_ROOT/versions/node"
+mkdir -p "$VERSIONS_DIR"
+
+make_fake_node() {
+  local version_dir="$1"
+  local reported_version="$2"
+  mkdir -p "$version_dir/bin"
+  cat > "$version_dir/bin/node" <<SH
+#!/usr/bin/env bash
+if [[ "\$1" == "--version" ]]; then
+  echo "v$reported_version"
+fi
+SH
+  chmod +x "$version_dir/bin/node"
+}
+
+# Compatible with `^20.19.0`.
+make_fake_node "$VERSIONS_DIR/v20.19.0" "20.19.0"
+make_fake_node "$VERSIONS_DIR/v20.25.3" "20.25.3"
+# Not compatible with either clause: major 21 satisfies neither `^20.19.0`
+# (major must stay 20) nor `>=22.12.0`.
+make_fake_node "$VERSIONS_DIR/v21.0.0" "21.0.0"
+# Compatible with `>=22.12.0`, including the highest installed version, so
+# selection has to compare across both clauses rather than picking within one.
+make_fake_node "$VERSIONS_DIR/v22.12.0" "22.12.0"
+make_fake_node "$VERSIONS_DIR/v23.1.0" "23.1.0"
+# A prerelease/nightly directory name: must never be selected, and must never
+# be treated as a huge version by concatenating its suffix digits.
+make_fake_node "$VERSIONS_DIR/v22.20.0-nightly20240101" "22.20.0-nightly20240101"
+
+# A well-behaved fake nvm.sh for the selection tests below: defines the `nvm`
+# function and activates a version by prepending its bin dir to PATH.
+cat > "$NVM_ROOT/nvm.sh" <<'SH'
+#!/usr/bin/env bash
+nvm() {
+  case "${1:-}" in
+    use)
+      local version="$2"
+      local version_dir="$NVM_DIR/versions/node/v$version"
+      [[ -x "$version_dir/bin/node" ]] || return 1
+      export PATH="$version_dir/bin:$PATH"
+      return 0
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+SH
+
+# A dedicated, separate nvm installation: a hostile fake nvm.sh standing in
+# for a real installation with a stale
+# `default` alias: sourced without `--no-use` it fails outright (simulating
+# `nvm use default` failing because the aliased version was removed), and it
+# references an unset variable (simulating known unset-variable spots in real
+# nvm.sh). A correct load_nvm must pass `--no-use` and relax `set -u` around
+# the source, or this aborts the caller before any version is scanned. Kept
+# in its own directory so it never overwrites the well-behaved nvm.sh other
+# tests rely on.
+HOSTILE_NVM_ROOT="$FIXTURE_ROOT/hostile-nvm"
+mkdir -p "$HOSTILE_NVM_ROOT"
+cat > "$HOSTILE_NVM_ROOT/nvm.sh" <<'SH'
+#!/usr/bin/env bash
+if [[ "${1:-}" != "--no-use" ]]; then
+  echo "hostile-nvm: stale default alias failed" >&2
+  return 1
+fi
+: "$FAKE_NVM_UNSET_VAR"
+nvm() {
+  case "${1:-}" in
+    use)
+      local version="$2"
+      local version_dir="$NVM_DIR/versions/node/v$version"
+      [[ -x "$version_dir/bin/node" ]] || return 1
+      export PATH="$version_dir/bin:$PATH"
+      return 0
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+SH
+
+COMMON_ENV="export APP_DIR='$REPO_DIR' NVM_DIR='$NVM_ROOT'"
+
+### node_version_satisfies_engine_range: boundary versions #################
+
+test_range_lower_bound_caret_matches() {
+  local output
+  output="$(run_isolated "$COMMON_ENV" '
+    node_version_satisfies_engine_range "20.19.0" "^20.19.0 || >=22.12.0" && echo yes || echo no
+  ')"
+  assert_eq "yes" "$output" "20.19.0 is the inclusive floor of ^20.19.0"
+}
+
+test_range_below_lower_bound_caret_rejected() {
+  local output
+  output="$(run_isolated "$COMMON_ENV" '
+    node_version_satisfies_engine_range "20.18.9" "^20.19.0 || >=22.12.0" && echo yes || echo no
+  ')"
+  assert_eq "no" "$output" "20.18.9 is just below the ^20.19.0 floor"
+}
+
+test_range_next_major_rejected_by_caret() {
+  local output
+  output="$(run_isolated "$COMMON_ENV" '
+    node_version_satisfies_engine_range "21.0.0" "^20.19.0 || >=22.12.0" && echo yes || echo no
+  ')"
+  assert_eq "no" "$output" "21.x satisfies neither clause"
+}
+
+test_range_gte_lower_bound_matches() {
+  local output
+  output="$(run_isolated "$COMMON_ENV" '
+    node_version_satisfies_engine_range "22.12.0" "^20.19.0 || >=22.12.0" && echo yes || echo no
+  ')"
+  assert_eq "yes" "$output" "22.12.0 is the inclusive floor of >=22.12.0"
+}
+
+test_range_below_gte_bound_rejected() {
+  local output
+  output="$(run_isolated "$COMMON_ENV" '
+    node_version_satisfies_engine_range "22.11.9" "^20.19.0 || >=22.12.0" && echo yes || echo no
+  ')"
+  assert_eq "no" "$output" "22.11.9 is just below the >=22.12.0 floor"
+}
+
+test_range_far_above_gte_bound_matches() {
+  local output
+  output="$(run_isolated "$COMMON_ENV" '
+    node_version_satisfies_engine_range "23.5.0" "^20.19.0 || >=22.12.0" && echo yes || echo no
+  ')"
+  assert_eq "yes" "$output" "23.5.0 satisfies >=22.12.0"
+}
+
+test_range_rejects_prerelease_version_string() {
+  local output
+  output="$(run_isolated "$COMMON_ENV" '
+    node_version_satisfies_engine_range "22.12.0-nightly20240101" "^20.19.0 || >=22.12.0" && echo yes || echo no
+  ')"
+  assert_eq "no" "$output" \
+    "a prerelease/nightly version string must be rejected outright, not parsed as a huge release"
+}
+
+test_range_rejects_shorthand_gte_clause_instead_of_accepting() {
+  local output
+  local status=0
+  output="$(run_isolated "$COMMON_ENV" '
+    node_version_satisfies_engine_range "23.5.0" ">=22"
+  ')" || status=$?
+  [[ "$status" -ne 0 ]] || {
+    printf '  a shorthand ">=22" clause must fail closed, not silently accept, got: %s\n' "$output" >&2
+    return 1
+  }
+  [[ "$output" == *"Unsupported frontend engines.node clause"* ]] || {
+    printf '  expected an actionable unsupported-range error, got: %s\n' "$output" >&2
+    return 1
+  }
+}
+
+test_range_rejects_garbage_gte_clause_instead_of_accepting() {
+  local output
+  local status=0
+  output="$(run_isolated "$COMMON_ENV" '
+    node_version_satisfies_engine_range "23.5.0" ">=garbage"
+  ')" || status=$?
+  [[ "$status" -ne 0 ]] || {
+    printf '  a garbage ">=garbage" clause must fail closed, not silently accept, got: %s\n' "$output" >&2
+    return 1
+  }
+  [[ "$output" == *"Unsupported frontend engines.node clause"* ]] || {
+    printf '  expected an actionable unsupported-range error, got: %s\n' "$output" >&2
+    return 1
+  }
+}
+
+test_range_rejects_shorthand_caret_clause_instead_of_accepting() {
+  local output
+  local status=0
+  output="$(run_isolated "$COMMON_ENV" '
+    node_version_satisfies_engine_range "22.12.0" "^22"
+  ')" || status=$?
+  [[ "$status" -ne 0 ]] || {
+    printf '  a shorthand "^22" clause must fail closed, not silently accept, got: %s\n' "$output" >&2
+    return 1
+  }
+  [[ "$output" == *"Unsupported frontend engines.node clause"* ]] || {
+    printf '  expected an actionable unsupported-range error, got: %s\n' "$output" >&2
+    return 1
+  }
+}
+
+### select_compatible_nvm_node: picks the highest compatible, real release ##
+
+test_selects_highest_compatible_across_clauses() {
+  local output
+  output="$(run_isolated "$COMMON_ENV" '
+    select_compatible_nvm_node "^20.19.0 || >=22.12.0" >/dev/null
+    node --version
+  ')"
+  assert_eq "v23.1.0" "$output" \
+    "must compare candidates across both clauses, not just within the first one that matches"
+}
+
+test_never_selects_nightly_directory() {
+  local output
+  output="$(run_isolated "$COMMON_ENV" '
+    select_compatible_nvm_node ">=22.12.0" >/dev/null 2>&1
+    node --version
+  ')"
+  assert_eq "v23.1.0" "$output" \
+    "a nightly-suffixed directory must never be selected, even when it numerically looks newest"
+}
+
+### DEPLOY_NODE_VERSION override ############################################
+
+test_deploy_node_version_override_selects_requested_version() {
+  local output
+  output="$(run_isolated "$COMMON_ENV; export DEPLOY_NODE_VERSION=20.19.0" '
+    ensure_frontend_node_runtime >/dev/null
+    node --version
+  ')"
+  assert_eq "v20.19.0" "$output" \
+    "an explicit override must win even though a higher version is also installed"
+}
+
+test_deploy_node_version_incompatible_override_fails() {
+  local output
+  local status=0
+  output="$(run_isolated "$COMMON_ENV; export DEPLOY_NODE_VERSION=21.0.0" '
+    ensure_frontend_node_runtime
+  ')" || status=$?
+  [[ "$status" -ne 0 ]] || { printf '  expected a non-zero exit, got 0\n' >&2; return 1; }
+  [[ "$output" == *"does not satisfy"* ]] || {
+    printf '  expected an actionable "does not satisfy" message, got: %s\n' "$output" >&2
+    return 1
+  }
+}
+
+### No nvm and no compatible system Node.js: fails with an actionable error #
+
+test_no_nvm_and_incompatible_system_node_fails_with_actionable_message() {
+  local output
+  local status=0
+  local system_node_dir="$FIXTURE_ROOT/system-node-incompatible"
+  make_fake_node "$system_node_dir" "18.0.0"
+  output="$(env -i \
+    PATH="$system_node_dir/bin:/usr/bin:/bin" \
+    HOME="$FIXTURE_ROOT/home" \
+    bash --noprofile --norc -c "
+      export APP_DIR='$REPO_DIR' NVM_DIR='$FIXTURE_ROOT/nonexistent-nvm'
+      # shellcheck source=/dev/null
+      source '$DEPLOY_MAIN'
+      ensure_frontend_node_runtime
+    " 2>&1)" || status=$?
+  [[ "$status" -ne 0 ]] || { printf '  expected a non-zero exit, got 0\n' >&2; return 1; }
+  [[ "$output" == *"nvm was not found"* ]] || {
+    printf '  expected an actionable "nvm was not found" message, got: %s\n' "$output" >&2
+    return 1
+  }
+}
+
+### Hardened nvm.sh sourcing #################################################
+
+test_load_nvm_survives_stale_default_alias_and_unset_variable() {
+  local output
+  local status=0
+  output="$(run_isolated "export APP_DIR='$REPO_DIR' NVM_DIR='$HOSTILE_NVM_ROOT'" '
+    load_nvm
+    command -v nvm >/dev/null 2>&1 && echo nvm-loaded || echo nvm-missing
+  ')" || status=$?
+  [[ "$status" -eq 0 ]] || { printf '  expected exit 0, got %s: %s\n' "$status" "$output" >&2; return 1; }
+  assert_eq "nvm-loaded" "$output" "load_nvm must define nvm despite the hostile fixture"
+}
+
+test_load_nvm_restores_shell_options_after_sourcing() {
+  local output
+  output="$(run_isolated "export APP_DIR='$REPO_DIR' NVM_DIR='$HOSTILE_NVM_ROOT'" '
+    load_nvm
+    case $- in *e*) errexit=on;; *) errexit=off;; esac
+    case $- in *u*) nounset=on;; *) nounset=off;; esac
+    case ":$SHELLOPTS:" in *:pipefail:*) pipefail=on;; *) pipefail=off;; esac
+    echo "$errexit,$nounset,$pipefail"
+  ')"
+  assert_eq "on,on,on" "$output" \
+    "errexit/nounset/pipefail must be restored once load_nvm returns"
+}
+
+### Restricted sudo deployment: restart-only fast path ######################
+
+DEPLOY_FIXTURE_BIN="$FIXTURE_ROOT/deploy-bin"
+mkdir -p "$DEPLOY_FIXTURE_BIN"
+cat > "$DEPLOY_FIXTURE_BIN/java" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$DEPLOY_FIXTURE_BIN/java"
+
+# Fake sudo: records every invocation (proving whether a privileged command
+# ran at all) and then executes it for real, so a test can assert on both
+# "was sudo called" and "what did the privileged command do".
+cat > "$DEPLOY_FIXTURE_BIN/sudo" <<'SH'
+#!/usr/bin/env bash
+echo "sudo $*" >> "$SUDO_LOG"
+# Strips the sudo flags this repo's scripts use (-H, -u USER, --) before
+# executing the target command for realism; real sudo parses these itself.
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -H) shift ;;
+    -u) shift 2 ;;
+    --) shift; break ;;
+    *) break ;;
+  esac
+done
+exec "$@"
+SH
+chmod +x "$DEPLOY_FIXTURE_BIN/sudo"
+
+# Fake systemctl: only understands the two subcommands restart_or_require_
+# admin_setup uses. `is-enabled` and `restart` are logged separately from
+# `sudo` so a test can tell a bare (non-root) status read apart from the
+# privileged restart.
+cat > "$DEPLOY_FIXTURE_BIN/systemctl" <<'SH'
+#!/usr/bin/env bash
+echo "systemctl $*" >> "$SYSTEMCTL_LOG"
+case "$1" in
+  is-enabled)
+    [[ "$FAKE_UNIT_ENABLED" == "1" ]]
+    exit $?
+    ;;
+  restart)
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+SH
+chmod +x "$DEPLOY_FIXTURE_BIN/systemctl"
+
+# Runs restart_or_require_admin_setup against a fixture SYSTEM_UNIT_DIR and
+# fake sudo/systemctl. Writes its exit status, combined output, and the two
+# fake command logs to files under $FIXTURE_ROOT (rather than packing them
+# into one returned string) since the output can itself contain newlines.
+run_restart_or_require_admin_setup() {
+  local unit_dir="$1"
+  local unit_enabled="$2"
+  local sudo_log="$FIXTURE_ROOT/sudo.log"
+  local systemctl_log="$FIXTURE_ROOT/systemctl.log"
+  local output_file="$FIXTURE_ROOT/restart-output.log"
+  local status_file="$FIXTURE_ROOT/restart-status"
+  local status=0
+  local output
+
+  : > "$sudo_log"
+  : > "$systemctl_log"
+
+  output="$(env -i \
+    PATH="$DEPLOY_FIXTURE_BIN:/usr/bin:/bin" \
+    HOME="$FIXTURE_ROOT/home" \
+    SUDO_LOG="$sudo_log" \
+    SYSTEMCTL_LOG="$systemctl_log" \
+    FAKE_UNIT_ENABLED="$unit_enabled" \
+    bash --noprofile --norc -c "
+      export APP_DIR='$REPO_DIR' SYSTEM_UNIT_DIR='$unit_dir'
+      export BACKEND_SERVICE='hsclubs.service' SYSTEMCTL_BIN='$DEPLOY_FIXTURE_BIN/systemctl'
+      # shellcheck source=/dev/null
+      source '$DEPLOY_MAIN'
+      backend_service_unit_content /fixture/backend.jar > '$FIXTURE_ROOT/desired.service'
+      restart_or_require_admin_setup '$FIXTURE_ROOT/desired.service'
+    " 2>&1)" || status=$?
+
+  printf '%s\n' "$status" > "$status_file"
+  printf '%s\n' "$output" > "$output_file"
+}
+
+### docs/DEPLOYMENT.md sample must match backend_service_unit_content #######
+
+test_deployment_doc_systemd_sample_matches_generated_unit() {
+  local expected_ini actual_ini
+  local fixture_java_dir="$FIXTURE_ROOT/usr-bin"
+  mkdir -p "$fixture_java_dir"
+  cat > "$fixture_java_dir/java" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fixture_java_dir/java"
+
+  expected_ini="$(awk '
+    /^### Run as a service \(systemd\)/ { in_section = 1 }
+    in_section && /^```ini$/ { in_block = 1; next }
+    in_block && /^```$/ { exit }
+    in_block { print }
+  ' "$DEPLOYMENT_DOC")"
+  expected_ini="${expected_ini//\/usr\/bin\/java/$fixture_java_dir/java}"
+
+  actual_ini="$(env -i PATH="$fixture_java_dir:/usr/bin:/bin" HOME="$FIXTURE_ROOT/home" \
+    bash --noprofile --norc -c "
+      export APP_DIR=/opt/hsclubs BACKEND_ENV_FILE=/opt/hsclubs/backend/.env
+      export BACKEND_RUN_USER=your-deploy-user SYSTEMD_SCOPE=system
+      # shellcheck source=/dev/null
+      source '$DEPLOY_MAIN'
+      backend_service_unit_content /opt/hsclubs/backend/target/demo-0.0.1-SNAPSHOT.jar
+    ")"
+
+  assert_eq "$expected_ini" "$actual_ini" \
+    "docs/DEPLOYMENT.md's sample unit must be byte-for-byte what backend_service_unit_content generates for its documented defaults"
+}
+
+test_restart_only_when_unit_matches_and_enabled() {
+  local unit_dir="$FIXTURE_ROOT/unit-matches"
+  mkdir -p "$unit_dir"
+  # The installed unit must be byte-for-byte what backend_service_unit_content
+  # would generate for the same jar path, so build it the same way.
+  env -i PATH="$DEPLOY_FIXTURE_BIN:/usr/bin:/bin" HOME="$FIXTURE_ROOT/home" \
+    bash --noprofile --norc -c "
+      export APP_DIR='$REPO_DIR' SYSTEM_UNIT_DIR='$unit_dir' BACKEND_SERVICE='hsclubs.service'
+      source '$DEPLOY_MAIN'
+      backend_service_unit_content /fixture/backend.jar
+    " > "$unit_dir/hsclubs.service"
+
+  run_restart_or_require_admin_setup "$unit_dir" "1"
+  local status output sudo_log systemctl_log
+  status="$(cat "$FIXTURE_ROOT/restart-status")"
+  output="$(cat "$FIXTURE_ROOT/restart-output.log")"
+  sudo_log="$(cat "$FIXTURE_ROOT/sudo.log")"
+  systemctl_log="$(cat "$FIXTURE_ROOT/systemctl.log")"
+
+  [[ "$status" -eq 0 ]] || { printf '  expected exit 0, got %s: %s\n' "$status" "$output" >&2; return 1; }
+  [[ "$sudo_log" == *"restart hsclubs.service"* ]] || {
+    printf '  expected the restart-only sudo command, got: %s\n' "$sudo_log" >&2
+    return 1
+  }
+  [[ "$systemctl_log" != *"daemon-reload"* && "$systemctl_log" != *"systemctl enable"* ]] || {
+    printf '  must never daemon-reload or enable an unchanged unit, got: %s\n' "$systemctl_log" >&2
+    return 1
+  }
+}
+
+test_refuses_before_privileged_install_when_unit_is_missing() {
+  local unit_dir="$FIXTURE_ROOT/unit-missing"
+  mkdir -p "$unit_dir"
+
+  run_restart_or_require_admin_setup "$unit_dir" "1"
+  local status output sudo_log
+  status="$(cat "$FIXTURE_ROOT/restart-status")"
+  output="$(cat "$FIXTURE_ROOT/restart-output.log")"
+  sudo_log="$(cat "$FIXTURE_ROOT/sudo.log")"
+
+  [[ "$status" -ne 0 ]] || { printf '  expected a non-zero exit, got 0\n' >&2; return 1; }
+  [[ -z "$sudo_log" ]] || {
+    printf '  must never invoke sudo when the unit is missing, got: %s\n' "$sudo_log" >&2
+    return 1
+  }
+  [[ "$output" == *"one-time admin task"* ]] || {
+    printf '  expected one-time admin setup instructions, got: %s\n' "$output" >&2
+    return 1
+  }
+}
+
+test_admin_setup_instructions_never_copy_to_fixed_path() {
+  local unit_dir="$FIXTURE_ROOT/unit-missing-fixed-path-check"
+  mkdir -p "$unit_dir"
+
+  run_restart_or_require_admin_setup "$unit_dir" "1"
+  local status output
+  status="$(cat "$FIXTURE_ROOT/restart-status")"
+  output="$(cat "$FIXTURE_ROOT/restart-output.log")"
+
+  [[ "$status" -ne 0 ]] || { printf '  expected a non-zero exit, got 0\n' >&2; return 1; }
+  [[ "$output" == *"$FIXTURE_ROOT/desired.service"* ]] || {
+    printf '  expected the message to point at the original generated file, got: %s\n' "$output" >&2
+    return 1
+  }
+  [[ "$output" != *"hsclubs.service.desired"* ]] || {
+    printf '  must never copy the desired unit to a predictable fixed path, got: %s\n' "$output" >&2
+    return 1
+  }
+}
+
+test_refuses_before_privileged_install_when_unit_differs() {
+  local unit_dir="$FIXTURE_ROOT/unit-differs"
+  mkdir -p "$unit_dir"
+  printf '[Unit]\nDescription=Some other unit\n' > "$unit_dir/hsclubs.service"
+
+  run_restart_or_require_admin_setup "$unit_dir" "1"
+  local status output sudo_log
+  status="$(cat "$FIXTURE_ROOT/restart-status")"
+  output="$(cat "$FIXTURE_ROOT/restart-output.log")"
+  sudo_log="$(cat "$FIXTURE_ROOT/sudo.log")"
+
+  [[ "$status" -ne 0 ]] || { printf '  expected a non-zero exit, got 0\n' >&2; return 1; }
+  [[ -z "$sudo_log" ]] || {
+    printf '  must never invoke sudo when the installed unit differs, got: %s\n' "$sudo_log" >&2
+    return 1
+  }
+}
+
+test_refuses_before_privileged_install_when_unit_not_enabled() {
+  local unit_dir="$FIXTURE_ROOT/unit-not-enabled"
+  mkdir -p "$unit_dir"
+  env -i PATH="$DEPLOY_FIXTURE_BIN:/usr/bin:/bin" HOME="$FIXTURE_ROOT/home" \
+    bash --noprofile --norc -c "
+      export APP_DIR='$REPO_DIR' SYSTEM_UNIT_DIR='$unit_dir' BACKEND_SERVICE='hsclubs.service'
+      source '$DEPLOY_MAIN'
+      backend_service_unit_content /fixture/backend.jar
+    " > "$unit_dir/hsclubs.service"
+
+  run_restart_or_require_admin_setup "$unit_dir" "0"
+  local status output sudo_log
+  status="$(cat "$FIXTURE_ROOT/restart-status")"
+  output="$(cat "$FIXTURE_ROOT/restart-output.log")"
+  sudo_log="$(cat "$FIXTURE_ROOT/sudo.log")"
+
+  [[ "$status" -ne 0 ]] || { printf '  expected a non-zero exit, got 0\n' >&2; return 1; }
+  [[ -z "$sudo_log" ]] || {
+    printf '  must never invoke sudo when the unit is not enabled, got: %s\n' "$sudo_log" >&2
+    return 1
+  }
+}
+
+### Restricted sudo deployment: run_as_backend_user skips sudo for self #####
+
+test_run_as_backend_user_skips_sudo_when_same_user() {
+  local output
+  output="$(env -i PATH="/usr/bin:/bin" HOME="$FIXTURE_ROOT/home" \
+    bash --noprofile --norc -c "
+      export APP_DIR='$REPO_DIR' SYSTEMD_SCOPE=system
+      export BACKEND_RUN_USER=\"\$(id -un)\"
+      # shellcheck source=/dev/null
+      source '$DEPLOY_MAIN'
+      run_as_backend_user echo backend-user-ran
+    " 2>&1)"
+  assert_eq "backend-user-ran" "$output" \
+    "must run directly, without sudo, when BACKEND_RUN_USER is the current user"
+}
+
+test_run_as_backend_user_uses_sudo_for_a_different_user() {
+  local output
+  output="$(env -i PATH="$DEPLOY_FIXTURE_BIN:/usr/bin:/bin" HOME="$FIXTURE_ROOT/home" \
+    SUDO_LOG="$FIXTURE_ROOT/different-user-sudo.log" \
+    bash --noprofile --norc -c "
+      : > \"\$SUDO_LOG\"
+      export APP_DIR='$REPO_DIR' SYSTEMD_SCOPE=system BACKEND_RUN_USER=a-different-service-account
+      # shellcheck source=/dev/null
+      source '$DEPLOY_MAIN'
+      run_as_backend_user echo should-not-run-directly >/dev/null 2>&1
+      cat \"\$SUDO_LOG\"
+    " 2>&1)"
+  [[ "$output" == *"sudo -H -u a-different-service-account"* ]] || {
+    printf '  expected sudo -H -u a-different-service-account, got: %s\n' "$output" >&2
+    return 1
+  }
+}
+
+### Run everything ###########################################################
+
+run_test "engine range: caret lower bound matches" test_range_lower_bound_caret_matches
+run_test "engine range: below caret lower bound is rejected" test_range_below_lower_bound_caret_rejected
+run_test "engine range: next major is rejected by caret" test_range_next_major_rejected_by_caret
+run_test "engine range: >= lower bound matches" test_range_gte_lower_bound_matches
+run_test "engine range: below >= lower bound is rejected" test_range_below_gte_bound_rejected
+run_test "engine range: far above >= lower bound matches" test_range_far_above_gte_bound_matches
+run_test "engine range: prerelease version string is rejected" test_range_rejects_prerelease_version_string
+run_test "engine range: shorthand >= clause fails closed" test_range_rejects_shorthand_gte_clause_instead_of_accepting
+run_test "engine range: garbage >= clause fails closed" test_range_rejects_garbage_gte_clause_instead_of_accepting
+run_test "engine range: shorthand ^ clause fails closed" test_range_rejects_shorthand_caret_clause_instead_of_accepting
+run_test "compatible selection: highest across clauses" test_selects_highest_compatible_across_clauses
+run_test "compatible selection: never picks a nightly directory" test_never_selects_nightly_directory
+run_test "override: DEPLOY_NODE_VERSION selects requested version" test_deploy_node_version_override_selects_requested_version
+run_test "override: incompatible DEPLOY_NODE_VERSION fails" test_deploy_node_version_incompatible_override_fails
+run_test "no nvm + incompatible system node fails" test_no_nvm_and_incompatible_system_node_fails_with_actionable_message
+run_test "load_nvm survives a stale default alias and an unset variable" test_load_nvm_survives_stale_default_alias_and_unset_variable
+run_test "load_nvm restores caller shell options" test_load_nvm_restores_shell_options_after_sourcing
+run_test "restart-only fast path when unit matches and is enabled" test_restart_only_when_unit_matches_and_enabled
+run_test "docs/DEPLOYMENT.md systemd sample matches the generated unit" test_deployment_doc_systemd_sample_matches_generated_unit
+run_test "refuses before privileged install: unit missing" test_refuses_before_privileged_install_when_unit_is_missing
+run_test "admin setup instructions never copy to a fixed path" test_admin_setup_instructions_never_copy_to_fixed_path
+run_test "refuses before privileged install: unit differs" test_refuses_before_privileged_install_when_unit_differs
+run_test "refuses before privileged install: unit not enabled" test_refuses_before_privileged_install_when_unit_not_enabled
+run_test "run_as_backend_user skips sudo for the same user" test_run_as_backend_user_skips_sudo_when_same_user
+run_test "run_as_backend_user uses sudo for a different user" test_run_as_backend_user_uses_sudo_for_a_different_user
+
+printf '\n%d run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]


### PR DESCRIPTION
## Summary

- make deployment select an already-installed Node version compatible with `frontend/package.json`, including nvm fallback without network installs
- reduce routine deployment privilege to one exact `systemctl restart hsclubs.service` command
- fail safely when the root-owned service unit is missing, changed, or not enabled
- fix stale-chunk storage behavior and its Node 25/jsdom regression test
- add 25 isolated shell tests for runtime selection, unit validation, and privilege boundaries

## Production verification

- server default Node 18.19.1 is rejected and nvm Node 25.4.0 is selected automatically
- server systemd unit matches the generated unit byte-for-byte
- staleChunk focused suite passes under the server's real Node 25 runtime
- sudoers template parses successfully with `visudo -cf`

## Validation

- `scripts/test-deploy-main.sh` - 25 passed
- `bash -n scripts/deploy-main.sh`
- `bash -n scripts/test-deploy-main.sh`
- `npm exec vitest -- run` - 323 passed
- `npm run type-check`
- `npm run build`
- scoped ESLint for staleChunk files

## One-time admin action

The restricted sudoers rule is intentionally not installable by the deployment account itself. An existing administrator must run the documented `visudo` and `install -m 0440` commands once. Until then, the full deployment script will stop before restarting the backend rather than requesting broad sudo access.