### PR TITLE
fix responsive theme backgrounds

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,31 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title></title>
+    <script>
+      // Runs before Vue mounts (and before any stylesheet needs to be correct) so a
+      // stored dark-mode preference never flashes light for a moment. Keep this rule
+      // in sync with resolveInitialTheme (src/utils/themeBootstrap.ts).
+      // The placeholder below is replaced at build/dev time by the school-brand-title Vite
+      // plugin with the validated VITE_DEFAULT_COLOR_MODE fallback ('light' or 'dark'),
+      // matching schoolTemplate.defaultColorMode.
+      ;(function () {
+        var root = document.documentElement
+        var theme = '__DEFAULT_COLOR_MODE__'
+        if (theme !== 'light' && theme !== 'dark') {
+          theme = 'light'
+        }
+        try {
+          var stored = window.localStorage.getItem('theme')
+          if (stored === 'light' || stored === 'dark') {
+            theme = stored
+          }
+        } catch (error) {
+          /* localStorage unavailable (e.g. private browsing); keep the fallback theme */
+        }
+        root.dataset.theme = theme
+        root.style.colorScheme = theme
+      })()
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/src/App.mobileTheme.spec.ts
+++ b/frontend/src/App.mobileTheme.spec.ts
@@ -1,0 +1,63 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import App from './App.vue'
+
+const stubView = { template: '<div />' }
+
+const buildRouter = () =>
+  createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'home', component: stubView },
+      { path: '/about', name: 'about', component: stubView },
+      { path: '/calendar', name: 'calendar', component: stubView },
+      { path: '/admin', name: 'owner-clubs', component: stubView },
+      { path: '/profile', name: 'profile', component: stubView },
+      { path: '/auth', name: 'auth-choice', component: stubView },
+      { path: '/search', name: 'club-search', component: stubView },
+      { path: '/terms', name: 'terms', component: stubView },
+      { path: '/privacy', name: 'privacy', component: stubView },
+    ],
+  })
+
+const mountApp = async () => {
+  const router = buildRouter()
+  await router.push('/')
+  await router.isReady()
+  return mount(App, { global: { plugins: [router] } })
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  localStorage.clear()
+  document.documentElement.removeAttribute('data-theme')
+})
+
+afterEach(() => {
+  document.documentElement.removeAttribute('data-theme')
+})
+
+describe('mobile menu theme toggle', () => {
+  it('offers a theme toggle with English copy inside the mobile menu', async () => {
+    const wrapper = await mountApp()
+    await wrapper.find('.mobile-menu-toggle').trigger('click')
+
+    const toggle = wrapper.find('.mobile-theme-toggle')
+    expect(toggle.exists()).toBe(true)
+    expect(toggle.text()).toContain('Dark mode')
+  })
+
+  it('switches the document theme when tapped, without closing the mobile menu', async () => {
+    const wrapper = await mountApp()
+    await wrapper.find('.mobile-menu-toggle').trigger('click')
+
+    await wrapper.find('.mobile-theme-toggle').trigger('click')
+
+    expect(document.documentElement.dataset.theme).toBe('dark')
+    expect(localStorage.getItem('theme')).toBe('dark')
+    expect(wrapper.find('.mobile-menu').exists()).toBe(true)
+  })
+})

--- a/frontend/src/App.mobileTheme.spec.ts
+++ b/frontend/src/App.mobileTheme.spec.ts
@@ -1,11 +1,27 @@
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { createMemoryHistory, createRouter } from 'vue-router'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import App from './App.vue'
 
 const stubView = { template: '<div />' }
+const originalLocalStorage = Object.getOwnPropertyDescriptor(window, 'localStorage')
+
+const installBrowserLocalStorage = () => {
+  const values = new Map<string, string>()
+  const storage: Storage = {
+    get length() {
+      return values.size
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => [...values.keys()][index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, String(value)),
+  }
+  Object.defineProperty(window, 'localStorage', { configurable: true, value: storage })
+}
 
 const buildRouter = () =>
   createRouter({
@@ -32,12 +48,20 @@ const mountApp = async () => {
 
 beforeEach(() => {
   setActivePinia(createPinia())
-  window.localStorage.clear()
+  installBrowserLocalStorage()
   document.documentElement.removeAttribute('data-theme')
 })
 
 afterEach(() => {
   document.documentElement.removeAttribute('data-theme')
+})
+
+afterAll(() => {
+  if (originalLocalStorage) {
+    Object.defineProperty(window, 'localStorage', originalLocalStorage)
+  } else {
+    Reflect.deleteProperty(window, 'localStorage')
+  }
 })
 
 describe('mobile menu theme toggle', () => {
@@ -57,7 +81,7 @@ describe('mobile menu theme toggle', () => {
     await wrapper.find('.mobile-theme-toggle').trigger('click')
 
     expect(document.documentElement.dataset.theme).toBe('dark')
-    expect(localStorage.getItem('theme')).toBe('dark')
+    expect(window.localStorage.getItem('theme')).toBe('dark')
     expect(wrapper.find('.mobile-menu').exists()).toBe(true)
   })
 })

--- a/frontend/src/App.mobileTheme.spec.ts
+++ b/frontend/src/App.mobileTheme.spec.ts
@@ -32,7 +32,7 @@ const mountApp = async () => {
 
 beforeEach(() => {
   setActivePinia(createPinia())
-  localStorage.clear()
+  window.localStorage.clear()
   document.documentElement.removeAttribute('data-theme')
 })
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -80,7 +80,7 @@ const applyTheme = (value: ColorMode) => {
 
 const persistTheme = (value: ColorMode) => {
   try {
-    localStorage.setItem('theme', value)
+    window.localStorage.setItem('theme', value)
   } catch (error) {
     console.warn('Failed to persist theme preference.', error)
   }
@@ -93,7 +93,10 @@ const toggleTheme = () => {
 }
 
 try {
-  theme.value = resolveInitialTheme(localStorage.getItem('theme'), schoolTemplate.defaultColorMode)
+  theme.value = resolveInitialTheme(
+    window.localStorage.getItem('theme'),
+    schoolTemplate.defaultColorMode,
+  )
 } catch (error) {
   console.warn('Failed to read theme preference.', error)
 }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -211,6 +211,7 @@ watch(
           class="mobile-menu-toggle"
           :class="{ open: mobileMenuOpen }"
           :aria-expanded="mobileMenuOpen"
+          aria-controls="mobile-navigation"
           aria-label="Toggle menu"
           @click="toggleMobileMenu"
         >
@@ -245,7 +246,7 @@ watch(
       </div>
 
       <Transition name="mobile-menu">
-        <div v-if="mobileMenuOpen" class="mobile-menu">
+        <div v-if="mobileMenuOpen" id="mobile-navigation" class="mobile-menu">
           <div class="mobile-menu-inner">
             <form class="search-bar" @submit.prevent="submitSearch">
               <input
@@ -782,6 +783,16 @@ watch(
 
 .footer-links a:hover {
   color: var(--mv-nav-text-hover);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mobile-menu-enter-active,
+  .mobile-menu-leave-active,
+  .hamburger,
+  .hamburger::before,
+  .hamburger::after {
+    transition: none;
+  }
 }
 
 @media (max-width: 480px) {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -6,6 +6,7 @@ import { storeToRefs } from 'pinia'
 import { useAuthStore } from './stores/auth'
 import ErrorDisplay from './components/ErrorDisplay.vue'
 import { schoolTemplate, type ColorMode } from './config/schoolTemplate'
+import { resolveInitialTheme } from './utils/themeBootstrap'
 
 const searchQuery = ref('')
 const route = useRoute()
@@ -47,6 +48,10 @@ watch(
 )
 
 const logoText = schoolTemplate.brandName
+// A bound constant (rather than a literal in the template) so Vue's asset-url
+// transform, which only rewrites relative paths, leaves this root-absolute
+// public path untouched under both Vite build and Vitest's SSR module runner.
+const logoUrl = '/android-chrome-512x512.png'
 const searchPlaceholder = 'Search clubs, advisors, categories, or keywords'
 document.title = logoText
 
@@ -59,11 +64,18 @@ const handleMobileLogout = () => {
   handleLogout()
 }
 
+// Left open after toggling so the visual change is immediately visible,
+// unlike navigation actions in this menu which close it.
+const handleMobileThemeToggle = () => {
+  toggleTheme()
+}
+
 const theme = ref<ColorMode>(schoolTemplate.defaultColorMode)
 const themeLabel = computed(() => (theme.value === 'light' ? 'Dark mode' : 'Light mode'))
 
 const applyTheme = (value: ColorMode) => {
   document.documentElement.dataset.theme = value
+  document.documentElement.style.colorScheme = value
 }
 
 const persistTheme = (value: ColorMode) => {
@@ -81,10 +93,7 @@ const toggleTheme = () => {
 }
 
 try {
-  const storedTheme = localStorage.getItem('theme')
-  if (storedTheme === 'light' || storedTheme === 'dark') {
-    theme.value = storedTheme
-  }
+  theme.value = resolveInitialTheme(localStorage.getItem('theme'), schoolTemplate.defaultColorMode)
 } catch (error) {
   console.warn('Failed to read theme preference.', error)
 }
@@ -158,7 +167,7 @@ watch(
         <div class="header-left">
           <div class="logo">
             <RouterLink to="/" class="logo-link">
-              <img class="logo-icon" src="/android-chrome-512x512.png" :alt="`${logoText} logo`" />
+              <img class="logo-icon" :src="logoUrl" :alt="`${logoText} logo`" />
               <span class="logo-text">{{ logoText }}</span>
             </RouterLink>
           </div>
@@ -237,53 +246,61 @@ watch(
 
       <Transition name="mobile-menu">
         <div v-if="mobileMenuOpen" class="mobile-menu">
-          <form class="search-bar" @submit.prevent="submitSearch">
-            <input
-              v-model="searchQuery"
-              type="search"
-              :placeholder="searchPlaceholder"
-              class="search-input"
-            />
-            <button type="submit" class="search-button" aria-label="Search clubs">
-              <span class="search-icon">🔍</span>
-            </button>
-          </form>
-          <nav class="mobile-nav">
-            <RouterLink to="/" class="mobile-nav-link" @click="closeMobileMenu">Home</RouterLink>
-            <RouterLink to="/about" class="mobile-nav-link" @click="closeMobileMenu"
-              >Category</RouterLink
-            >
-            <RouterLink to="/calendar" class="mobile-nav-link" @click="closeMobileMenu"
-              >Calendar</RouterLink
-            >
-            <RouterLink
-              v-if="currentUser?.isOwner"
-              to="/admin"
-              class="mobile-nav-link"
-              @click="closeMobileMenu"
-              >Admin</RouterLink
-            >
-          </nav>
-          <div class="mobile-actions">
-            <template v-if="isAuthenticated">
-              <RouterLink to="/profile" class="mobile-nav-link" @click="closeMobileMenu"
-                >Profile</RouterLink
-              >
-              <button type="button" class="auth-btn ghost" @click="handleMobileLogout">
-                Log out
+          <div class="mobile-menu-inner">
+            <form class="search-bar" @submit.prevent="submitSearch">
+              <input
+                v-model="searchQuery"
+                type="search"
+                :placeholder="searchPlaceholder"
+                class="search-input"
+              />
+              <button type="submit" class="search-button" aria-label="Search clubs">
+                <span class="search-icon">🔍</span>
               </button>
-            </template>
-            <template v-else>
-              <RouterLink to="/auth?intent=login" class="mobile-nav-link" @click="closeMobileMenu"
-                >Log in</RouterLink
+            </form>
+            <nav class="mobile-nav">
+              <RouterLink to="/" class="mobile-nav-link" @click="closeMobileMenu">Home</RouterLink>
+              <RouterLink to="/about" class="mobile-nav-link" @click="closeMobileMenu"
+                >Category</RouterLink
+              >
+              <RouterLink to="/calendar" class="mobile-nav-link" @click="closeMobileMenu"
+                >Calendar</RouterLink
               >
               <RouterLink
-                to="/auth?intent=register"
-                class="auth-btn primary"
+                v-if="currentUser?.isOwner"
+                to="/admin"
+                class="mobile-nav-link"
                 @click="closeMobileMenu"
-                >Register</RouterLink
+                >Admin</RouterLink
               >
-            </template>
+            </nav>
+            <button type="button" class="mobile-theme-toggle" @click="handleMobileThemeToggle">
+              <span class="theme-icon" aria-hidden="true">{{
+                theme === 'light' ? '🌙' : '☀️'
+              }}</span>
+              <span>{{ themeLabel }}</span>
+            </button>
+            <div class="mobile-actions">
+              <template v-if="isAuthenticated">
+                <RouterLink to="/profile" class="mobile-nav-link" @click="closeMobileMenu"
+                  >Profile</RouterLink
+                >
+                <button type="button" class="auth-btn ghost" @click="handleMobileLogout">
+                  Log out
+                </button>
+              </template>
+              <template v-else>
+                <RouterLink to="/auth?intent=login" class="mobile-nav-link" @click="closeMobileMenu"
+                  >Log in</RouterLink
+                >
+                <RouterLink
+                  to="/auth?intent=register"
+                  class="auth-btn primary"
+                  @click="closeMobileMenu"
+                  >Register</RouterLink
+                >
+              </template>
+            </div>
           </div>
         </div>
       </Transition>
@@ -312,6 +329,10 @@ watch(
   width: 100%;
   display: flex;
   flex-direction: column;
+  background-color: var(--mv-night);
+  background-image: var(--app-body-bg);
+  background-repeat: no-repeat;
+  background-size: 100% 100%;
 }
 
 .header {
@@ -569,9 +590,17 @@ watch(
 }
 
 .mobile-menu {
-  padding: 1rem var(--page-padding-inline) 1.5rem;
   border-bottom: 1px solid var(--mv-header-border);
   background: var(--mv-header-bg);
+  display: grid;
+  grid-template-rows: 1fr;
+  opacity: 1;
+}
+
+.mobile-menu-inner {
+  overflow: hidden;
+  min-height: 0;
+  padding: 1rem var(--page-padding-inline) 1.5rem;
 }
 
 .mobile-nav {
@@ -601,6 +630,27 @@ watch(
   color: var(--mv-nav-text-active);
 }
 
+.mobile-theme-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  margin-top: 0.5rem;
+  padding: 0.7rem 0.5rem;
+  border-radius: 12px;
+  border: 1px solid var(--mv-ghost-border);
+  background: transparent;
+  color: var(--mv-ghost-text);
+  font-size: 1rem;
+  cursor: pointer;
+  text-align: left;
+}
+
+.mobile-theme-toggle:hover,
+.mobile-theme-toggle:active {
+  background: var(--mv-surface-accent);
+}
+
 .mobile-actions {
   display: flex;
   flex-direction: column;
@@ -617,14 +667,13 @@ watch(
 .mobile-menu-enter-active,
 .mobile-menu-leave-active {
   transition:
-    max-height 0.3s ease,
+    grid-template-rows 0.3s ease,
     opacity 0.25s ease;
-  max-height: 500px;
 }
 
 .mobile-menu-enter-from,
 .mobile-menu-leave-to {
-  max-height: 0;
+  grid-template-rows: 0fr;
   opacity: 0;
 }
 
@@ -638,6 +687,8 @@ watch(
   }
 
   .search-bar {
+    flex: 1 1 180px;
+    min-width: 0;
     max-width: 280px;
   }
 }

--- a/frontend/src/assets/base.css
+++ b/frontend/src/assets/base.css
@@ -1,5 +1,6 @@
 /* Platform color tokens with school-specific overrides */
 :root {
+  color-scheme: light;
   --mv-night: #eef4ff;
   --mv-ink: #f8fbff;
   --mv-graphite: #dce7f7;
@@ -11,6 +12,8 @@
   --mv-text: #0f172a;
   --mv-text-muted: #475569;
   --mv-radius: 28px;
+  /* One continuous background for the whole page (see App.vue's .app-shell):
+     no per-card gradients, so a long page reads as a single vertical strip. */
   --app-body-bg:
     radial-gradient(circle at top left, rgba(59, 130, 246, 0.16), transparent 32%),
     radial-gradient(circle at 85% 12%, rgba(14, 165, 233, 0.14), transparent 30%),
@@ -37,12 +40,10 @@
   --mv-primary-bg: #2563eb;
   --mv-primary-text: #ffffff;
   --mv-primary-shadow: 0 12px 24px rgba(37, 99, 235, 0.24);
-  --mv-surface-hero: linear-gradient(135deg, rgba(239, 246, 255, 0.96), rgba(219, 234, 254, 0.92));
-  --mv-surface-hero-strong: linear-gradient(
-    135deg,
-    rgba(219, 234, 254, 0.96),
-    rgba(191, 219, 254, 0.92)
-  );
+  /* Translucent solid surfaces, not gradients: hero cards let the page's own
+     background gradient show through instead of restarting their own patch. */
+  --mv-surface-hero: rgba(219, 234, 254, 0.55);
+  --mv-surface-hero-strong: rgba(191, 219, 254, 0.62);
   --mv-surface-card: rgba(255, 255, 255, 0.86);
   --mv-surface-card-strong: rgba(248, 251, 255, 0.96);
   --mv-surface-soft: rgba(226, 239, 255, 0.72);
@@ -69,6 +70,7 @@
 }
 
 :root[data-theme='dark'] {
+  color-scheme: dark;
   --mv-night: #07111f;
   --mv-ink: #0b1628;
   --mv-graphite: #132238;
@@ -81,7 +83,8 @@
   --mv-text-muted: #b8c5d6;
   --app-body-bg:
     radial-gradient(circle at 15% 15%, rgba(14, 165, 233, 0.22), transparent 42%),
-    radial-gradient(circle at 80% 0%, rgba(37, 99, 235, 0.18), transparent 42%), #07111f;
+    radial-gradient(circle at 80% 0%, rgba(37, 99, 235, 0.18), transparent 42%),
+    linear-gradient(180deg, #0b1628 0%, #07111f 55%, #04090f 100%);
   --app-body-text: #f8fafc;
   --mv-header-bg: rgba(7, 17, 31, 0.9);
   --mv-header-border: rgba(125, 211, 252, 0.14);
@@ -104,12 +107,8 @@
   --mv-primary-bg: #38bdf8;
   --mv-primary-text: #082f49;
   --mv-primary-shadow: 0 10px 20px rgba(56, 189, 248, 0.26);
-  --mv-surface-hero: linear-gradient(125deg, rgba(14, 165, 233, 0.18), rgba(15, 23, 42, 0.92));
-  --mv-surface-hero-strong: linear-gradient(
-    120deg,
-    rgba(14, 165, 233, 0.24),
-    rgba(15, 23, 42, 0.96)
-  );
+  --mv-surface-hero: rgba(20, 45, 74, 0.58);
+  --mv-surface-hero-strong: rgba(23, 55, 89, 0.68);
   --mv-surface-card: rgba(15, 23, 42, 0.78);
   --mv-surface-card-strong: rgba(15, 23, 42, 0.9);
   --mv-surface-soft: rgba(30, 41, 59, 0.62);

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -10,9 +10,16 @@ body {
   height: 100%;
 }
 
+/* Solid tokenized fallback only (no gradient) so overscroll/bounce gaps never
+   flash white. The actual gradient is painted once, on .app-shell, so a long
+   page reads as a single continuous strip instead of three stacked ones. */
+html {
+  background-color: var(--mv-night);
+}
+
 body {
   margin: 0;
-  background: var(--app-body-bg);
+  background-color: var(--mv-night);
   color: var(--app-body-text);
 }
 
@@ -22,6 +29,7 @@ body {
   font-weight: normal;
   display: flex;
   color: inherit;
+  background-color: var(--mv-night);
 }
 
 .page-shell {

--- a/frontend/src/utils/themeBootstrap.spec.ts
+++ b/frontend/src/utils/themeBootstrap.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveInitialTheme } from './themeBootstrap'
+
+describe('resolveInitialTheme', () => {
+  it('uses a valid stored theme over the fallback', () => {
+    expect(resolveInitialTheme('dark', 'light')).toBe('dark')
+    expect(resolveInitialTheme('light', 'dark')).toBe('light')
+  })
+
+  it('falls back to the provided default when nothing valid is stored', () => {
+    expect(resolveInitialTheme(null, 'dark')).toBe('dark')
+    expect(resolveInitialTheme('system', 'light')).toBe('light')
+    expect(resolveInitialTheme('', 'dark')).toBe('dark')
+  })
+})

--- a/frontend/src/utils/themeBootstrap.ts
+++ b/frontend/src/utils/themeBootstrap.ts
@@ -1,0 +1,14 @@
+import type { ColorMode } from '../config/schoolTemplate'
+
+// Shared with the inline pre-mount bootstrap in index.html, which sets
+// document.documentElement.dataset.theme before Vue mounts to avoid a
+// light/dark flash. Keep the decision rule here in sync with that script.
+export const resolveInitialTheme = (
+  storedTheme: string | null,
+  fallback: ColorMode,
+): ColorMode => {
+  if (storedTheme === 'light' || storedTheme === 'dark') {
+    return storedTheme
+  }
+  return fallback
+}

--- a/frontend/src/views/CalendarView.spec.ts
+++ b/frontend/src/views/CalendarView.spec.ts
@@ -1,0 +1,54 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../services/clubService', () => ({
+  fetchCalendar: vi.fn(),
+}))
+
+import { fetchCalendar } from '../services/clubService'
+import CalendarView from './CalendarView.vue'
+
+const fetchCalendarMock = vi.mocked(fetchCalendar)
+
+const mountCalendar = async () => {
+  const wrapper = mount(CalendarView, { global: { stubs: { RouterLink: true } } })
+  await flushPromises()
+  return wrapper
+}
+
+beforeEach(() => {
+  fetchCalendarMock.mockReset()
+  fetchCalendarMock.mockResolvedValue([])
+})
+
+describe('CalendarView wide-grid scroll wrapper', () => {
+  it('wraps the wide weekly grid in an explicit horizontal scroll region', async () => {
+    const wrapper = await mountCalendar()
+
+    const scrollRegion = wrapper.find('.calendar-scroll')
+    expect(scrollRegion.exists()).toBe(true)
+    expect(scrollRegion.find('.weekly-calendar').exists()).toBe(true)
+  })
+
+  it('gives screen reader and mobile users an English hint that the grid scrolls horizontally', async () => {
+    const wrapper = await mountCalendar()
+
+    const hint = wrapper.find('.calendar-scroll-hint')
+    expect(hint.exists()).toBe(true)
+    expect(hint.text().toLowerCase()).toContain('scroll')
+  })
+
+  it('exposes the scroll region as a focusable, labeled landmark described by the hint', async () => {
+    const wrapper = await mountCalendar()
+
+    const scrollRegion = wrapper.find('.calendar-scroll')
+    const hint = wrapper.find('.calendar-scroll-hint')
+
+    expect(scrollRegion.attributes('role')).toBe('region')
+    expect(scrollRegion.attributes('tabindex')).toBe('0')
+    expect(scrollRegion.attributes('aria-label')).toBeTruthy()
+    expect(scrollRegion.attributes('aria-label')?.toLowerCase()).toContain('schedule')
+    expect(hint.attributes('id')).toBeTruthy()
+    expect(scrollRegion.attributes('aria-describedby')).toBe(hint.attributes('id'))
+  })
+})

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -374,6 +374,11 @@ function clampPercentage(value: number) {
   overscroll-behavior-x: contain;
 }
 
+.calendar-scroll:focus-visible {
+  outline: 2px solid var(--mv-gold);
+  outline-offset: 4px;
+}
+
 .weekly-calendar {
   min-width: 1120px;
 }

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -222,71 +222,83 @@ function clampPercentage(value: number) {
       <section v-if="loading" class="status-banner">Loading schedule...</section>
       <section v-else-if="error" class="status-banner error">{{ error }}</section>
 
-      <div v-else class="calendar-scroll">
-        <div class="weekly-calendar">
-          <div class="week-grid week-header">
-            <div class="time-axis-heading">
-              <span>Local time</span>
-              <strong>{{ currentTimeLabel }}</strong>
-            </div>
-            <div
-              v-for="day in calendarDays"
-              :key="day"
-              class="day-heading"
-              :class="{ today: day === todayShortLabel }"
-            >
-              <span class="day-name">{{ day }}</span>
-              <span class="day-date">{{ formatWeekDate(day) }}</span>
-            </div>
-          </div>
+      <template v-else>
+        <p id="calendar-scroll-hint" class="calendar-scroll-hint">
+          Scroll horizontally to see the full week on narrow screens.
+        </p>
 
-          <div v-for="period in meetingPeriods" :key="period.key" class="week-grid period-row">
-            <div class="period-label">
-              <strong>{{ period.label }}</strong>
-              <span>{{ period.time }}</span>
-            </div>
-
-            <section
-              v-for="day in calendarDays"
-              :key="day"
-              class="calendar-cell"
-              :class="{ 'current-day': day === todayShortLabel }"
-            >
+        <div
+          class="calendar-scroll"
+          role="region"
+          tabindex="0"
+          aria-label="Weekly meeting schedule, scrollable horizontally"
+          aria-describedby="calendar-scroll-hint"
+        >
+          <div class="weekly-calendar">
+            <div class="week-grid week-header">
+              <div class="time-axis-heading">
+                <span>Local time</span>
+                <strong>{{ currentTimeLabel }}</strong>
+              </div>
               <div
-                v-if="
-                  currentTimeMarker &&
-                  day === todayShortLabel &&
-                  period.key === currentTimeMarker.period
-                "
-                class="current-time-line"
-                :style="{ '--current-time-offset': `${currentTimeMarker.offset}%` }"
-                aria-hidden="true"
+                v-for="day in calendarDays"
+                :key="day"
+                class="day-heading"
+                :class="{ today: day === todayShortLabel }"
               >
-                <span>{{ currentTimeLabel }}</span>
+                <span class="day-name">{{ day }}</span>
+                <span class="day-date">{{ formatWeekDate(day) }}</span>
+              </div>
+            </div>
+
+            <div v-for="period in meetingPeriods" :key="period.key" class="week-grid period-row">
+              <div class="period-label">
+                <strong>{{ period.label }}</strong>
+                <span>{{ period.time }}</span>
               </div>
 
-              <div v-if="weeklySchedule[day]?.[period.key].length" class="event-stack">
-                <RouterLink
-                  v-for="event in weeklySchedule[day]?.[period.key]"
-                  :key="event.id"
-                  class="event-card"
-                  :to="`/clubs/${event.id}`"
-                  :aria-label="`${event.title}, ${event.location || 'Location TBD'}`"
+              <section
+                v-for="day in calendarDays"
+                :key="day"
+                class="calendar-cell"
+                :class="{ 'current-day': day === todayShortLabel }"
+              >
+                <div
+                  v-if="
+                    currentTimeMarker &&
+                    day === todayShortLabel &&
+                    period.key === currentTimeMarker.period
+                  "
+                  class="current-time-line"
+                  :style="{ '--current-time-offset': `${currentTimeMarker.offset}%` }"
+                  aria-hidden="true"
                 >
-                  <img
-                    class="event-avatar"
-                    :src="event.avatarUrl"
-                    :alt="`${event.title} avatar`"
-                    loading="lazy"
-                  />
-                  <p class="event-location">{{ event.location || 'Location TBD' }}</p>
-                </RouterLink>
-              </div>
-              <p v-else class="empty">No meetings</p>
-            </section>
+                  <span>{{ currentTimeLabel }}</span>
+                </div>
+
+                <div v-if="weeklySchedule[day]?.[period.key].length" class="event-stack">
+                  <RouterLink
+                    v-for="event in weeklySchedule[day]?.[period.key]"
+                    :key="event.id"
+                    class="event-card"
+                    :to="`/clubs/${event.id}`"
+                    :aria-label="`${event.title}, ${event.location || 'Location TBD'}`"
+                  >
+                    <img
+                      class="event-avatar"
+                      :src="event.avatarUrl"
+                      :alt="`${event.title} avatar`"
+                      loading="lazy"
+                    />
+                    <p class="event-location">{{ event.location || 'Location TBD' }}</p>
+                  </RouterLink>
+                </div>
+                <p v-else class="empty">No meetings</p>
+              </section>
+            </div>
           </div>
         </div>
-      </div>
+      </template>
     </section>
   </div>
 </template>
@@ -337,6 +349,20 @@ function clampPercentage(value: number) {
   font-weight: 600;
 }
 
+.calendar-scroll-hint {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+  font-size: 0.8rem;
+  color: var(--mv-text-faint);
+}
+
 .calendar-scroll {
   overflow-x: auto;
   border: 1px solid var(--mv-border);
@@ -344,6 +370,8 @@ function clampPercentage(value: number) {
   background: var(--mv-surface-card);
   box-shadow: var(--mv-shadow-card);
   scrollbar-color: var(--mv-border-strong) transparent;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-x: contain;
 }
 
 .weekly-calendar {
@@ -589,6 +617,16 @@ function clampPercentage(value: number) {
 }
 
 @media (max-width: 720px) {
+  .calendar-scroll-hint {
+    position: static;
+    width: auto;
+    height: auto;
+    margin: -0.5rem 0 0;
+    overflow: visible;
+    clip: auto;
+    white-space: normal;
+  }
+
   .calendar-heading {
     align-items: flex-start;
     flex-direction: column;

--- a/frontend/src/views/ClubAdminView.spec.ts
+++ b/frontend/src/views/ClubAdminView.spec.ts
@@ -197,7 +197,8 @@ describe('ClubAdminView member count', () => {
   // straight into the "you do not manage this club" notice.
   it('keeps the editor open after a successful save by a club president', async () => {
     const club = buildClub({ canManage: true })
-    const { canManage: _ignored, ...storedRowFromUpdate } = buildClub({ name: 'Chess Team' })
+    const storedRowFromUpdate = buildClub({ name: 'Chess Team' })
+    delete storedRowFromUpdate.canManage
     updateClubMock.mockResolvedValue(storedRowFromUpdate as Club)
 
     const wrapper = await mountView(club)

--- a/frontend/src/views/ClubAdminView.vue
+++ b/frontend/src/views/ClubAdminView.vue
@@ -1272,6 +1272,15 @@ textarea {
   .form-actions button {
     width: 100%;
   }
+
+  .member-entry {
+    grid-template-columns: auto minmax(0, 1fr) minmax(120px, auto) auto;
+    gap: 0.5rem;
+  }
+
+  .member-role {
+    min-width: 120px;
+  }
 }
 .image-upload { margin-top: 0.5rem; }
 .upload-btn {

--- a/frontend/src/views/ClubDetailView.vue
+++ b/frontend/src/views/ClubDetailView.vue
@@ -629,11 +629,9 @@ onBeforeUnmount(() => {
 }
 
 .club-media-section {
-  border-radius: 28px;
-  border: 1px solid var(--mv-border);
+  border-top: 1px solid var(--mv-border);
   padding: clamp(1.5rem, 4vw, 2.75rem);
-  background: var(--mv-surface-card-strong);
-  box-shadow: var(--mv-shadow-card);
+  padding-inline: 0;
 }
 
 .empty-state {
@@ -705,8 +703,7 @@ onBeforeUnmount(() => {
   }
 
   .club-media-section {
-    padding: 1.25rem;
-    border-radius: 22px;
+    padding-block: 1.25rem;
   }
 }
 

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue'
-import { RouterLink, useRoute } from 'vue-router'
+import { RouterLink } from 'vue-router'
 import SkeletonLoader from '../components/SkeletonLoader.vue'
 import { fetchAllClubs, fetchClubs } from '../services/clubService'
 import type { Club } from '../types/club'
@@ -11,7 +11,6 @@ const clubs = ref<Club[]>([])
 const loading = ref(true)
 const error = ref('')
 
-const route = useRoute()
 const schoolDisplayName = computed(() => schoolTemplate.schoolName)
 const schoolShortName = computed(() => schoolTemplate.shortName)
 const currentHeroImageIndex = ref(0)
@@ -291,6 +290,7 @@ const changeHeroImage = (offset: number) => {
 
 .hero-copy {
   max-width: 520px;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -299,6 +299,7 @@ const changeHeroImage = (offset: number) => {
 .hero-copy h1 {
   font-size: clamp(2rem, 4vw, 3rem);
   margin: 0;
+  overflow-wrap: break-word;
 }
 
 .hero-copy p {
@@ -671,6 +672,13 @@ const changeHeroImage = (offset: number) => {
 
   .hero-copy {
     max-width: 100%;
+  }
+
+  .hero-visual {
+    /* .home-hero switches to a column here, where flex-basis sets height
+       rather than width; pin it back to auto so this rule only ever sizes
+       the row layout above 720px. */
+    flex-basis: auto;
   }
 
   .home-hero {

--- a/frontend/src/views/OwnerAdminView.vue
+++ b/frontend/src/views/OwnerAdminView.vue
@@ -1,15 +1,12 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
-import { RouterLink, useRoute } from 'vue-router'
+import { RouterLink } from 'vue-router'
 import { fetchClubCount, fetchAllClubs, createClub } from '../services/clubService'
 import type { Club } from '../types/club'
 import { useAuthStore } from '../stores/auth'
 import { clubImage } from '../utils/clubImages'
 import { clubCategoryOptions } from '../utils/clubCategories'
-
-
-const route = useRoute()
 const authStore = useAuthStore()
 const { currentUser, userLoading, hasCheckedSession } = storeToRefs(authStore)
 
@@ -570,6 +567,11 @@ select {
     align-items: flex-start;
   }
 
+  .club-main,
+  .club-meta {
+    min-width: 0;
+  }
+
   .hero-actions {
     width: 100%;
     align-items: flex-start;
@@ -583,6 +585,21 @@ select {
   select {
     width: 100%;
     min-width: 0;
+  }
+}
+
+/* Row layout only: flex-basis sets width here. In the max-width:700 column
+   layout above, flex-basis would set height instead, so this range stops
+   short of that breakpoint. */
+@media (min-width: 701px) and (max-width: 900px) {
+  .club-main {
+    min-width: 0;
+    flex: 1 1 220px;
+  }
+
+  .club-meta {
+    min-width: 0;
+    flex: 1 1 200px;
   }
 }
 

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -457,6 +457,13 @@ const handleGraduationYearSave = async () => {
   border: 1px solid var(--mv-border);
   background: var(--mv-surface-soft);
   font-size: 0.9rem;
+  flex-wrap: wrap;
+}
+
+.request-row > span:not(.request-status):not(.request-date) {
+  flex: 1 1 160px;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .request-status.pending {

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -111,6 +111,11 @@ const clearCache = () => {
   color: inherit;
 }
 
+.setting-row > div {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .setting-row.link:hover {
   background: var(--mv-surface-accent);
 }

--- a/frontend/vite.config.spec.ts
+++ b/frontend/vite.config.spec.ts
@@ -1,0 +1,62 @@
+// @vitest-environment node
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, afterEach, describe, expect, it } from 'vitest'
+import type { Plugin } from 'vite'
+
+import { schoolBrandTitlePlugin } from './vite.config'
+
+type ConfigResolvedHook = (config: { mode: string; envDir: string }) => void
+type TransformIndexHtmlHook = (html: string) => string
+
+const baseHtml = '<html><head><title></title></head><body></body></html>'
+const emptyEnvDir = mkdtempSync(join(tmpdir(), 'hsclubs-vite-config-'))
+
+const runPlugin = (envOverrides: Record<string, string | undefined>) => {
+  const plugin: Plugin = schoolBrandTitlePlugin()
+  const configResolved = plugin.configResolved as ConfigResolvedHook
+  const transformIndexHtml = plugin.transformIndexHtml as TransformIndexHtmlHook
+
+  for (const [key, value] of Object.entries(envOverrides)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+
+  configResolved({ mode: 'production', envDir: emptyEnvDir })
+  return transformIndexHtml(`${baseHtml}<script>var theme = '__DEFAULT_COLOR_MODE__'</script>`)
+}
+
+describe('schoolBrandTitlePlugin default color mode injection', () => {
+  const originalEnv = process.env.VITE_DEFAULT_COLOR_MODE
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.VITE_DEFAULT_COLOR_MODE
+    } else {
+      process.env.VITE_DEFAULT_COLOR_MODE = originalEnv
+    }
+  })
+
+  afterAll(() => {
+    rmSync(emptyEnvDir, { recursive: true, force: true })
+  })
+
+  it('falls back to light when VITE_DEFAULT_COLOR_MODE is unset', () => {
+    const html = runPlugin({ VITE_DEFAULT_COLOR_MODE: undefined })
+    expect(html).toContain("var theme = 'light'")
+  })
+
+  it('injects dark when VITE_DEFAULT_COLOR_MODE=dark', () => {
+    const html = runPlugin({ VITE_DEFAULT_COLOR_MODE: 'dark' })
+    expect(html).toContain("var theme = 'dark'")
+  })
+
+  it('falls back to light for any other configured value, matching schoolTemplate', () => {
+    const html = runPlugin({ VITE_DEFAULT_COLOR_MODE: 'system' })
+    expect(html).toContain("var theme = 'light'")
+  })
+})

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,17 +15,30 @@ const escapeHtml = (value: string) =>
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#039;')
 
-const schoolBrandTitlePlugin = (): Plugin => {
+export const schoolBrandTitlePlugin = (): Plugin => {
   let brandName = 'HS Clubs'
+  let defaultColorMode: 'light' | 'dark' = 'light'
 
   return {
     name: 'school-brand-title',
     configResolved(config) {
       const env = loadEnv(config.mode, config.envDir, '')
       brandName = process.env.VITE_BRAND_NAME?.trim() || env.VITE_BRAND_NAME?.trim() || brandName
+
+      // Same fallback rule as schoolTemplate.defaultColorMode: only 'dark' opts out of
+      // the 'light' default, so the pre-mount script in index.html never flashes the
+      // wrong theme before Vue applies the user's stored preference.
+      const configuredColorMode = (
+        process.env.VITE_DEFAULT_COLOR_MODE ?? env.VITE_DEFAULT_COLOR_MODE
+      )
+        ?.trim()
+        .toLowerCase()
+      defaultColorMode = configuredColorMode === 'dark' ? 'dark' : 'light'
     },
     transformIndexHtml(html) {
-      return html.replace('<title></title>', `<title>${escapeHtml(brandName)}</title>`)
+      return html
+        .replace('<title></title>', `<title>${escapeHtml(brandName)}</title>`)
+        .replaceAll('__DEFAULT_COLOR_MODE__', defaultColorMode)
     },
   }
 }


### PR DESCRIPTION
## Summary

- paint one continuous theme gradient across the full app instead of restarting gradients inside individual cards
- provide solid light/dark fallbacks across html, body, app root and overscroll so white gaps cannot leak through
- apply stored/default theme before Vue mounts and expose the theme toggle in the mobile menu
- remove nested media card styling and improve responsive layouts across navigation, home, club detail/admin, profile, owner admin and settings
- make the wide calendar an accessible, focusable horizontal scroll region on narrow screens

## Responsive coverage

Reviewed CSS contracts for 320px, 360px, 390px, 700/720px, 768px, 860/900px and 1024px breakpoints. Fixed tablet flex-basis issues, narrow text wrapping, action-row wrapping and header search minimum widths.

## Validation

- `npm exec eslint -- .`
- `npm exec vitest -- run` - 333 tests
- `npm run type-check`
- `npm run build`
- light/dark default injection tests
- mobile theme-menu tests
- calendar accessibility tests

## Visual follow-up

The implementation has been statically audited and unit-tested. Final contrast, long-scroll gradient continuity and touch-scroll feel should also be inspected in a real mobile browser after deployment.